### PR TITLE
Let Moths Eat Fruit!!

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -19,7 +19,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/food/meat/slab/human/mutant/moth
 	liked_food = VEGETABLES | DAIRY | CLOTH
-	disliked_food = FRUIT | GROSS | BUGS
+	disliked_food = GROSS | BUGS
 	toxic_food = MEAT | RAW | SEAFOOD
 	mutanteyes = /obj/item/organ/internal/eyes/moth
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes "fruit" from the moth dislike list. Does not add them to the "likes" list, because mothic culture prioritizes cheese

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/12107211/176564284-bd45ae64-ce01-4b9a-8f09-2dfd3ce8473d.png)

Moths and butterflies fucking LOVE fruit irl and it BUGS me that moths in game cant even have it. fix this immediately.

## Changelog

:cl:
balance: moths can now eat fruit
/:cl:
