### PR TITLE
Removed or modified a number of unpleasant brain traumas and mutations.

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -1,7 +1,7 @@
 /datum/brain_trauma/special/imaginary_friend
 	name = "Imaginary Friend"
 	desc = "Patient can see and hear an imaginary person."
-	scan_desc = "partial schizophrenia"
+	scan_desc = "active imagination"
 	gain_text = "<span class='notice'>You feel in good company, for some reason.</span>"
 	lose_text = "<span class='warning'>You feel lonely again.</span>"
 	var/mob/camera/imaginary_friend/friend

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -7,7 +7,7 @@
 /datum/brain_trauma/mild/hallucinations
 	name = "Hallucinations"
 	desc = "Patient suffers constant hallucinations."
-	scan_desc = "schizophrenia"
+	scan_desc = "hallucinations"
 	gain_text = "<span class='warning'>You feel your grip on reality slipping...</span>"
 	lose_text = "<span class='notice'>You feel more grounded.</span>"
 
@@ -31,31 +31,6 @@
 
 /datum/brain_trauma/mild/stuttering/on_lose()
 	owner.remove_status_effect(/datum/status_effect/speech/stutter)
-	return ..()
-
-/datum/brain_trauma/mild/dumbness
-	name = "Dumbness"
-	desc = "Patient has reduced brain activity, making them less intelligent."
-	scan_desc = "reduced brain activity"
-	gain_text = "<span class='warning'>You feel dumber.</span>"
-	lose_text = "<span class='notice'>You feel smart again.</span>"
-
-/datum/brain_trauma/mild/dumbness/on_gain()
-	ADD_TRAIT(owner, TRAIT_DUMB, TRAUMA_TRAIT)
-	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "dumb", /datum/mood_event/oblivious)
-	return ..()
-
-/datum/brain_trauma/mild/dumbness/on_life(delta_time, times_fired)
-	owner.adjust_timed_status_effect(5 SECONDS * delta_time, /datum/status_effect/speech/stutter/derpspeech, max_duration = 50 SECONDS)
-	if(DT_PROB(1.5, delta_time))
-		owner.emote("drool")
-	else if(owner.stat == CONSCIOUS && DT_PROB(1.5, delta_time))
-		owner.say(pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"), forced = "brain damage")
-
-/datum/brain_trauma/mild/dumbness/on_lose()
-	REMOVE_TRAIT(owner, TRAIT_DUMB, TRAUMA_TRAIT)
-	owner.remove_status_effect(/datum/status_effect/speech/stutter/derpspeech)
-	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "dumb")
 	return ..()
 
 /datum/brain_trauma/mild/speech_impediment

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -228,29 +228,6 @@
 	linked_target = null
 	linked = FALSE
 
-/datum/brain_trauma/special/psychotic_brawling
-	name = "Violent Psychosis"
-	desc = "Patient fights in unpredictable ways, ranging from helping his target to hitting them with brutal strength."
-	scan_desc = "violent psychosis"
-	gain_text = "<span class='warning'>You feel unhinged...</span>"
-	lose_text = "<span class='notice'>You feel more balanced.</span>"
-	var/datum/martial_art/psychotic_brawling/psychotic_brawling
-
-/datum/brain_trauma/special/psychotic_brawling/on_gain()
-	..()
-	psychotic_brawling = new(null)
-	if(!psychotic_brawling.teach(owner, TRUE))
-		to_chat(owner, span_notice("But your martial knowledge keeps you grounded."))
-		qdel(src)
-
-/datum/brain_trauma/special/psychotic_brawling/on_lose()
-	..()
-	psychotic_brawling.remove(owner)
-	QDEL_NULL(psychotic_brawling)
-
-/datum/brain_trauma/special/psychotic_brawling/bath_salts
-	name = "Chemical Violent Psychosis"
-
 /datum/brain_trauma/special/tenacity
 	name = "Tenacity"
 	desc = "Patient is psychologically unaffected by pain and injuries, and can remain standing far longer than a normal person."

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -129,30 +129,6 @@
 		return
 	REMOVE_TRAIT(owner, TRAIT_CLUMSY, GENETIC_MUTATION)
 
