### PR TITLE
Makes the malware injection objective description more clear

### DIFF
--- a/orbstation/antagonists/traitor/objectives/final_objective/malware_injection.dm
+++ b/orbstation/antagonists/traitor/objectives/final_objective/malware_injection.dm
@@ -4,8 +4,9 @@
 /datum/traitor_objective/final/malware_injection
 	name = "Hack %NUMBER% APCs, and inject the AI with malware in the %DEPT%"
 	description = "Press the button to call down a drop pod containing a malware injector and a circuit board for a malware injection console. \
-	Use the injector to hack %NUMBER% APCs, and then go to the %DEPT% to build the console. Use the injector on the console to begin \
-	corrupting the AI. WARNING: This process will alert the AI and trigger nearby alarms."
+	Use the injector to hack %NUMBER% APCs, and then go to the %DEPT% to build the console. Note that the console will not work in command staff offices, \
+	which are protected. Use the injector on the console to begin corrupting the AI. \
+	WARNING: This process will alert the AI and trigger nearby alarms."
 
 	///Name of the department where the Syndicate AI upload needs to be built.
 	var/department_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This updates the in-game description for the malware injection traitor objective to specifically state that the upload console will not work in command staff offices, as these are considered to be "command" areas rather than being part of their departments.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This should hopefully prevent confusion in the future over where to build the console for the objective.