### PR TITLE
Made it impossible to use the xenobiology "gender change potion" on anyone but yourself.

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -947,11 +947,15 @@
 
 /obj/item/slimepotion/genderchange
 	name = "gender change potion"
-	desc = "An interesting chemical mix that changes the biological gender of what its applied to. Cannot be used on things that lack gender entirely."
+	desc = "An interesting chemical mix that changes the gender of what it's applied to. Can only be used on yourself."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potlightpink"
 
 /obj/item/slimepotion/genderchange/attack(mob/living/L, mob/user)
+	if(L != user)
+		to_chat(user, span_warning("You can't use this on someone else!"))
+		return
+
 	if(!istype(L) || L.stat == DEAD)
 		to_chat(user, span_warning("The potion can only be used on living things!"))
 		return


### PR DESCRIPTION
As described in the title, the gender change potion can now only be used on the wielder.

Resolves #103 in a quick and dirty way. There are other issues with this item, but this is the main thing.