### PR TITLE
Renames "sanity" to "stress" in descriptive text.

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -49,7 +49,7 @@
 
 /datum/component/mood/proc/print_mood(mob/user)
 	var/msg = "[span_info("<EM>My current mental status:</EM>")]\n"
-	msg += span_notice("My current sanity: ") //Long term
+	msg += span_notice("My current stress: ") //Long term
 	switch(sanity)
 		if(SANITY_GREAT to INFINITY)
 			msg += "[span_boldnicegreen("My mind feels like a temple!")]\n"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -742,7 +742,7 @@
 
 /datum/quirk/unstable
 	name = "Unstable"
-	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
+	desc = "Due to past troubles, you are unable to recover from stress. Be very careful managing your mood!"
 	icon = "angry"
 	value = -10
 	mob_trait = TRAIT_UNSTABLE


### PR DESCRIPTION
The use of the word "sanity" here is a bit ableist and generally unpleasant. It has been changed to the far more neutral "stress" in both places where the player actually sees it. To prevent merge conflicts, the underlying code has not been changed.