### PR TITLE
Informs admins if the Acting Captain is evil

### DIFF
--- a/orbstation/antagonists/acting_captain_check.dm
+++ b/orbstation/antagonists/acting_captain_check.dm
@@ -1,0 +1,30 @@
+
+// When any antag datum is applied to anything, yell if it is given to someone who has the captain's spare ID or the safe code.
+/datum/mind/add_antag_datum(datum_type_or_instance, team)
+	. = ..()
+	if (!.)
+		return
+	if (!has_spare_ID_access())
+		return
+	message_admins("[current] became an antagonist, but may be the Acting Captain!")
+
+#define SPARE_ID_ITEMS list(/obj/item/card/id/advanced/gold/captains_spare, /obj/item/paper/fluff/spare_id_safe_code)
+/// Returns true if this mind owns an item which would allow you to get the captain's spare ID
+/datum/mind/proc/has_spare_ID_access()
+	if (!current)
+		return FALSE
+	for (var/obj/item in current.get_all_contents())
+		if (!is_type_in_list(item, SPARE_ID_ITEMS))
+			continue
+		return TRUE
+	return FALSE
+#undef SPARE_ID_ITEMS
+
+// Also do it when the safe code is given out.
+/datum/controller/subsystem/job/promote_to_captain(mob/living/carbon/human/new_captain, acting_captain = FALSE)
+	. = ..()
+	if (!acting_captain)
+		return
+	if (!is_special_character(new_captain))
+		return
+	message_admins("[new_captain] became Acting Captain, but may be an antagonist!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4716,6 +4716,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "orbstation\antagonists\acting_captain_check.dm"
 #include "orbstation\antagonists\dynamic.dm"
 #include "orbstation\antagonists\rulesets_latejoin.dm"
 #include "orbstation\antagonists\rulesets_midround.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This prints a message to admins if someone is given an antagonist datum of any kind and owns either the spare ID codes, or the spare ID itself.
It does the same thing if someone is given the spare ID code at round start and has an antagonist role already.
This should cover roundstart, latejoin, and midround antagonist rolls.

This method is not foolproof, it will fail if someone memorises the safe code, gets rid of the paper, and becomes an antagonist before getting the ID... but that doesn't seem very likely.

## Why It's Good For The Game

We agreed that this is a stopgap we want until we can make a better system.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Sends a message to admins if someone is both evil and the Acting Captain, so they can resolve it somehow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
