### PR TITLE
New midround antagonist/ghost role: Changeling Infiltrator

### DIFF
--- a/_maps/shuttles/changeling_pod.dmm
+++ b/_maps/shuttles/changeling_pod.dmm
@@ -1,0 +1,122 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/changeling_pod)
+"f" = (
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"g" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/changeling_pod)
+"h" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/changeling_infiltrator,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"k" = (
+/turf/template_noop,
+/area/template_noop)
+"n" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"s" = (
+/obj/machinery/computer/shuttle/changeling_pod,
+/obj/machinery/light/red/directional/north,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"x" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/docking_port/mobile/changeling_pod{
+	dwidth = 2;
+	width = 5;
+	height = 6
+	},
+/obj/docking_port/stationary{
+	dwidth = 2;
+	width = 5;
+	height = 6;
+	name = "abandoned pod"
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"A" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/changeling_pod)
+"B" = (
+/obj/machinery/status_display/evac/directional/east,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"E" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate/secret,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"K" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/changeling_pod,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+"Z" = (
+/obj/effect/decal/cleanable/blood/gibs/old{
+	pixel_y = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/pickaxe/emergency,
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/changeling_pod)
+
+(1,1,1) = {"
+k
+a
+a
+g
+a
+A
+"}
+(2,1,1) = {"
+a
+a
+K
+n
+E
+A
+"}
+(3,1,1) = {"
+g
+s
+h
+f
+f
+x
+"}
+(4,1,1) = {"
+a
+a
+B
+f
+Z
+A
+"}
+(5,1,1) = {"
+k
+a
+a
+g
+a
+A
+"}

--- a/orbstation/antagonists/changeling_infiltrator/changeling_infiltrator.dm
+++ b/orbstation/antagonists/changeling_infiltrator/changeling_infiltrator.dm
@@ -1,0 +1,224 @@
+// Changeling Infiltrator: ghost role that spawns on a pilotable shuttle out in deep space,
+// given the objective to sneak on board the station and infiltrate the crew.
+
+/datum/job/changeling_infiltrator
+	title = "Changeling Infiltrator"
+
+// Event that spawns the changeling and their ship. Does not alert the crew (obviously)
+
+/datum/round_event_control/changeling_infiltrator
+	name = "Changeling Infiltrator"
+	typepath = /datum/round_event/ghost_role/changeling_infiltrator
+	weight = 5 // same as aliens
+	min_players = 15
+	earliest_start = 30 MINUTES
+	max_occurrences = 1
+	dynamic_should_hijack = TRUE
+
+/datum/round_event/ghost_role/changeling_infiltrator
+	role_name = "changeling infiltrator"
+
+/datum/round_event/ghost_role/changeling_infiltrator/spawn_role()
+	var/list/candidates = get_candidates(ROLE_CHANGELING, ROLE_CHANGELING)
+	if(!candidates.len) // we only need one
+		return NOT_ENOUGH_PLAYERS
+
+	var/mob/dead/selected = pick_n_take(candidates)
+
+	var/mob/living/new_mob = spawn_changeling_infiltrator(selected)
+
+	if(!new_mob)
+		return NOT_ENOUGH_PLAYERS
+
+	spawned_mobs += new_mob
+
+	return SUCCESSFUL_SPAWN
+
+///Proc that spawns the changeling infiltrator. also called by the changeling infiltrator ruleset
+/proc/spawn_changeling_infiltrator(mob/new_ling)
+	if(!new_ling)
+		return
+
+	var/turf/T
+	var/datum/map_template/shuttle/changeling_pod/ship = new
+	if(SSmapping.empty_space) // if there's an empty space z level, spawn the pod somewhere there
+		var/x = rand(TRANSITIONEDGE,world.maxx - TRANSITIONEDGE - ship.width)
+		var/y = rand(TRANSITIONEDGE,world.maxy - TRANSITIONEDGE - ship.height)
+		var/z = SSmapping.empty_space.z_value
+		T = locate(x,y,z)
+	else // otherwise, try to use a random carp spawn location
+		var/list/spawn_points = list()
+		for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
+			spawn_points += C
+		var/obj/pod_spawn = pick(spawn_points)
+		T = locate(pod_spawn.x,pod_spawn.y,pod_spawn.z)
+		pod_spawn.Destroy() // removes the spawn point from the landmarks list so the game doesn't spawn a carp on our poor changeling
+
+	if(!T)
+		message_admins("Changeling infiltrator event found no turf to load in.")
+		qdel(ship)
+		return
+
+	if(!ship.load(T, centered = TRUE))
+		CRASH("Loading changeling infiltrator ship failed!")
+
+	// spawns the changeling at the changeling spawner object
+	// don't feel great about this, but the problem is that get_affected_turfs returns a list of turfs
+	// so you have to loop through the turfs and then loop through each turf to find the spawner object
+	// the pirate event also does this. it is what it is
+	for(var/turf/A in ship.get_affected_turfs(T, centered = TRUE))
+		for(var/obj/effect/mob_spawn/ghost_role/human/changeling_infiltrator/spawner in A)
+			var/mob/living/carbon/human/new_mob = spawner.create(new_ling)
+			return new_mob
+
+	return
+
+/obj/effect/mob_spawn/ghost_role/human/changeling_infiltrator
+	name = "changeling sleeper"
+	desc = "An old cryo sleeper, desperately frozen shut many years ago."
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	prompt_name = "a changeling infiltrator"
+	outfit = /datum/outfit/changeling_infiltrator
+	anchored = TRUE
+	density = FALSE
+	show_flavor = FALSE //Flavour only exists for spawners menu
+	you_are_text = "You are a changeling infiltrator."
+	flavour_text = "You awaken in an abandoned escape pod in a forsaken part of the galaxy. As you slowly regain your senses, your memories start to resurface... \
+	that old station, a chaotic brawl, blood and organs strewn everywhere... then pod doors hissing shut, and finally, nothing but silence. \
+	Those scientists thought they could seal you away forever. They were wrong."
+	important_text = "Use the navigation computer and shuttle console to navigate the pod to the station, and sneak your way on board."
+	spawner_job_path = /datum/job/changeling_infiltrator
+
+///Makes the player a changeling with a unique objective to fully absorb a certain amount of people, as well as an "escape with identity" objective
+/obj/effect/mob_spawn/ghost_role/human/changeling_infiltrator/special(mob/living/spawned_mob, mob/mob_possessor)
+	. = ..()
+	var/datum/antagonist/changeling/antag_datum = new
+	antag_datum.give_objectives = FALSE // we're giving them custom objectives
+
+	// add our new full absorb objective
+	var/datum/objective/true_absorb/absorb_objective = new
+	absorb_objective.owner = spawned_mob
+	absorb_objective.gen_amount_goal()
+	antag_datum.objectives += absorb_objective
+
+	// add "escape with [person]'s identity" objective
+	var/datum/objective/escape/escape_with_identity/identity_theft = new
+	identity_theft.owner = spawned_mob
+	identity_theft.find_target()
+	antag_datum.objectives += identity_theft
+
+	to_chat(spawned_mob, span_alert("[flavour_text]"))
+
+	spawned_mob.mind.add_antag_datum(antag_datum)
+	spawned_mob.regenerate_icons() // have to do this or else the hair is invisible at first
+
+	to_chat(spawned_mob, span_alert("[important_text]"))
+
+// True absorb objective - this requires using the absorb ability, *NOT* DNA sting
+
+/datum/objective/true_absorb
+	name = "true absorb"
+
+///Sets the number of required absorbs. 1 absorb for every [players_per_absorb] players
+/datum/objective/true_absorb/proc/gen_amount_goal(players_per_absorb = 10)
+	//target_amount = rand (lowbound,highbound)
+	target_amount = 1
+	var/player_count = 0
+	var/list/datum/mind/owners = get_owners()
+	if (SSticker.current_state == GAME_STATE_SETTING_UP)
+		for(var/i in GLOB.new_player_list)
+			var/mob/dead/new_player/P = i
+			if(P.ready == PLAYER_READY_TO_PLAY && !(P.mind in owners))
+				player_count ++
+				if(player_count == players_per_absorb)
+					target_amount ++
+					player_count = 0
+	else if (SSticker.IsRoundInProgress())
+		for(var/mob/living/carbon/human/P in GLOB.player_list)
+			if(!(P.mind.has_antag_datum(/datum/antagonist/changeling)) && !(P.mind in owners))
+				player_count ++
+				if(player_count == players_per_absorb)
+					target_amount ++
+					player_count = 0
+
+	update_explanation_text()
+	return target_amount
+
+/datum/objective/true_absorb/update_explanation_text()
+	. = ..()
+	explanation_text = "Fully absorb the DNA of [target_amount] [target_amount > 1 ? "people" : "person"]."
+
+/datum/objective/true_absorb/admin_edit(mob/admin)
+	var/count = input(admin,"How many people to absorb?","absorb",target_amount) as num|null
+	if(count)
+		target_amount = count
+	update_explanation_text()
+
+/datum/objective/true_absorb/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	var/absorbed_count = 0
+	for(var/datum/mind/M in owners)
+		if(!M)
+			continue
+		var/datum/antagonist/changeling/changeling = M.has_antag_datum(/datum/antagonist/changeling)
+		if(!changeling || !changeling.stored_profiles)
+			continue
+		absorbed_count += changeling.true_absorbs
+	return absorbed_count >= target_amount
+
+// Outfit that the changeling spawns with
+// a bunch of chameleon gear to make them less immediately suspicious, but anyone attentive will notice they're not on the crew manifest
+
+/datum/outfit/changeling_infiltrator
+	name = "Changeling Infiltrator"
+	uniform = /obj/item/clothing/under/chameleon
+	suit = /obj/item/clothing/suit/chameleon
+	shoes = /obj/item/clothing/shoes/chameleon
+	back = /obj/item/storage/backpack/chameleon
+	r_pocket = /obj/item/flashlight
+	id = /obj/item/card/id/advanced/chameleon
+	box = /obj/item/storage/box/survival/engineer/radio
+
+// the toolbox on their pod has the contents and power of a Syndicate toolbox but looks like a normal one
+
+/obj/item/storage/toolbox/syndicate/secret
+	name = "emergency toolbox"
+	desc = "Danger. Very robust."
+	icon_state = "red"
+	inhand_icon_state = "toolbox_red"
+	material_flags = NONE
+
+// The ship the infiltrator spawns on
+
+/area/shuttle/changeling_pod
+	name = "Abandoned Pod"
+	requires_power = TRUE
+
+/datum/map_template/shuttle/changeling_pod
+	name = "abandoned pod"
+	port_id = "changeling"
+	suffix = "pod"
+
+/obj/machinery/computer/shuttle/changeling_pod
+	name = "abandoned pod console"
+	shuttleId = "changelingpod"
+	icon_screen = "commsyndie"
+	icon_keyboard = "syndie_key"
+	light_color = COLOR_SOFT_RED
+	possible_destinations = "changelingpod_away;changelingpod_home;changelingpod_custom"
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/changeling_pod
+	name = "abandoned pod navigation computer"
+	desc = "Used to designate a precise transit location for the abandoned pod."
+	shuttleId = "changelingpod"
+	lock_override = CAMERA_LOCK_STATION
+	shuttlePortId = "changelingpod_custom"
+	x_offset = -3
+	y_offset = 2
+	see_hidden = TRUE
+
+/obj/docking_port/mobile/changeling_pod
+	name = "abandoned pod"
+	id = "changelingpod"
+	rechargeTime = 5 MINUTES

--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -1,0 +1,23 @@
+
+//////////////////////////////////////////////
+//                                          //
+//         CHANGELING INFILTRATOR           //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator
+	name = "Changeling Infiltrator"
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	antag_flag = ROLE_CHANGELING
+	weight = 3
+	cost = 12
+	requirements = list(70,70,60,50,40,20,20,10,10,10)
+	required_candidates = 1
+	repeatable = FALSE
+
+/datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator/generate_ruleset_body(mob/applicant)
+	var/mob/living/carbon/human/new_mob = spawn_changeling_infiltrator(applicant)
+	return new_mob
+
+/datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator/finish_setup(mob/new_character, index)
+	return // the spawned player is given the antag datum via the spawner, so we don't need to do it here

--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -11,7 +11,7 @@
 	antag_flag = ROLE_CHANGELING
 	weight = 3
 	cost = 12
-	requirements = list(70,70,60,50,40,20,20,10,10,10)
+	requirements = list(70,60,50,50,40,20,20,10,10,10)
 	required_candidates = 1
 	repeatable = FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4555,6 +4555,8 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "orbstation\antagonists\rulesets_midround.dm"
+#include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"
 #include "orbstation\Chaplain\ratlain.dm"
 #include "orbstation\clothing\misc.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds a new midround antagonist to the game: the Changeling Infiltrator. Unlike roundstart changelings, who spawn as a member of the crew, these changelings spawn on an abandoned 5x6 escape pod in the middle of space (or, on maps that don't have space, like Icebox, just outside of the station, on a random carp spawn location) with a randomized human identity, and must use the navigation computer on the pod to fly it to a spot near the station, from which they can disembark and sneak on board. The pod has a rather long recharging period of 10 minutes, since it's mostly just meant to be a way of getting _onto_ the station.

Their pod comes stocked with a handful of emergency tools to make boarding easier - a bulky emergency space suit and pickaxe like the ones that typically appear in pod storage containers, a winter jacket, and an emergency toolbox that comes with all the tools found in a Syndicate toolbox (black insulated gloves included). The changeling also starts with a chameleon jumpsuit/shoes/backpack and an agent ID, which grants them maintenance access as well as a perfunctory identity which might give the changeling a passing bit of credibility if someone happens to pass by them in maintenance, although anyone who applies any scrutiny will likely realize that they're not on the crew manifest. Their backpack contains a box with an extended capacity emergency oxygen tank and a radio.

Unlike roundstart changelings, changeling infiltrators get an objective that requires them to fully absorb a small number of crewmembers - 1, plus 1 for every 10 crewmembers, up to a maximum of 5 at 40+ players. Their intended MO is to kill a member of the crew, absorb them, and take their place. They also get a regular "escape alive" objective.

This antagonist can spawn from a midround ruleset or from a rare event, similar to pirates and aliens. It draws from ghost players and uses the normal changeling setting in the preferences menu.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Changelings are probably one of the most interesting antagonist types in the game, especially in terms of flavor, and this approaches them from a different angle. There's something I find particularly creepy in an exciting way about the idea of a crew member getting replaced by a complete stranger partway through a round and people not noticing until it's too late. The pilotable pod also allows for some fun entry routes - I've tried it out on every map except Deltastation (which is far too big for our population), and they all have some cool possibilities for sneaky or just plain funny parking locations. Although this likely won't appear super often, it should hopefully spice up rounds a bit, and add an extra layer of paranoia to the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New 'changeling infiltrator' midround ghost role, which can spawn from a ruleset or rare event. Sneak on board the station and replace one of the crewmembers!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
