### PR TITLE
Notifies admins of antagonist count at round start

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -300,6 +300,8 @@ SUBSYSTEM_DEF(ticker)
 		else
 			stack_trace("[S] [S.type] found in start landmarks list, which isn't a start landmark!")
 
+	var/special_role_count = 0
+
 	// handle persistence stuff that requires ckeys, in this case hardcore mode and temporal scarring
 	for(var/i in GLOB.player_list)
 		if(!ishuman(i))
@@ -309,12 +311,17 @@ SUBSYSTEM_DEF(ticker)
 		iter_human.increment_scar_slot()
 		iter_human.load_persistent_scars()
 
+		if(iter_human.mind?.special_role)
+			special_role_count++
+
 		if(!iter_human.hardcore_survival_score)
 			continue
 		if(iter_human.mind?.special_role)
 			to_chat(iter_human, span_notice("You will gain [round(iter_human.hardcore_survival_score) * 2] hardcore random points if you greentext this round!"))
 		else
 			to_chat(iter_human, span_notice("You will gain [round(iter_human.hardcore_survival_score)] hardcore random points if you survive this round!"))
+
+	message_admins("Game started with [special_role_count] antagonist(s) out of [GLOB.alive_player_list.len] players.")
 
 //These callbacks will fire after roundstart key transfer
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -321,7 +321,7 @@ SUBSYSTEM_DEF(ticker)
 		else
 			to_chat(iter_human, span_notice("You will gain [round(iter_human.hardcore_survival_score)] hardcore random points if you survive this round!"))
 
-	message_admins("Game started with [special_role_count] antagonist(s) out of [GLOB.alive_player_list.len] players.")
+	message_admins(span_alert("Game started with [special_role_count] antagonist(s) out of [GLOB.alive_player_list.len] players."))
 
 //These callbacks will fire after roundstart key transfer
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The game will now send admins a message at the start of a round telling them the number of antagonists and active players, like so:

**"ADMIN LOG: Game started with 2 antagonist(s) out of 12 players."**

The message appears right after the "welcome to the station" message.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

We've had several rounds where too few antagonists have spawned for the current playercount, such as one recent round where there were 20 players but only 1 traitor. Until we figure out how to rebalance the way threat and antagonists are generated, this should at least allow admins to manually fix the problem themselves by going into the game mode panel and clicking the "execute midround ruleset" button (ideally choosing to spawn Syndicate Sleeper Agents).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Admins will now be notified of antagonist count at the beginning of rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
