### PR TITLE
Zombie nerfs / changes

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -10,7 +10,7 @@
 	icon_state = "bloodhand_left"
 	var/icon_left = "bloodhand_left"
 	var/icon_right = "bloodhand_right"
-	hitsound = 'sound/hallucinations/growl1.ogg'
+	hitsound = 'sound/weapons/slash.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
 	sharpness = SHARP_EDGED
 	wound_bonus = -30
@@ -35,9 +35,8 @@
 	if(!proximity_flag)
 		return
 	else if(isliving(target))
-		if(ishuman(target))
-			try_to_zombie_infect(target)
-		else
+		// ORBSTATION: Zombie claws don't infect people, there's a bite action for that.
+		if(!ishuman(target))
 			check_feast(target, user)
 
 /proc/try_to_zombie_infect(mob/living/carbon/human/target)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -34,10 +34,9 @@
 	. = ..()
 	if(!proximity_flag)
 		return
-	else if(isliving(target))
+	else if(isliving(target) && !ishuman(target))
 		// ORBSTATION: Zombie claws don't infect people, there's a bite action for that.
-		if(!ishuman(target))
-			check_feast(target, user)
+		check_feast(target, user)
 
 /proc/try_to_zombie_infect(mob/living/carbon/human/target)
 	CHECK_DNA_AND_SPECIES(target)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -47,10 +47,10 @@
 		Remove(owner)
 	if(owner.mob_biotypes & MOB_MINERAL)//does not process in inorganic things
 		return
-	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
-		owner.adjustToxLoss(0.5 * delta_time)
-		if (DT_PROB(5, delta_time))
-			to_chat(owner, span_danger("You feel sick..."))
+	// ORBSTATION: Zombie organ only damages you if you're in critical condition.
+	if(owner.health <= HEALTH_THRESHOLD_CRIT && owner.stat != DEAD)
+		if (causes_damage && !iszombie(owner))
+			owner.adjustToxLoss(0.5 * delta_time)
 	if(timer_id)
 		return
 	if(owner.suiciding)

--- a/orbstation/species/zombie/zombie_bite.dm
+++ b/orbstation/species/zombie/zombie_bite.dm
@@ -44,8 +44,8 @@
 	if(ismonkey(target))
 		to_chat(owner, span_warning("You can only bite humanoid targets!"))
 		return FALSE
-	if(NOBLOOD in target.dna.species.species_traits || NOZOMBIE in target.dna.species.species_traits) // you cannot bite plasmamen, skeletons, golems, other zombies, etc
-		to_chat(owner, span_warning("You can't seem to bite this person!"))
+	if((NOBLOOD in target.dna.species.species_traits) || (NOZOMBIE in target.dna.species.species_traits)) // you cannot bite plasmamen, skeletons, golems, other zombies, etc
+		to_chat(owner, span_warning("This person has no blood to infect!"))
 		return FALSE
 	if(owner.grab_state < GRAB_NECK)
 		to_chat(owner, span_warning("You need a stronger grip to bite this person!"))

--- a/orbstation/species/zombie/zombie_bite.dm
+++ b/orbstation/species/zombie/zombie_bite.dm
@@ -1,5 +1,5 @@
 /// Time it takes to bite the target.
-#define ZOMBIE_BITE_TIME 10 SECONDS
+#define ZOMBIE_BITE_TIME 8 SECONDS
 
 /datum/action/zombie_bite
 	name = "Bite"

