### PR TITLE
Tweaks to unfavorable situations

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -811,15 +811,16 @@
 	// If we have a certain amount of ghosts, we'll add some more !!fun!! options to the list
 	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
 
-	// Pirates require empty space for the ship, and ghosts for the pirates obviously
-	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_PIRATES))
-		hack_options += HACK_PIRATE
-	// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
-	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
-		hack_options += HACK_FUGITIVES
-	// If less than a certain percent of the population is ghosts, consider sleeper agents
-	if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
-		hack_options += HACK_SLEEPER
+	if(EMERGENCY_IDLE_OR_RECALLED) // ORBSTATION: only create new antags if the emergency shuttle hasn't been called
+		// Pirates require empty space for the ship, and ghosts for the pirates obviously
+		if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_PIRATES))
+			hack_options += HACK_PIRATE
+		// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
+		if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
+			hack_options += HACK_FUGITIVES
+		// If less than a certain percent of the population is ghosts, consider sleeper agents
+		if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
+			hack_options += HACK_SLEEPER
 
 	var/picked_option = pick(hack_options)
 	message_admins("[ADMIN_LOOKUPFLW(hacker)] hacked a [name] located at [ADMIN_VERBOSEJMP(src)], resulting in: [picked_option]!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This makes two slight tweaks to unfavorable situations, which primarily happen when a traitor hacks the communications console for an objective.

First, the hack will no longer attempt to create new antagonists if the emergency shuttle is currently called, docked at the station, or flying to Centcom. Instead, it will only trigger one of the three pre-defined unfavorable events (those being immovable rod, meteors, or a portal storm that summons Syndicate trooper simplemobs.)

Second, when the hack attempts to spawn a heavy ruleset, it will use a threat level higher than the current threat level by 30, allowing it to spawn more threatening antagonists such as wizards and ninjas, even at lower populations. (Especially once the changes I made to the dynamic config get in. See here: https://pastebin.com/449Yac6e.)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Becoming an antagonist when the shuttle has already been called is very rough, as it means you will have to suddenly scramble to complete your objectives, and won't have any time to put together any fun schemes or gimmicks. Plus, by that point, people are usually ready for the round to end, so a brand new threat showing up out of nowhere can be frustrating.

Allowing the hack to execute rulesets that are at a threat level higher than the current threat level is good because it makes this objective much more impactful on the overall round, and fits with the in-universe flavor of this objective being the station getting shifted into a more dangerous part of space.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hacking the communications console will no longer create new antagonists if the emergency shuttle has been called.
balance: Hacking the communications console can now summon antagonists that require a higher threat level than the current amount.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
