### PR TITLE
Allows traitors to opt out of uplink objectives and choose a custom objective instead

### DIFF
--- a/orbstation/antagonists/traitor/contract_negotiation.dm
+++ b/orbstation/antagonists/traitor/contract_negotiation.dm
@@ -43,6 +43,7 @@
 	if(!custom_objective_text) // such as if the user hits "cancel"
 		return source
 
+	log_traitor("[key_name(user)] opted out of uplink objectives and chose a custom objective: [custom_objective_text]")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has chosen a custom traitor objective: [span_syndradio("[custom_objective_text]")] | [ADMIN_SYNDICATE_REPLY(user)]")
 
 	// Let's fail all the objectives on the uplink to get them out of the way.

--- a/orbstation/antagonists/traitor/contract_negotiation.dm
+++ b/orbstation/antagonists/traitor/contract_negotiation.dm
@@ -1,0 +1,69 @@
+#define CUSTOM_OBJECTIVE_MAX_LENGTH 300
+
+/datum/uplink_category/contract
+	name = "Contract Negotiation"
+	weight = -3 // just above discount items (because those are apparently hard-coded to be at the bottom)
+
+/datum/uplink_item/contract
+	category = /datum/uplink_category/contract
+	surplus = 0
+	cant_discount = TRUE
+
+/datum/uplink_item/contract/freeform
+	name = "Renegotiate Contract"
+	desc = "Opt out of conventional objectives and forge your own path forward in pursuit of a custom goal. \
+	Be warned that you will no longer be able to earn telecrystals. There is no turning back."
+	item = /obj/effect/gibspawner/generic
+	surplus = 0
+	cost = 0
+	restricted = TRUE
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchase_log_vis = FALSE
+
+	/// The default explanation of the freeform objective, which can be customized by the traitor.
+	var/default_objective_text = "Sow fear and discord as a free agent of the Syndicate."
+
+/datum/uplink_item/contract/freeform/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
+	var/datum/antagonist/traitor/traitor_datum
+	for(var/datum/antagonist/antag in user.mind.antag_datums)
+		if(istype(antag, /datum/antagonist/traitor))
+			traitor_datum = antag
+			break
+	// Non-traitors can't use this for obvious reasons :v
+	if(!traitor_datum)
+		return source //For log icon
+
+	for(var/datum/objective/primary_objective in traitor_datum.objectives)
+		if(istype(primary_objective, /datum/objective/custom) || istype(primary_objective, /datum/objective/traitor_final)) // prevents overriding pre-existing custom objectives or final objectives
+			to_chat(user, span_warning("Request denied. The terms of your current contract are non-negotiatable."))
+			return source
+
+	// Allow the traitor to write down a custom objective if they so wish.
+	var/custom_objective_text = tgui_input_text(user, "Write down the terms of your new contract:", "Custom Objective", default_objective_text, CUSTOM_OBJECTIVE_MAX_LENGTH)
+	if(!custom_objective_text) // such as if the user hits "cancel"
+		return source
+
+	message_admins("[ADMIN_LOOKUPFLW(user)] has chosen a custom traitor objective: [span_syndradio("[custom_objective_text]")] | [ADMIN_SYNDICATE_REPLY(user)]")
+
+	// Let's fail all the objectives on the uplink to get them out of the way.
+	for(var/datum/traitor_objective/active_objective as anything in uplink_handler.active_objectives)
+		active_objective.fail_objective(penalty_cost = 0)
+	for(var/datum/traitor_objective/potential_objective as anything in uplink_handler.potential_objectives)
+		potential_objective.fail_objective()
+
+	// The traitor can no longer take new objectives. Displays "you are locked out of objectives" on the objectives screen.
+	uplink_handler.maximum_potential_objectives = 0
+
+	// Replace those normal primary objectives with a special objective that automatically succeeds
+	user.playsound_local(get_turf(user), 'sound/traitor/final_objective.ogg', vol = 100, vary = FALSE, channel = CHANNEL_TRAITOR)
+	traitor_datum.objectives.Cut()
+	var/datum/objective/custom/custom_objective = new /datum/objective/custom()
+	custom_objective.explanation_text = custom_objective_text
+	custom_objective.owner = traitor_datum.owner
+	custom_objective.completed = TRUE
+	traitor_datum.objectives += custom_objective
+	to_chat(user, span_boldwarning("Your request has been received. Until further notice, these are the new terms of your contract. Good luck, agent."))
+	traitor_datum.owner.announce_objectives()
+	return source
+
+#undef CUSTOM_OBJECTIVE_MAX_LENGTH

