### PR TITLE
Rebalanced several random event chances, and disabled a few.

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,7 +1,8 @@
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
-	weight = 25
+	weight = 0
+	max_occurrences = 0
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/obsessed
 	name = "Obsession Awakening"
 	typepath = /datum/round_event/obsessed
-	max_occurrences = 1
-	min_players = 20
+	max_occurrences = 0
+	min_players = 200
 
 /datum/round_event/obsessed
 	fakeable = FALSE
@@ -19,6 +19,6 @@
 			continue
 		if(!H.getorgan(/obj/item/organ/internal/brain))
 			continue
-		H.gain_trauma(/datum/brain_trauma/special/obsessed)
-		announce_to_ghosts(H)
+		//H.gain_trauma(/datum/brain_trauma/special/obsessed)
+		//announce_to_ghosts(H)
 		break

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
-	weight = 20
-	max_occurrences = 2
+	weight = 0
+	max_occurrences = 0
 	min_players = 40 // To avoid shafting lowpop
 
 /datum/round_event/heart_attack/start()

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -1,8 +1,9 @@
 /datum/round_event_control/processor_overload
 	name = "Processor Overload"
 	typepath = /datum/round_event/processor_overload
-	weight = 15
+	weight = 0
 	min_players = 20
+	max_occurrences = 0
 
 /datum/round_event/processor_overload
 	announceWhen = 1

--- a/code/modules/events/rpgtitles.dm
+++ b/code/modules/events/rpgtitles.dm
@@ -2,7 +2,7 @@
 	name = "RPG Titles"
 	weight = 3
 	typepath = /datum/round_event/wizard/rpgtitles
-	max_occurrences = 1
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/rpgtitles/start()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -45,8 +45,7 @@
 /datum/round_event_control/spacevine
 	name = "Space Vines"
 	typepath = /datum/round_event/spacevine
-	weight = 15
-	max_occurrences = 3
+	max_occurrences = 1
 	min_players = 10
 
 /datum/round_event/spacevine


### PR DESCRIPTION
- Disabled "Spontaneous Brain Trauma", "Obsession Awakening", "Random Heart Attack", "Processor Overload", and "RPG Titles" events.
- Decreased chance of "Space Vines" event; reduced maximum possible occurrences per round to 1.
- Nuked "Obsession Awakening" event: it doesn't do anything even if an admin specifically clicks it for some reason.