-
-//Tourettes causes you to randomly stand in place and shout.
-/datum/mutation/human/tourettes
-	name = "Tourette's Syndrome"
-	desc = "A chronic twitch that forces the user to scream bad words." //definitely needs rewriting
-	quality = NEGATIVE
-	text_gain_indication = "<span class='danger'>You twitch.</span>"
-	synchronizer_coeff = 1
-
-/datum/mutation/human/tourettes/on_life(delta_time, times_fired)
-	if(DT_PROB(5 * GET_MUTATION_SYNCHRONIZER(src), delta_time) && owner.stat == CONSCIOUS && !owner.IsStun())
-		switch(rand(1, 3))
-			if(1)
-				owner.emote("twitch")
-			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
-		var/x_offset_old = owner.pixel_x
-		var/y_offset_old = owner.pixel_y
-		var/x_offset = owner.pixel_x + rand(-2,2)
-		var/y_offset = owner.pixel_y + rand(-1,1)
-		animate(owner, pixel_x = x_offset, pixel_y = y_offset, time = 1)
-		animate(owner, pixel_x = x_offset_old, pixel_y = y_offset_old, time = 1)
-
-
 //Deafness makes you deaf.
 /datum/mutation/human/deaf
 	name = "Deafness"

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -83,45 +83,6 @@
 
 	return modified_char
 
-/datum/status_effect/speech/stutter/derpspeech
-	id = "derp_stutter"
-	/// The probability of making our message entirely uppercase + adding exclamations
-	var/capitalize_prob = 50
-	/// The probability of adding a stutter to the entire message, if we're not already stuttering
-	var/message_stutter_prob = 15
-
-/datum/status_effect/speech/stutter/derpspeech/handle_message(datum/source, list/message_args)
-
-	var/message = html_decode(message_args[1])
-
-	message = replacetext(message, " am ", " ")
-	message = replacetext(message, " is ", " ")
-	message = replacetext(message, " are ", " ")
-	message = replacetext(message, "you", "u")
-	message = replacetext(message, "help", "halp")
-	message = replacetext(message, "grief", "grife")
-	message = replacetext(message, "space", "spess")
-	message = replacetext(message, "carp", "crap")
-	message = replacetext(message, "reason", "raisin")
-
-	if(prob(capitalize_prob))
-		var/exclamation = pick("!", "!!", "!!!")
-		message = uppertext(message)
-		message += "[apply_speech(exclamation, exclamation)]"
-
-	message_args[1] = message
-
-	var/mob/living/living_source = source
-	if(!isliving(source) || living_source.has_status_effect(/datum/status_effect/speech/stutter))
-		return
-
-	// If we're not stuttering, we have a chance of calling parent here, adding stutter effects
-	if(prob(message_stutter_prob))
-		return ..()
-
-	// Otherwise just return and don't call parent, we already modified our speech
-	return
-
 /datum/status_effect/speech/slurring
 	/// The chance that any given character in a message will be replaced with a common character
 	var/common_prob = 25

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -934,9 +934,9 @@
 		JOB_SECURITY_OFFICER,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 1
-	weight = 4
-	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
+	required_candidates = 100
+	weight = 0
+	cost = 3000 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 

--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -23,7 +23,6 @@
 		/obj/item/reagent_containers/syringe/contraband/space_drugs,
 		/obj/item/reagent_containers/syringe/contraband/krokodil,
 		/obj/item/reagent_containers/syringe/contraband/methamphetamine,
-		/obj/item/reagent_containers/syringe/contraband/bath_salts,
 		/obj/item/reagent_containers/syringe/contraband/fentanyl,
 		/obj/item/reagent_containers/syringe/contraband/morphine,
 		/obj/item/reagent_containers/syringe/contraband/saturnx,

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -154,16 +154,6 @@
 	desc = "Apply this for Security Clown."
 	remove_mutations = list(/datum/mutation/human/clumsy)
 