--- a/orbstation/antagonists/traitor/contract_negotiation.dm
+++ b/orbstation/antagonists/traitor/contract_negotiation.dm
@@ -35,7 +35,7 @@
 
 	for(var/datum/objective/primary_objective in traitor_datum.objectives)
 		if(istype(primary_objective, /datum/objective/custom) || istype(primary_objective, /datum/objective/traitor_final)) // prevents overriding pre-existing custom objectives or final objectives
-			to_chat(user, span_warning("Request denied. The terms of your current contract are non-negotiatable."))
+			to_chat(user, span_warning("Request denied. The terms of your current contract are non-negotiable."))
 			return source
 
 	// Allow the traitor to write down a custom objective if they so wish.
@@ -45,6 +45,10 @@
 
 	log_traitor("[key_name(user)] opted out of uplink objectives and chose a custom objective: [custom_objective_text]")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has chosen a custom traitor objective: [span_syndradio("[custom_objective_text]")] | [ADMIN_SYNDICATE_REPLY(user)]")
+
+	for(var/client/admin_client in GLOB.admins)
+		if(admin_client.prefs.toggles & SOUND_ADMINHELP)
+			SEND_SOUND(admin_client, sound('sound/effects/gong.ogg'))
 
 	// Let's fail all the objectives on the uplink to get them out of the way.
 	for(var/datum/traitor_objective/active_objective as anything in uplink_handler.active_objectives)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4746,6 +4746,7 @@
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"
 #include "orbstation\antagonists\heretic\heretic_knowledge.dm"
+#include "orbstation\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"
 #include "orbstation\antagonists\traitor\objectives\final_objective\malware_injection.dm"
 #include "orbstation\chaplain\ratlain.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds an option to the traitor uplink called "Renegotiate Contract", found under the new "Contract Negotiation" category right above "Discounted Items" at the bottom of the list. Using it prompts the traitor to enter a custom objective of their own, which will automatically be marked as complete and replaces the standard three primary objectives. This also notifies the admins and gives them the option to respond in-character as Syndicate command, which could lead to some fun, unique interactions. Using this option locks the traitor out of normal uplink objectives and fails any current uplink objectives they have, but without any telecrystal penalty. This option cannot be selected if the traitor already has a custom objective or has selected a final objective.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Some of the most fun and inventive traitor rounds happen as a result of the traitor coming up with a zany scheme and deciding to do their own thing for the whole round. In this case, the uplink objectives can start to become a distraction, encouraging a more "play-to-win" mindset focused on getting final objectives instead of having fun. Having an option for a more free-form experience will hopefully allow people to free themselves from the psychological burden of their other objectives in addition to making people care less about "greentext" (because the custom objectives automatically succeed unless an admin manually marks it as a failure). Personally, I often find traitor way less frustrating when I just make my own fun, even if it results in my death or arrest at the end.

In the future, we could add more things to the "Contract Negotiation" category which could potentially allow traitors to shake up the structure of the mode even further, which could be a lot of fun.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
feature: Added the "Renegotiate Contract" option to the traitor uplink, under the new "Contract Negotiation" category. A traitor can use this for free in order to replace their primary objectives with a new, custom objective that auto-completes. Doing this also locks the traitor out of standard uplink objectives, meaning they will no longer be able to earn telecrystals. This is also incompatible with final objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
