### PR TITLE
Survival boxes now start with a pocket crowbar

### DIFF
--- a/orbstation/objects/items/storage.dm
+++ b/orbstation/objects/items/storage.dm
@@ -1,0 +1,9 @@
+// Survival boxes
+
+/obj/item/storage/box/survival/PopulateContents()
+	..()
+	new /obj/item/crowbar(src)
+
+/obj/item/storage/box/hug/survival/PopulateContents()
+	..()
+	new /obj/item/crowbar(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4655,6 +4655,7 @@
 #include "orbstation\datums\components\crafting\recipes.dm"
 #include "orbstation\datums\greyscale\config_types\greyscale_configs.dm"
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
+#include "orbstation\objects\items\storage.dm"
 #include "orbstation\species\ethereal\respawn_penalties.dm"
 #include "orbstation\species\zombie\zombie_bite.dm"
 #include "orbstation\species\zombie\zombies.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The survival box is meant to contain items that will help a character survive in an emergency, at least long enough to flee to safety. In such a situation, often there will be firelocks or depowered airlocks blocking the way, which require a crowbar to get past. It just makes sense to give everyone a crowbar just in case of these sorts of situations.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Survival boxes now start with a pocket crowbar already inside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