-/obj/item/dnainjector/antitour
-	name = "\improper DNA injector (Anti-Tour.)"
-	desc = "Will cure Tourette's."
-	remove_mutations = list(/datum/mutation/human/tourettes)
-
-/obj/item/dnainjector/tourmut
-	name = "\improper DNA injector (Tour.)"
-	desc = "Gives you a nasty case of Tourette's."
-	add_mutations = list(/datum/mutation/human/tourettes)
-
 /obj/item/dnainjector/stuttmut
 	name = "\improper DNA injector (Stutt.)"
 	desc = "Makes you s-s-stuttterrr."

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -160,7 +160,6 @@
 		/datum/reagent/medicine/pyroxadone,\
 		/datum/reagent/medicine/rezadone,\
 		/datum/reagent/medicine/regen_jelly,\
-		/datum/reagent/drug/bath_salts,\
 		/datum/reagent/hair_dye,\
 		/datum/reagent/consumable/honey,\
 		/datum/reagent/consumable/frostoil,\

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -75,7 +75,6 @@
 						/datum/reagent/lithium = 0.15,
 						/datum/reagent/medicine/atropine = 0.15,
 						/datum/reagent/drug/methamphetamine = 0.15,
-						/datum/reagent/drug/bath_salts = 0.15,
 						/datum/reagent/drug/krokodil = 0.15,
 						/datum/reagent/toxin/lipolicide = 0.15,
 						/datum/reagent/drug/nicotine = 0.1)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -185,59 +185,6 @@
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, (rand(5, 10) / 10) * REM * delta_time)
 	. = TRUE
 
-/datum/reagent/drug/bath_salts
-	name = "Bath Salts"
-	description = "Makes you impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
-	reagent_state = LIQUID
-	color = "#FAFAFA"
-	overdose_threshold = 20
-	taste_description = "salt" // because they're bathsalts?
-	addiction_types = list(/datum/addiction/stimulants = 25)  //8 per 2 seconds
-	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
-	ph = 8.2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/drug/bath_salts/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-		rage = new()
-		C.gain_trauma(rage, TRAUMA_RESILIENCE_ABSOLUTE)
-
-/datum/reagent/drug/bath_salts/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	if(rage)
-		QDEL_NULL(rage)
-	..()
-
-/datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
-	if(DT_PROB(2.5, delta_time))
-		to_chat(M, span_notice("[high_message]"))
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "salted", /datum/mood_event/stimulant_heavy, name)
-	M.adjustStaminaLoss(-5 * REM * delta_time, 0)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 4 * REM * delta_time)
-	M.hallucination += 5 * REM * delta_time
-	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !ismovable(M.loc))
-		step(M, pick(GLOB.cardinals))
-		step(M, pick(GLOB.cardinals))
-	..()
-	. = TRUE
-
-/datum/reagent/drug/bath_salts/overdose_process(mob/living/M, delta_time, times_fired)
-	M.hallucination += 5 * REM * delta_time
-	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !ismovable(M.loc))
-		for(var/i in 1 to round(8 * REM * delta_time, 1))
-			step(M, pick(GLOB.cardinals))
-	if(DT_PROB(10, delta_time))
-		M.emote(pick("twitch","drool","moan"))
-	if(DT_PROB(28, delta_time))
-		M.drop_all_held_items()
-	..()
-
 /datum/reagent/drug/aranesp
 	name = "Aranesp"
 	description = "Amps you up, gets you going, and rapidly restores stamina damage. Side effects include breathlessness and toxicity."

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -76,12 +76,6 @@
 	e.start(holder.my_atom)
 	holder.clear_reagents()
 
-/datum/chemical_reaction/bath_salts
-	results = list(/datum/reagent/drug/bath_salts = 7)
-	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)
-	required_temp = 374
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
-
 /datum/chemical_reaction/aranesp
 	results = list(/datum/reagent/drug/aranesp = 3)
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 1, /datum/reagent/medicine/atropine = 1, /datum/reagent/medicine/morphine = 1)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -280,9 +280,6 @@
 /obj/item/reagent_containers/syringe/contraband/methamphetamine
 	list_reagents = list(/datum/reagent/drug/methamphetamine = 15)
 
