### PR TITLE
rename heartbeat of the mansus to something better

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -9,7 +9,7 @@
  * Allows the heretic to sacrifice living heart targets.
  */
 /datum/heretic_knowledge/hunt_and_sacrifice
-	name = "Heartbeat of the Mansus"
+	name = "Heartbeat of the Mansus (Sacrifice)"
 	desc = "Allows you to sacrifice targets to the Mansus by bringing them to a rune in critical (or worse) condition. \
 		If you have no targets, stand on a transmutation rune and invoke it to aquire some."
 	required_atoms = list(/mob/living/carbon/human = 1)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -9,7 +9,7 @@
  * Allows the heretic to sacrifice living heart targets.
  */
 /datum/heretic_knowledge/hunt_and_sacrifice
-	name = "Heartbeat of the Mansus (Sacrifice)"
+	name = "Heartbeat of the Mansus"
 	desc = "Allows you to sacrifice targets to the Mansus by bringing them to a rune in critical (or worse) condition. \
 		If you have no targets, stand on a transmutation rune and invoke it to aquire some."
 	required_atoms = list(/mob/living/carbon/human = 1)

--- a/orbstation/antagonists/heretic/heretic_knowledge.dm
+++ b/orbstation/antagonists/heretic/heretic_knowledge.dm
@@ -2,3 +2,6 @@
 
 /datum/heretic_knowledge/limited_amount/starting
 	cost = 0
+
+/datum/heretic_knowledge/hunt_and_sacrifice
+	name = "Heartbeat of the Mansus (Sacrifice)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames "Heartbeat of the Mansus" to "Heartbeat of the Mansus (Sacrifice)"

## Why It's Good For The Game

i couldnt figure out which option actually sacrificed my very nicely dead victim on a near-perfect heretic run and i died because i was tabbed out frantically ctrl-f-ing through the heretic guide. and im salty about it

## Changelog

:cl:
qol: It's now slightly clearer how you sacrifice something as a heretic ("Heartbeat of the Mansus" renamed to "Heartbeat of the Mansus (Sacrifice)")
/:cl: