### PR TITLE
Adds random juices as a possibility for podperson blood

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -20,7 +20,6 @@
 	heatmod = 1.5
 	payday_modifier = 1.0
 	meat = /obj/item/food/meat/slab/human/mutant/plant
-	exotic_blood = /datum/reagent/water
 	disliked_food = MEAT | DAIRY | SEAFOOD | BUGS
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
@@ -111,6 +110,12 @@
 			SPECIES_PERK_ICON = "lightbulb",
 			SPECIES_PERK_NAME = "Light Nutrition",
 			SPECIES_PERK_DESC = "Podpeople passively gain nutrition while standing in well-lit areas.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+			SPECIES_PERK_ICON = "tint",
+			SPECIES_PERK_NAME = initial(exotic_blood.name),
+			SPECIES_PERK_DESC = "Podpeople blood is Water or a random fruit juice, which can make recieving medical treatment harder.",
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,

--- a/orbstation/_globalvars/pod_bloodtypes.dm
+++ b/orbstation/_globalvars/pod_bloodtypes.dm
@@ -1,0 +1,8 @@
+GLOBAL_LIST_INIT(pod_bloodtypes, list(
+	/datum/reagent/water,
+	/datum/reagent/consumable/pineapplejuice,
+	/datum/reagent/consumable/orangejuice,
+	/datum/reagent/consumable/limejuice,
+	/datum/reagent/consumable/tomatojuice,
+	/datum/reagent/consumable/lemonjuice
+))

--- a/orbstation/species/podpeople/random_blood.dm
+++ b/orbstation/species/podpeople/random_blood.dm
@@ -1,0 +1,6 @@
+
+/datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	exotic_blood = pick(GLOB.pod_bloodtypes)
+	. = ..()
+
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4738,6 +4738,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "orbstation\_globalvars\pod_bloodtypes.dm"
 #include "orbstation\antagonists\acting_captain_check.dm"
 #include "orbstation\antagonists\dynamic.dm"
 #include "orbstation\antagonists\rulesets_latejoin.dm"
@@ -4775,6 +4776,7 @@
 #include "orbstation\quirks\xcard\xenotoxin.dm"
 #include "orbstation\shuttles\shuttles.dm"
 #include "orbstation\species\ethereal\respawn_penalties.dm"
+#include "orbstation\species\podpeople\random_blood.dm"
 #include "orbstation\species\zombie\zombie_bite.dm"
 #include "orbstation\species\zombie\zombies.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will cause round-start pod people to have a random juice or water as their blood type. The juice selection is taken from the selection available in a soda dispenser.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Grown podpeople already can have a reagent type as their blood round-start species should have this as well. It also adds minor difficulty to healing them, as the juices will not be readily available at a sink or chem dispenser. Slight nerf I guess.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Pizzie11
add: Roundstart Podpeople now have a random juice or water as their blood type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
