### PR TITLE
[DNM] Hunger mood balance

### DIFF
--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -9,11 +9,11 @@
 
 /datum/mood_event/hungry
 	description = "I'm getting a bit hungry."
-	mood_change = -6
+	mood_change = -2
 
 /datum/mood_event/starving
 	description = "I'm starving!"
-	mood_change = -10
+	mood_change = -6
 
 //charge
 /datum/mood_event/supercharged


### PR DESCRIPTION
This test alters the bad mood from hunger.

Regular hungry mood:
Decreased to -2 mood, from -6. This means, on its own, Hunger will not decrease your sanity, but an extra -1 will move it to the previous levels (which will reach a 0.25 slowdown mood in 16.5 minutes). 

Starving mood:
Decreased to -6 mood, from -10. This is equal to the old hungry mood. This will reach a reach a 0.25 slowdown mood in 16.5 minutes, on its own. An extra -1 will move to the previous level (which will reach 0.5 slowdown mood in 12.5 minutes.

Does not adjust ethereal values.


