### PR TITLE
Removed religion/bible autorenaming

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -70,33 +70,10 @@
 
 	B.deity_name = new_deity
 
-	switch(lowertext(new_religion))
-		if("homosexuality", "gay", "penis", "ass", "cock", "cocks")
-			new_bible = pick("Guys Gone Wild","Coming Out of The Closet","War of Cocks")
-			switch(new_bible)
-				if("War of Cocks")
-					B.deity_name = pick("Dick Powers", "King Cock")
-				else
-					B.deity_name = pick("Gay Space Jesus", "Gandalf", "Dumbledore")
-			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // starts off brain damaged as fuck
-		if("lol", "wtf", "poo", "badmin", "shitmin", "deadmin", "meme", "memes")
-			new_bible = pick("Woody's Got Wood: The Aftermath", "Sweet Bro and Hella Jeff: Expanded Edition","F.A.T.A.L. Rulebook")
-			switch(new_bible)
-				if("Woody's Got Wood: The Aftermath")
-					B.deity_name = pick("Woody", "Andy", "Cherry Flavored Lube")
-				if("Sweet Bro and Hella Jeff: Expanded Edition")
-					B.deity_name = pick("Sweet Bro", "Hella Jeff", "Stairs", "AH")
-				if("F.A.T.A.L. Rulebook")
-					B.deity_name = "Twenty Ten-Sided Dice"
-			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // also starts off brain damaged as fuck
-		if("servicianism", "partying")
-			B.desc = "Happy, Full, Clean. Live it and give it."
-		if("weeaboo","kawaii")
-			new_bible = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
-			B.deity_name = "Anime"
-		else
-			if(new_bible == DEFAULT_BIBLE)
-				new_bible = DEFAULT_BIBLE_REPLACE(new_bible)
+	// auto bible/deity renaming removed -- if somebody wants to worship Gay Space Jesus via the book of The War of Cocks, they can enter that themself
+
+	if(new_bible == DEFAULT_BIBLE)
+		new_bible = DEFAULT_BIBLE_REPLACE(new_bible)
 
 	B.name = new_bible
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, if you named your religion as chaplain one of a certain few keywords, it would automatically set your holy book and deity to some hardcoded joke names. These included "gay, homosexuality, cocks" etc -> deity "Dick Powers, Gay Space Jesus, Dumbledore", "lol, memes, meme" -> holy book "Sweet Bro and Hella Jeff: Expanded Edition" etc. (See code diffs for full list.) This functionality has been removed.

## Why It's Good For The Game

A few of these joke replacements were in poor taste (references to the FATAL system, among other things), and many weren't particularly funny. In addition, choosing the "gay" etc religion replacement or the "memes" etc one would automatically inflict severe brain damage, which isn't great.

Removing the automatic replacements lets us avoid the problematic/unfunny ones, and still allows users to make as many dumb jokes of their own as they want.

## Changelog

:cl:
del: Naming your religion certain keywords (such as "gay", "meme", or "anime") will no longer automatically set your deity or holy book's name to hardcoded tg in-jokes.
/:cl:
