### PR TITLE
Changes "destroy Telecommunication Hub" objective to "destroy Common Server"

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
@@ -38,7 +38,7 @@
 	progression_maximum = 30 MINUTES
 	allow_more_than_max = TRUE
 	applicable_jobs = list(
-		JOB_STATION_ENGINEER = /obj/machinery/telecomms/hub,
+		JOB_STATION_ENGINEER = /obj/machinery/telecomms/server/presets/common,
 		JOB_SCIENTIST = /obj/machinery/rnd/server,
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

One-line change. The title says it all.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

At the moment, the tcomms hub is destroyed very frequently. It's rare that anyone is monitoring tcomms, which makes it an easy source of reputation points and telecrystals. The tcomms hub is also very tricky to repair properly, as it involves reconnecting many different machines, including ones that aren't physically present in the tcomms server room. If done incorrectly, this can easily result in rounds where comms go down and never come back, which is undesirable at its current frequency.  Obviously, antags can sabotage the hub if they want to, but they don't need the extra incentive.

Changing this objective to target the common server accomplishes a similar effect (preventing people from talking over the common channel) but is much easier to repair with only a little tcomms knowledge, and it does not disrupt departmental channels, which feels more interesting to me. Also, as a positive side effect, this objective will not generate if the common server has already been destroyed and repaired, as doing so turns the common server object into a generic server object rather than the preset that it spawns with on the map.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The "destroy the Telecommunication Hub" traitor objective has been changed to "destroy the Common Server."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
