### PR TITLE
Windoors are no longer the most insurmountable obstacle in the universe

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -7,7 +7,7 @@
 	closingLayer = ABOVE_WINDOW_LAYER
 	resistance_flags = ACID_PROOF
 	var/base_state = "left"
-	max_integrity = 75 // ORBSTATION: it's a door made of GLASS. 5 hits from circular saw, 8 from toolbox, etc
+	max_integrity = 75 // ORBSTATION: it's a door made of GLASS. in practice takes about 7 hits from a circular saw or toolbox
 	integrity_failure = 0
 	armor = list(MELEE = 20, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 0, FIRE = 70, ACID = 100)
 	visible = FALSE
@@ -27,7 +27,7 @@
 	/// Time it takes to pry open the windoor with the jaws of life.
 	var/pry_time = 4 SECONDS
 	/// Percent chance for the windoor to break when pried open with the jaws of life.
-	var/pry_break_chance = 25
+	var/pry_break_chance = 30
 
 /obj/machinery/door/window/Initialize(mapload, set_dir, unres_sides)
 	. = ..()
@@ -257,6 +257,7 @@
 
 /obj/machinery/door/window/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1) && !disassembled)
+		playsound(src, SFX_SHATTER, 70, TRUE)
 		for(var/obj/fragment in debris)
 			fragment.forceMove(get_turf(src))
 			transfer_fingerprints_to(fragment)
@@ -301,9 +302,9 @@
 	if(!panel_open)
 		return
 	add_fingerprint(user)
-	user.visible_message(span_notice("[user] starts to remove the electronics from the [name]."), \
-	span_notice("You start to remove the electronics from the [name]..."))
-	if(!tool.use_tool(src, user, pry_time, volume=50))
+	user.visible_message(span_notice("[user] starts to remove the electronics from \the [name]."), \
+	span_notice("You start to remove the electronics from \the [name]..."))
+	if(!tool.use_tool(src, user, pry_time * 1.5, volume=50))
 		return
 	if(!panel_open || !loc)
 		return
@@ -362,24 +363,25 @@
 			open(2)
 		else
 			close(2)
-	else if(istype(I, /obj/item/crowbar/power)) // ORBSTATION: jaws of life can pry open windoors, but with a chance to break them
+	else if(!panel_open)
 		if(!density)
+			to_chat(user, span_notice("\The [name] is already open!"))
+			return
+		if(istype(I, /obj/item/crowbar/power)) // ORBSTATION: jaws of life can pry open windoors, but with a chance to break them
 			add_fingerprint(user)
-			user.visible_message(span_notice("[user] starts to pry open the [name] with [I]."), \
-			span_notice("You start prying open the [name] with [I]..."))
-			if(!I.use_tool(src, user, pry_time, volume=50))
+			user.visible_message(span_notice("[user] starts to pry open \the [name] with [I]."), \
+			span_notice("You start prying open \the [name] with [I]..."))
+			if(!I.use_tool(src, user, pry_time, volume=80))
 				return
 			if(!loc)
 				return
 			if(prob(pry_break_chance))
-				user.visible_message(span_danger("The [name] breaks apart under the force of [I]!"))
-				atom_break()
+				user.visible_message(span_danger("\The [name] breaks apart under the force of [I]!"))
+				deconstruct(disassembled = FALSE)
 			else
 				open(2)
 		else
-			to_chat(user, span_notice("The [name] is already open!"))
-	else
-		to_chat(user, span_warning("The door's motors resist your efforts to force it!"))
+			to_chat(user, span_warning("The door's motors resist your efforts to force it!"))
 
 /obj/machinery/door/window/do_animate(animation)
 	switch(animation)
@@ -438,11 +440,11 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = null
-	max_integrity = 125 //Stronger doors for prison (regular window door health is 75)
+	max_integrity = 200 //Stronger doors for prison (regular window door health is 75)
 	reinf = 1
 	explosion_block = 1
-	pry_time = 8 SECONDS
-	pry_break_chance = 50
+	pry_time = 10 SECONDS
+	pry_break_chance = 60
 
 /obj/machinery/door/window/brigdoor/security/cell
 	name = "cell door"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -7,7 +7,7 @@
 	closingLayer = ABOVE_WINDOW_LAYER
 	resistance_flags = ACID_PROOF
 	var/base_state = "left"
-	max_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
+	max_integrity = 75 // ORBSTATION: it's a door made of GLASS. 5 hits from circular saw, 8 from toolbox, etc
 	integrity_failure = 0
 	armor = list(MELEE = 20, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 0, FIRE = 70, ACID = 100)
 	visible = FALSE
@@ -24,6 +24,10 @@
 	var/rods = 2
 	var/cable = 1
 	var/list/debris = list()
+	/// Time it takes to pry open the windoor with the jaws of life.
+	var/pry_time = 4 SECONDS
+	/// Percent chance for the windoor to break when pried open with the jaws of life.
+	var/pry_break_chance = 25
 
 /obj/machinery/door/window/Initialize(mapload, set_dir, unres_sides)
 	. = ..()
