### PR TITLE
Station tiles on icebox cannot become holes

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -28,7 +28,7 @@
 			"Linkage": null,
 			"Gravity": true,
 			"Ice Ruins Underground": true,
-			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
+			"Baseturf": "/turf/open/misc/asteroid/snow/icemoon",
 			"No Parallax": true
 		},
 		{
@@ -38,7 +38,7 @@
 			"Gravity": true,
 			"Ice Ruins": true,
 			"Weather_Snowstorm": true,
-			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
+			"Baseturf": "/turf/open/floor/plating/snowed/icemoon",
 			"No Parallax": true
 		}
 	],


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This replaces the baseturfs for icebox with "snowy plating" on the higher level and "snow" on the lower level.
The effect of this is that exploded station turfs can no longer become holes.
These turfs spread icebox atmosphere and radiate cold. This is rather trivially repaired in the case of the plating because you can just cover it with tiles, and slightly more difficult for snow (you need to place rods first and use twice as many tiles).

## Why It's Good For The Game

I'm not sure if it is, but we should try it out.
People are often frustrated about falling into player-created holes on icebox and getting stuck and dying, this prevents that.
It does nothing about holes which are already there when the map starts, those only effect people who are intentionally going outside and should have prepared accordingly.

Not being able to make the floor into holes might be an acceptable compromise between people who like icebox, and people who don't like falling in holes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The floor on Icebox has been reinforced and will no longer give way under extreme pressure. No more turning the vault into a homemade Chasm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
