### PR TITLE
Configurable minimum threat level var and roundstart report accuracy vars

### DIFF
--- a/orbstation/antagonists/dynamic.dm
+++ b/orbstation/antagonists/dynamic.dm
@@ -1,15 +1,23 @@
 /datum/game_mode/dynamic
-	///Number of antagonists that count towards the traitor limit.
-	///(Generally, antagonists that spawn as members of the crew, aside from thieves.)
+	/// Number of antagonists that count towards the traitor limit.
+	/// (Generally, antagonists that spawn as members of the crew, aside from thieves.)
 	var/traitor_limit_antag_count = 0
-	///Theoretical percentage of crew that can become traitors at 100 threat.
-	///Used to calculate maximum traitor count for current population and threat level.
-	///Remember that threat level generally falls somewhere around 50.
-	///Configurable in dynamic.json.
+	/// Theoretical percentage of crew that can become traitors at 100 threat.
+	/// Used to calculate maximum traitor count for current population and threat level.
+	/// Remember that threat level generally falls somewhere around 50.
+	/// Configurable in dynamic.json.
 	var/max_threat_traitor_percent = 0.5
+	/// Minimum amount of threat allowed to generate.
+	var/min_threat_level = 30
+	/// Chance that the roundstart threat report will be wrong about the threat level.
+	var/fake_report_chance = 5
+	/// Potential positive deviance from the actual threat level in the roundstart threat report.
+	var/pos_shown_threat_deviance = 10
+	/// Potential negative deviance from the actual threat level in the roundstart threat report.
+	var/neg_shown_threat_deviance = -10
 
-///Calculates the limit for midround/latejoin traitor spawns based on current population and threat level.
-///Returns TRUE or FALSE depending on if more traitors can spawn or not.
+/// Calculates the limit for midround/latejoin traitor spawns based on current population and threat level.
+/// Returns TRUE or FALSE depending on if more traitors can spawn or not.
 /datum/game_mode/dynamic/proc/calculate_traitor_limit()
 	var/traitor_limit = round(((threat_level / 100) * max_threat_traitor_percent) * GLOB.alive_player_list.len, 1)
 
@@ -18,6 +26,18 @@
 
 	return TRUE
 
+/datum/game_mode/dynamic/generate_threat()
+	..()
+	threat_level = max(min_threat_level, threat_level)
+
+/datum/game_mode/dynamic/setup_shown_threat()
+	if(threat_level == 100) // if the threat level is somehow at 100 we want the game to always print out the "Impending Doom" report because it's funny
+		shown_threat = 100
+	else if (prob(fake_report_chance))
+		shown_threat = rand(min_threat_level, max_threat_level)
+	else
+		shown_threat = clamp(threat_level + rand(neg_shown_threat_deviance, pos_shown_threat_deviance), 0, 100)
+
 /datum/dynamic_ruleset
-	///If set to TRUE, the game will count antags spawned by this ruleset when limiting how many midround/latejoin traitors can spawn.
+	/// If set to TRUE, the game will count antags spawned by this ruleset when limiting how many midround/latejoin traitors can spawn.
 	var/counts_toward_traitor_limit = FALSE


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a few new variables to our dynamic.dm, which are all configurable in dynamic.json, three of which are replacing unconfigurable defines from the original dynamic.dm:

1. min_threat_level: Self-explanatory. the minimum level of threat that can possibly generate. Set to 30 by default.
2. fake_report_chance: Chance for the roundstart threat report to be completely random. Lowered to 5% from its original value of 8%.
3. pos_shown_threat_deviance: Potential deviance in shown threat from the actual threat level, positive. Set to 10, lowered from 15.
4. neg_shown_threat_deviance: Potential deviance in shown threat from the actual threat level, negative. Set to 10, lowered from 15.

Also, if the threat level is 100, the report will _always_ say "Impending Doom", because it's funny.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

- Sometimes the game generates threat so low that barely any antagonists spawn, which leads to pretty boring rounds. 

- The threat report is an interesting way of preparing the heads for whatever threats they might encounter on the shift, but it's a bit too inaccurate right now. It's good for this to be customizable.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: There is now a minimum level of threat that the game can generate in a round.
balance: Enemy communication intercept report is now somewhat more accurate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