@@ -284,9 +288,6 @@
 	. = ..()
 	if(flags_1 & NODECONSTRUCT_1)
 		return
-	if(density || operating)
-		to_chat(user, span_warning("You need to open the door to access the maintenance panel!"))
-		return
 	add_fingerprint(user)
 	tool.play_tool_sound(src)
 	panel_open = !panel_open
@@ -297,14 +298,14 @@
 	. = ..()
 	if(flags_1 & NODECONSTRUCT_1)
 		return
-	if(!panel_open || density || operating)
+	if(!panel_open)
 		return
 	add_fingerprint(user)
-	user.visible_message(span_notice("[user] removes the electronics from the [name]."), \
-	span_notice("You start to remove electronics from the [name]..."))
-	if(!tool.use_tool(src, user, 40, volume=50))
+	user.visible_message(span_notice("[user] starts to remove the electronics from the [name]."), \
+	span_notice("You start to remove the electronics from the [name]..."))
+	if(!tool.use_tool(src, user, pry_time, volume=50))
 		return
-	if(!panel_open || density || operating || !loc)
+	if(!panel_open || !loc)
 		return
 	var/obj/structure/windoor_assembly/windoor_assembly = new /obj/structure/windoor_assembly(loc)
 	switch(base_state)
@@ -361,6 +362,22 @@
 			open(2)
 		else
 			close(2)
+	else if(istype(I, /obj/item/crowbar/power)) // ORBSTATION: jaws of life can pry open windoors, but with a chance to break them
+		if(!density)
+			add_fingerprint(user)
+			user.visible_message(span_notice("[user] starts to pry open the [name] with [I]."), \
+			span_notice("You start prying open the [name] with [I]..."))
+			if(!I.use_tool(src, user, pry_time, volume=50))
+				return
+			if(!loc)
+				return
+			if(prob(pry_break_chance))
+				user.visible_message(span_danger("The [name] breaks apart under the force of [I]!"))
+				atom_break()
+			else
+				open(2)
+		else
+			to_chat(user, span_notice("The [name] is already open!"))
 	else
 		to_chat(user, span_warning("The door's motors resist your efforts to force it!"))
 
@@ -421,9 +438,11 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = null
-	max_integrity = 300 //Stronger doors for prison (regular window door health is 200)
+	max_integrity = 125 //Stronger doors for prison (regular window door health is 75)
 	reinf = 1
 	explosion_block = 1
+	pry_time = 8 SECONDS
+	pry_break_chance = 50
 
 /obj/machinery/door/window/brigdoor/security/cell
 	name = "cell door"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,9 +24,9 @@
 	var/rods = 2
 	var/cable = 1
 	var/list/debris = list()
-	/// Time it takes to pry open the windoor with the jaws of life.
+	/// ORBSTATION: Time it takes to pry open the windoor with the jaws of life. Time to disassemble is this * 1.5.
 	var/pry_time = 4 SECONDS
-	/// Percent chance for the windoor to break when pried open with the jaws of life.
+	/// ORBSTATION: Percent chance for the windoor to break when pried open with the jaws of life.
 	var/pry_break_chance = 30
 
 /obj/machinery/door/window/Initialize(mapload, set_dir, unres_sides)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -440,7 +440,7 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = null
-	max_integrity = 200 //Stronger doors for prison (regular window door health is 75)
+	max_integrity = 220 //Stronger doors for prison (regular window door health is 75)
 	reinf = 1
 	explosion_block = 1
 	pry_time = 10 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Windoors now have lower integrity, allowing them to be broken quicker as a result blunt force.
- - Regular windoors: 150 -> 75 (around 7 hits of a toolbox, probably 3 or 4 hits from wielded fire axe)
- - Reinforced windoors: 300 -> 220 (around 20...ish? hits of toolbox (I forgot), 10 hits from wielded fire axe)
- Windoors can now be disassembled even when closed using a screwdriver and a crowbar. Doing so takes some time.
- - Regular windoors: 6 seconds
- - Reinforced windoors: 15 seconds
- The jaws of life can now be used to pry open closed windoors, which takes some time and has a chance to break the windoor, leaving behind evidence.
- - Regular windoors: 4 seconds, 30% chance
- - Reinforced windoors: 10 seconds, 60% chance
- Added a shatter sound-effect to windoors breaking, consistent with regular windows.

Closes #126.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Right now windoors are ridiculously durable despite being a piece of glass with wire and electronics in it. This seems to mostly stem from certain people on /tg/ being awful gremlins who like to break into departments even when they're not antagonists, but we don't have that problem here, so it's mostly just a bizarre design decision. Windoors, in general, are only found at the front desks of departments, or inside of rooms. Having them be harder to get past than _airlocks_ doesn't make sense. This PR makes things a lot more sensible, and adds additional functionality to the jaws of life which make it even better as a tool for rescue missions (and just general antaggery).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Windoors are less durable, can be disassembled even when closed, and can be pried open with the jaws of life, albeit with a chance of breaking the window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