-/obj/item/reagent_containers/syringe/contraband/bath_salts
-	list_reagents = list(/datum/reagent/drug/bath_salts = 15)
-
 /obj/item/reagent_containers/syringe/contraband/fentanyl
 	list_reagents = list(/datum/reagent/toxin/fentanyl = 15)
 

--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -3,33 +3,14 @@
     ],
 
     "mutations": [
-        "telikesis",
-        "halk",
-        "eppilapse",
-        "kamelien",
-        "eksrey",
-        "glowey skin",
-        "fungal tb",
-        "stun gloves"
     ],
 
     "george": [
-        "joerge",
-        "george",
-        "gorge",
-        "gdoruge"
     ],
 
     "mellens": [
-        "mellens",
-        "melons",
-        "mwrlins"
     ],
     "random_gibberish": [
-        "g",
-        "squid",
-        "r",
-        "carbon dioxide"
     ],
 
     "y_replacements": [
@@ -39,43 +20,15 @@
     ],
 
     "servers": [
-        "bager",
-        "sybl",
-        "mrs sybil",
-        "mr basil",
-        "mr terry",
-        "berry",
-        "vent hell",
-        "colonel hall"
     ],
 
     "create_verbs": [
-        "spawn",
-        "MAke me",
-        "creat",
-        "tc trade me",
-        "gib"
     ],
 
     "create_nouns": [
-        "zenomorfs",
-        "ayleins",
-        "treaitors",
-        "sheadow lings",
-        "abdoocters",
-        "revinent",
-        "deval",
-        "deth squads",
-        "bleb",
-        "cock cult",
-        "anteg"
     ],
 
     "bug": [
-        "",
-        "IS TIS A BUG??",
-        "SI IST A BUGG/",
-        "BUG!!!"
     ],
 
     "semicolon": [


### PR DESCRIPTION
There may be more to come in the future, but this deals with some of the most egregious ones.

- Removed ""Tourette's"" as a mutation.
-- deleted entries in code/game/objects/items/dna_injector.dm
-- deleted entry in code/datums/mutations/body.dm
- Removed inaccurate and tasteless references to schizophrenia
-- Renamed the scan_desc of the "Imaginary Friend" trauma from "partial schizophrenia" to "active imagination" in code/datums/brain_damage/imaginary_friend.dm. This is a band-aid, as we may wish to change the flavor entirely in a future update.
-- Renamed the scan_desc of the "Hallucinations" trauma from "schizophrenia" to "hallucinations" in code/datums/brain_damage/mild.dm
- Removed the "dumbness" mild trauma.
-- Deleted entry in code/datums/brain_damage/mild.dm
-- Deleted "derpspeech" debuff in code/datums/status_effects/debuffs/speech_debuffs.dm. Yes, they really called it that.
- Emptied out most of the lists in strings/traumas.json. I couldn't find where most of these are used, but given that they were all joke misspellings of other words, they were probably "jokes" about "dumb" characters spouting memes or somthing.
- Removed the "violent psychosis" special trauma.
-- Removed entry in code/datums/brain_damage/special.dm
-- Did NOT remove the associated martial art, as it could likely be reflavored into something less shitty.
- Removed the "bath salts" drug, as its existence was predicated on the "violent psychosis" trauma.
-- Removed the narcotics spawner entry in code/game/objects/effects/spawners/random/contraband.dm
-- Removed bath salts as a reagent in "omega weed" in code/modules/hydroponics/grown/cannabis.dm
-- Removed as a possible cargo bounty in code/modules/cargo/bounties/reagent.dm
-- Removed as a contraband syringe in code/modules/reagents/reagent_containers/syringes.dm
-- Removed the reaction that produces bath salts in code/modules/reagents/chemistry/recipes/drugs.dm
-- Removed entry in code/modules/reagents/chemistry/reagents/drug_reagents/dm
- Disabled "Obsessed" antagonist.
-- As a stopgap, edited values in code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm so that the Obsessed can never spawn. This is only a temporary solution, but removing an antagonist type entirely seemed complicated.
