### PR TITLE
Medical cadaver crates

### DIFF
--- a/orbstation/modules/cargo/packs.dm
+++ b/orbstation/modules/cargo/packs.dm
@@ -3,3 +3,57 @@
 /datum/supply_pack/medical/cadaver
 	cost = CARGO_CRATE_VALUE * 5
 	access = ACCESS_MEDICAL
+	crate_type = /obj/structure/closet/crate/coffin //this is temporary
+	crate_name = "medical cadaver crate"
+
+//this SHOULD function identically for every cadaver crate
+/datum/supply_pack/medical/cadaver/generate()
+	. = ..()
+	var/mob/living/carbon/human/H = locate() in .
+	H.death()
+	for (var/part in H.internal_organs) //each cadaver comes with a complimentary set of organs, held in stasis
+		var/obj/item/organ/O = part
+		O.organ_flags |= ORGAN_FROZEN
+
+/datum/supply_pack/medical/cadaver/human
+	name = "Medical Cadaver Crate (Human)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a human."
+	contains = list(/mob/living/carbon/human)
+
+/datum/supply_pack/medical/cadaver/felinid
+	name = "Medical Cadaver Crate (Felinid)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a felinid."
+	contains = list(/mob/living/carbon/human/species/felinid)
+
+/datum/supply_pack/medical/cadaver/lizard
+	name = "Medical Cadaver Crate (Tiziran)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a tiziran."
+	contains = list(/mob/living/carbon/human/species/lizard)
+
+/datum/supply_pack/medical/cadaver/ethereal
+	name = "Medical Cadaver Crate (Ethereal)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a ethereal. Note that the body's crystal core has been removed for research purposes."
+	contains = list(/mob/living/carbon/human/species/ethereal)
+
+//remove the ethereal's heart - we don't want them regenerating
+/datum/supply_pack/medical/cadaver/ethereal/generate()
+	. = ..()
+	var/mob/living/carbon/human/H = locate() in .
+	for (var/part in H.internal_organs) //i feel like there's a more efficient way to do this
+		if(istype(part, /obj/item/organ/internal/heart))
+			qdel(part)
+
+/datum/supply_pack/medical/cadaver/moth
+	name = "Medical Cadaver Crate (Moth)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a moth."
+	contains = list(/mob/living/carbon/human/species/moth)
+
+/datum/supply_pack/medical/cadaver/jelly
+	name = "Medical Cadaver Crate (Jellyperson)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a jellyperson."
+	contains = list(/mob/living/carbon/human/species/jelly)
+
+/datum/supply_pack/medical/cadaver/pod
+	name = "Medical Cadaver Crate (Podperson)"
+	desc = "A preserved medical cadaver, for dissections, spare organs, or other experimental surgeries. This one is a podperson."
+	contains = list(/mob/living/carbon/human/species/pod)

--- a/orbstation/modules/cargo/packs.dm
+++ b/orbstation/modules/cargo/packs.dm
@@ -1,0 +1,5 @@
+//CARGO CRATES FOR ORBSTATION
+
+/datum/supply_pack/medical/cadaver
+	cost = CARGO_CRATE_VALUE * 5
+	access = ACCESS_MEDICAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4716,6 +4716,7 @@
 #include "orbstation\medical\surgery\lobotomy.dm"
 #include "orbstation\medical\surgery\pacification.dm"
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
+#include "orbstation\modules\cargo\packs.dm"
 #include "orbstation\modules\research\designs\mechfabricator_designs.dm"
 #include "orbstation\modules\research\techweb\all_nodes.dm"
 #include "orbstation\modules\surgery\bodyparts\robot_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds orderable "Medical Cadaver Crates" in cargo. These crates are restricted to Medical access (although they don't currently have locks on them), and each contains one randomized corpse of a selected roundstart species. Much like roundstart morgue bodies, these cadavers have all organs held in a non-decaying stasis (but unlike those bodies, they have a complete set!). Cadaver crates each cost 1000 credits.

This feature will later be enhanced with a custom crate type, which will most likely have a lock on it. For now, the crates are just coffins. For this reason, plasmaman cadavers are not currently available for order - they burst into flames while inside of the coffin, which is undesirable.

Finally, ethereal cadavers come with the heart pre-removed: both because ethereal hearts are too powerful an item to provide players for 1000 credits, and because the bodies immediately begin regenerating if they still have a heart.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This feature was inspired by the randomization of morgue bodies added recently. It gives a reliable way to acquire the corpse of any roundstart species other than plasmamen. This has a number of uses. Acquiring matching body parts and organs for a specific species, for example. In more dire scenarios, it may be a way to acquire bodies to transplant someone to that are less overtly dysphoric, though this obviously still requires caution. For certain unscrupulous types, it can serve as a somewhat morbid food source.

Finally, certain antags might love a way to acquire extra corpses - most notably, heretics have rituals that require body parts and full dead bodies. While there are already several ways to acquire these, more variety is always a good thing. Plus, unless the heretic is the sole cargo employee or a member of medical staff, there's something inherently suspicious about ordering corpses - especially if you're doing it privately. This adds more fun to the game.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new "Medical Cadaver Crates" to cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
