### PR TITLE
Refluffs some brain surgeries.

### DIFF
--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -46,10 +46,7 @@
 	display_pain(target, "Your head pounds with unimaginable pain!")
 
 /datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	display_results(user, target, span_notice("You succeed in lobotomizing [target]."),
-			span_notice("[user] successfully lobotomizes [target]!"),
-			span_notice("[user] completes the surgery on [target]'s brain."))
-	display_pain(target, "Your head goes totally numb for a moment, the pain is overwhelming!")
+	success_output(user, target)
 
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
@@ -67,13 +64,16 @@
 				target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
 	return ..()
 
+/datum/surgery_step/lobotomize/proc/success_output(mob/user, mob/living/carbon/target)
+	display_results(user, target, span_notice("You succeed in lobotomizing [target]."),
+			span_notice("[user] successfully lobotomizes [target]!"),
+			span_notice("[user] completes the surgery on [target]'s brain."))
+	display_pain(target, "Your head goes totally numb for a moment, the pain is overwhelming!")
+
 /datum/surgery_step/lobotomize/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/organ/internal/brain/target_brain = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(target_brain)
-		display_results(user, target, span_warning("You remove the wrong part, causing more damage!"),
-			span_notice("[user] successfully lobotomizes [target]!"),
-			span_notice("[user] completes the surgery on [target]'s brain."))
-		display_pain(target, "The pain in your head only seems to get worse!")
+		fail_output(user, target)
 		target_brain.applyOrganDamage(80)
 		switch(rand(1,3))
 			if(1)
@@ -88,3 +88,9 @@
 	else
 		user.visible_message(span_warning("[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore."), span_warning("You suddenly notice that the brain you were working on is not there anymore."))
 	return FALSE
+
+/datum/surgery_step/lobotomize/proc/fail_output(mob/user, mob/living/carbon/target)
+	display_results(user, target, span_warning("You remove the wrong part, causing more damage!"),
+		span_notice("[user] successfully lobotomizes [target]!"),
+		span_notice("[user] completes the surgery on [target]'s brain."))
+	display_pain(target, "The pain in your head only seems to get worse!")

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -37,12 +37,15 @@
 	display_pain(target, "Your head pounds with unimaginable pain!")
 
 /datum/surgery_step/pacify/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	success_output(user, target)
+	target.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)
+	return ..()
+
+/datum/surgery_step/pacify/proc/success_output(mob/user, mob/living/carbon/target)
 	display_results(user, target, span_notice("You succeed in neurologically pacifying [target]."),
 		span_notice("[user] successfully fixes [target]'s brain!"),
 		span_notice("[user] completes the surgery on [target]'s brain."))
 	display_pain(target, "Your head pounds... the concept of violence flashes in your head, and nearly makes you hurl!")
-	target.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)
-	return ..()
 
 /datum/surgery_step/pacify/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You screw up, rewiring [target]'s brain the wrong way around..."),

--- a/orbstation/medical/surgery/lobotomy.dm
+++ b/orbstation/medical/surgery/lobotomy.dm
@@ -1,0 +1,26 @@
+/datum/surgery/advanced/lobotomy
+	name = "Experimental Neural Bypass"
+
+/datum/surgery_step/lobotomize
+	name = "perform neural bypass"
+
+/datum/surgery_step/lobotomize/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, span_notice("You begin to rearrange the nerves in [target]'s brain..."),
+		span_notice("[user] begins to perform an experimental bypass on [target]'s brain."),
+		span_notice("[user] begins to perform surgery on [target]'s brain."))
+	display_pain(target, "You can feel someone rooting around in your skull!")
+
+/datum/surgery_step/lobotomize/success_output(mob/user, mob/living/carbon/target)
+	display_results(user, target, span_notice("You succeed in reorganising [target]'s brain."),
+		span_notice("[user] has reorganised [target]'s brain!"),
+		span_notice("[user] completes the surgery on [target]'s brain."))
+	display_pain(target, "Your head goes totally numb for a moment, something has changed!")
+
+/datum/surgery_step/lobotomize/fail_output(mob/user, mob/living/carbon/target)
+	display_results(user, target, span_warning("You make a mistake, causing more damage!"),
+		span_notice("[user] has reorganised [target]'s brain!"),
+		span_notice("[user] completes the surgery on [target]'s brain."))
+	display_pain(target, "The pain in your head only seems to get worse!")
+
+/datum/design/surgery/lobotomy
+	name = "Experimental Neural Bypass"

--- a/orbstation/medical/surgery/pacification.dm
+++ b/orbstation/medical/surgery/pacification.dm
@@ -1,0 +1,18 @@
+/datum/surgery/advanced/pacify
+	desc = "A surgical procedure which implants a chip into the brain, making the patient unwilling to cause direct harm. \
+		This chip can only be terminated by CentCom officials following an official investigation."
+
+/datum/surgery_step/pacify
+	name = "attach chip"
+
+/datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, span_notice("You begin to carefully insert the chip into [target]..."),
+		span_notice("[user] begins to fix [target]'s brain."),
+		span_notice("[user] begins to perform surgery on [target]'s brain."))
+	display_pain(target, "You can feel someone rooting around in your skull!")
+
+/datum/surgery_step/pacify/success_output(mob/user, mob/living/carbon/target)
+	display_results(user, target, span_notice("You succeed in artifically pacifying [target]."),
+		span_notice("[user] successfully fixes [target]'s brain!"),
+		span_notice("[user] completes the surgery on [target]'s brain."))
+	display_pain(target, "Your head pounds... the concept of violence flashes in your head, and nearly makes you hurl!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4654,6 +4654,8 @@
 #include "orbstation\clothing\misc.dm"
 #include "orbstation\datums\components\crafting\recipes.dm"
 #include "orbstation\datums\greyscale\config_types\greyscale_configs.dm"
+#include "orbstation\medical\surgery\lobotomy.dm"
+#include "orbstation\medical\surgery\pacification.dm"
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
 #include "orbstation\species\ethereal\respawn_penalties.dm"
 #include "orbstation\species\zombie\zombie_bite.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This modifies the name, fluff, and step text for a couple of brain surgeries to address concerns following a mod team discussion.

Pacification surgery has been refluffed to insert a temporary chip into someone's head instead of permanently changing their brain. This is intended to make it more palatable as an option to apply to apply to prisoners without setting off (as) serious in character concerns about permanent mutilation.
This doesn't mechanically add any kind of chip item, only the text is changed.

Lobotomy surgery has been renamed "Experimental Neural Bypass" because it... isn't really a lobotomy.
Again, mechanically it is exactly the same (removes most brain traumas with a high chance of adding a new permanent one in exchange) but has some names and fluff text replaced.

I had to touch some tg code here to make the text replacement cleaner but I am hoping it's in a minimally invasive way which shouldn't conflict easily.

## Why It's Good For The Game

Pacification is one of the tools we have to allow people to keep playing the game instead of rotting in a cell but rarely gets used because characters (justifiably) have extreme reactions to the proposal that we permanently modify someone's brain, even if they are a murderer.
As part of trying to encourage people to let security do their jobs more often in a way that allows people to keep playing, this fluff change should make allowing this an easier pill to swallow.

Also lobotomy is renamed because nobody liked performing something called "a lobotomy" to heal someone.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Changed the fluff of pacification surgery to make it more palatable as an option to apply to dangerous crew members.
add: Renamed Lobotomy surgery to Experimental Neural Bypass, as Lobotomy is an extremely loaded concept which doesn't really match the in-game effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