--- a/orbstation/species/zombie/zombie_bite.dm
+++ b/orbstation/species/zombie/zombie_bite.dm
@@ -1,0 +1,67 @@
+/// Time it takes to bite the target.
+#define ZOMBIE_BITE_TIME 10 SECONDS
+
+/datum/action/zombie_bite
+	name = "Bite"
+	icon_icon = 'icons/obj/surgery.dmi'
+	button_icon_state = "brain-x-d"
+	/// Set to TRUE when the user is currently trying to bite someone.
+	var/is_biting = FALSE
+
+/datum/action/zombie_bite/Trigger(trigger_flags)
+	var/mob/user = owner
+
+	if(!can_bite(user))
+		return
+
+	var/mob/living/carbon/target = owner.pulling
+	owner.visible_message(span_warning("[owner] begins biting through [target]'s skin!"), span_warning("You begin biting [target]!"))
+	is_biting = TRUE
+
+	if(!do_mob(owner, target, ZOMBIE_BITE_TIME))
+		is_biting = FALSE
+		return
+
+	is_biting = FALSE
+	bite_target(user, target)
+
+/// Biting a target requires you to be conscious and have the target in a neck grab.
+/datum/action/zombie_bite/proc/can_bite(mob/living/carbon/human/user)
+	if(!user || !user.mind)
+		return FALSE
+	if(!ishuman(user))
+		return FALSE
+	if(user.stat != CONSCIOUS)
+		return FALSE
+	if(is_biting)
+		return FALSE
+	if(!owner.pulling || !ishuman(owner.pulling))
+		to_chat(owner, span_warning("You must be grabbing a person to use this action!"))
+		return FALSE
+
+	var/mob/living/carbon/human/target = owner.pulling
+	CHECK_DNA_AND_SPECIES(target)
+	if(ismonkey(target))
+		to_chat(owner, span_warning("You can only bite humanoid targets!"))
+		return FALSE
+	if(NOBLOOD in target.dna.species.species_traits || NOZOMBIE in target.dna.species.species_traits) // you cannot bite plasmamen, skeletons, golems, other zombies, etc
+		to_chat(owner, span_warning("You can't seem to bite this person!"))
+		return FALSE
+	if(owner.grab_state < GRAB_NECK)
+		to_chat(owner, span_warning("You need a stronger grip to bite this person!"))
+		return FALSE
+
+	return TRUE
+
+/// Attempts to infect the target, and creates a severe slash wound on the targeted bodypart.
+/datum/action/zombie_bite/proc/bite_target(mob/living/user, mob/living/target, obj/item/bodypart/target_head)
+	try_to_zombie_infect(target)
+
+	owner.visible_message(span_danger("[owner] bites [target]!"), span_warning("You bite [target]!"))
+
+	var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
+	targeted_bodypart.force_wound_upwards(/datum/wound/slash/severe)
+
+	log_combat(user, target, "zombie bit")
+
+#undef ZOMBIE_BITE_TIME

--- a/orbstation/species/zombie/zombies.dm
+++ b/orbstation/species/zombie/zombies.dm
@@ -1,0 +1,24 @@
+/datum/species/zombie/infectious
+	armor = 0 // let's not give zombies more armor for no reason
+	brutemod = 1.25 // zombies are weak to brute-force attacks
+	var/datum/action/zombie_bite/bite_action
+
+/datum/species/zombie/infectious/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	if(ishuman(C))
+		bite_action = new
+		bite_action.Grant(C)
+	if(HAIR in old_species.species_traits)
+		species_traits |= HAIR
+	if(FACEHAIR in old_species.species_traits)
+		species_traits |= FACEHAIR
+	return ..()
+
+/datum/species/zombie/infectious/on_species_loss(mob/living/carbon/C)
+	if(bite_action)
+		bite_action.Remove(C)
+	return ..()
+
+/datum/species/zombie/infectious/spec_death(gibbed, mob/living/carbon/C)
+	if(bite_action)
+		bite_action.Remove(C)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4635,4 +4635,6 @@
 #include "orbstation\datums\components\crafting\recipes.dm"
 #include "orbstation\datums\greyscale\config_types\greyscale_configs.dm"
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
+#include "orbstation\species\zombie\zombie_bite.dm"
+#include "orbstation\species\zombie\zombies.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Zombies now have a 'bite' action which they can use on humanoid targets (who don't have the NOBLOOD or NOZOMBIE species traits) they have in a neck grab. This takes 10 seconds, leaves a severe wound on the targeted bodypart, and infects them with the zombie organ.
- Zombie claws no longer cause infection on hit.
- Zombie claws now make a slash sound rather than a growl on hit, for better feedback.
- Zombies no longer have natural armor, and take 25% more brute damage.
- The zombie organ now only causes damage if the infectee is in critical condition.
- Zombies can now have hair/facial hair if they were originally a species with those traits.

Closes #121.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Zombies have been in a pretty bad place for our server - one hit from a zombie is enough to instantly infect someone, and there's no possible way for medical to intervene in time for every single person, especially since the zombie tumor also kills you. Essentially every time zombies have appeared, the majority of the crew have gotten infected, and people have complained. Additionally, it feels bizarre and unflavorful that zombies don't have the ability to bite people, since that is their  classic ability in virtually every piece of zombie media.

However, I still wanted to keep the traitor romerol objective in the game, as it's good for there to be more variety in final objectives, and a zombie apocalypse is conceptually fun to endure as a crewmember.

This PR makes it so that individual zombies are much less of a threat, so they will need to rely on the power of numbers in order to take down their prey. Furthermore, traitors with the romerol objective will need to do some work to start their own zombie apocalypse by killing a few people beforehand, stealing bodies that haven't been revived yet, or even injecting themselves with it and then dying.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Zombies now infect people by grabbing their neck and using their "bite" ability, which takes 10 seconds, leaves a severe slash wound, and infects the victim. This does not work on species without blood or other zombies. Zombie claws no longer infect people.
balance: The zombie tumor organ only deals damage when in critical condition.
balance: Zombies no longer have natural armor, and take 25% more brute damage.
feature: Zombies will now retain the hair and facial hair they had in life.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
