### PR TITLE
Makes it possible to actually speak Ratvaric.

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -30,7 +30,8 @@
 		/datum/language/sylvan,
 		/datum/language/shadowtongue,
 		/datum/language/terrum,
-		/datum/language/nekomimetic
+		/datum/language/nekomimetic,
+		/datum/language/ratvaric
 	))
 
 /obj/item/organ/internal/tongue/Initialize(mapload)


### PR DESCRIPTION
Due to a minor oversight, the ratvaric language is not actually possible to speak currently - as languages must be specifically whitelisted on a tongue organ before you can speak them. I've added ratvaric to the list for the basic human tongue, which is what ratfolk have.