### PR TITLE
Disables drunken slurring filter, as well as Ballmer Peak messages.

### DIFF
--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -148,23 +148,15 @@
 	// Handle the Ballmer Peak.
 	// If our owner is a scientist (has the trait "TRAIT_BALLMER_SCIENTIST"), there's a 5% chance
 	// that they'll say one of the special "ballmer message" lines, depending their drunk-ness level.
-	if(HAS_TRAIT(owner, TRAIT_BALLMER_SCIENTIST) && prob(5))
-		if(drunk_value >= BALLMER_PEAK_LOW_END && drunk_value <= BALLMER_PEAK_HIGH_END)
-			owner.say(pick_list_replacements(VISTA_FILE, "ballmer_good_msg"), forced = "ballmer")
+	//if(HAS_TRAIT(owner, TRAIT_BALLMER_SCIENTIST) && prob(5))
+		//if(drunk_value >= BALLMER_PEAK_LOW_END && drunk_value <= BALLMER_PEAK_HIGH_END)
+			//owner.say(pick_list_replacements(VISTA_FILE, "ballmer_good_msg"), forced = "ballmer")
 
-		if(drunk_value > BALLMER_PEAK_WINDOWS_ME) // by this point you're into windows ME territory
-			owner.say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
-
-	// There's always a 30% chance to gain some drunken slurring
-	if(prob(30))
-		owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk)
+		//if(drunk_value > BALLMER_PEAK_WINDOWS_ME) // by this point you're into windows ME territory
+			//owner.say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
 
 	// And drunk people will always lose jitteriness
 	owner.adjust_timed_status_effect(-6 SECONDS, /datum/status_effect/jitter)
-
-	// Over 11, we will constantly gain slurring up to 10 seconds of slurring.
-	if(drunk_value >= 11)
-		owner.adjust_timed_status_effect(2.4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 10 SECONDS)
 
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
 	if(drunk_value >= 41)


### PR DESCRIPTION
Temporary fix while I rework how drunkenness works more completely. Many people, myself included, are annoyed with how taking two sips of beer makes you completely unable to speak like a normal person. This moves the onus of acting drunk more to the player to roleplay, which is fine for how we do things here.