### PR TITLE
Kheiral cuffs alert medical and supply radio when you die off-station

### DIFF
--- a/orbstation/modules/mining/voucher_sets.dm
+++ b/orbstation/modules/mining/voucher_sets.dm
@@ -1,0 +1,9 @@
+/datum/voucher_set/kheiral_cuffs
+	name = "Kheiral Kit"
+	description = "Contains a pair of kheiral cuffs and a survival emergency medipen. When worn, kheiral cuffs will broadcast your suit sensors even while off the station z-level, and will send an alert on medical and supply radio if you die while away."
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "strand"
+	set_items = list(
+		/obj/item/reagent_containers/hypospray/medipen/survival,
+		/obj/item/kheiral_cuffs,
+		)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4761,6 +4761,7 @@
 #include "orbstation\mob\living.dm"
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
 #include "orbstation\modules\client\looc.dm"
+#include "orbstation\modules\mining\voucher_sets.dm"
 #include "orbstation\modules\research\designs\mechfabricator_designs.dm"
 #include "orbstation\modules\research\techweb\all_nodes.dm"
 #include "orbstation\modules\surgery\bodyparts\robot_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title. This only works when you're off the station z-level (which is also when the cuffs activate their GPS) signal. Unfortunately this likely means they won't work on Icebox, but it's at least somewhat easier to notice and rescue dead miners on Icebox already. The alert message will also change if the wearer's body is destroyed, such as by megafauna.

![kheiral alert](https://user-images.githubusercontent.com/27435310/191624813-a2f0771a-e55f-43ab-ab67-f88074000234.png)

![kheiral alert 2](https://user-images.githubusercontent.com/27435310/191624824-7582802b-21d6-4599-a64c-347bac0a1e47.png)

This also adds a new mining voucher kit which includes a pair of kheiral cuffs and an survival emergency medipen.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

It's not uncommon for miners to die on Lavaland and not have their body found, which is a very frustrating experience, especially for players who are new to the job. Adding this functionality to the kheiral cuffs gives them an extra safety net and ensures that people will at least notice they have died, while still requiring people to go mount a rescue mission for them. This could also lead to some fun panic if an antagonist kills someone on Lavaland and doesn't notice they're wearing the kheiral cuffs until they hear the alert.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: When worn, kheiral cuffs will send an alert over medical and supply radio when the wearer dies as long as they're off the station z-level. With a mining voucher, a miner can also now get a kit containing a pair of kheiral cuffs and a survival emergency medipen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
