### PR TITLE
Toy facehuggers no longer bite and envenom people with the "Facehugger Immunity" quirk (for real this time)

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -173,12 +173,11 @@
 	//ensure we detach once we no longer need to be attached
 	addtimer(CALLBACK(src, .proc/detach), MAX_IMPREGNATION_TIME)
 
-	if (HAS_TRAIT(M, TRAIT_XCARD_XENO_IMMUNE))
-		VenomousBite(M)
-		PostBite(M)
-		return
-
 	if(!sterile)
+		if (HAS_TRAIT(M, TRAIT_XCARD_XENO_IMMUNE))
+			VenomousBite(M)
+			PostBite(M)
+			return
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
 		M.Unconscious(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings
 


### PR DESCRIPTION
Okay, now that I've targeted the right branch and (hopefully) fixed my commit history...

Puts the venomous bite stuff inside the sterility check, so toy facehuggers and Lamarrs no longer inject venom.

## Changelog

:cl:
fix: Toy facehuggers can no longer inject toxic paralytic venom
/:cl: