### PR TITLE
Small tweak/fix to changeling infiltrator

### DIFF
--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -27,13 +27,18 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator
 	name = "Changeling Infiltrator"
-	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
 	antag_flag = ROLE_CHANGELING
-	weight = 3
+	weight = 5
 	cost = 12
-	requirements = list(70,60,50,50,40,20,20,10,10,10)
+	requirements = list(101,60,50,50,40,20,20,10,10,10)
 	required_candidates = 1
 	repeatable = FALSE
+
+/datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator/ready(forced = FALSE)
+	if (required_candidates > (dead_players.len + list_observers.len))
+		return FALSE
+	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator/generate_ruleset_body(mob/applicant)
 	var/mob/living/carbon/human/new_mob = spawn_changeling_infiltrator(applicant)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I defined a "ready()" proc for changeling infiltrator, which should hopefully stop the "Possible volunteers was 0" message from appearing and make it so that it won't be chosen if there's no ghosts around. I also changed the ruleset to be heavy instead of light, so hopefully it should be rolled later in the game, when there's actually ghosts around, and it will be able to be summoned by the comms console hack.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Changeling infiltrator ruleset will now trigger later in the round, and can be caused by the communications console hack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
