### PR TITLE
Buffs digitigrade legs to offer the same foot protection as shoes

### DIFF
--- a/code/__HELPERS/bodyparts.dm
+++ b/code/__HELPERS/bodyparts.dm
@@ -1,1 +1,2 @@
 #define IS_ORGANIC_LIMB(limb) (limb.bodytype & BODYTYPE_ORGANIC)
+#define IS_DIGITIGRADE_LIMB(limb) (limb.bodytype & BODYTYPE_DIGITIGRADE)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -95,6 +95,8 @@
 	if (!(flags & CALTROP_BYPASS_SHOES))
 		if ((H.wear_suit?.body_parts_covered | H.w_uniform?.body_parts_covered | H.shoes?.body_parts_covered) & FEET)
 			return
+		if(IS_DIGITIGRADE_LIMB(O)) //digitigrade legs offer the same protection as shoes
+			return
 
 	var/damage = rand(min_damage, max_damage)
 	if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -69,6 +69,12 @@
 			if("feet")
 				if(!H.shoes)
 					affecting = H.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+					if(IS_DIGITIGRADE_LIMB(affecting))
+						playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
+						armed = FALSE
+						update_appearance()
+						pulse(FALSE)
+						return FALSE
 					H.Paralyze(60)
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
 				if(!H.gloves)


### PR DESCRIPTION
Characters with digitigrade legs will no longer suffer injury or be stunned by stepping on glass shards, broken bottles, light bulbs, mousetraps, and other things of that nature. They will still be injured by stepping on items that can cause damage through shoes.

The fact that digitigrade shoes do not currently exist makes digilegs a strict downgrade from regular legs. This PR fixes the worst aspects of that by making them "count" as shoes for the specific purpose listed. While they are still technically worse, walking through the tram hole will no longer be a pointless death sentence.