### PR TITLE
Heretic sacrifice targeting is now nicer to the heretic

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -343,7 +343,7 @@
 	var/datum/objective/minor_sacrifice/sac_objective = new()
 	sac_objective.owner = owner
 	if(num_heads < 2) // They won't get major sacrifice, so bump up minor sacrifice a bit
-		sac_objective.target_amount += 2
+		sac_objective.target_amount = 3
 		sac_objective.update_explanation_text()
 	objectives += sac_objective
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This makes the game deliberately avoid choosing more than one head or more than one security member when selecting sacrifice targets for a heretic, unless there are no other options. The Head of Security counts as both a head and security (obviously).

Also, the sacrifice objective for heretics will no longer have a chance of requiring more than four sacrifices.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

- Due to our low population, the chance of heretics having to sacrifice multiple heads/security members is disproportionately higher than it is on /tg/station. In some cases, a heretic has to sacrifice nothing _but_ heads and security members. This is pretty unfair for a role that's already very difficult.
- The Living Heart can only have up to four targets at a time, so the game being able to require more than that for ascension is very unintuitive, and a bit too much for our population. Again, heretic is already very difficult as-is.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heretics will no longer be given more than one head or more than one security member as a target unless there are no other options.
balance: Heretics will no longer have to sacrifice more than four people for their objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
