### PR TITLE
Malware injection objective nerfs

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -1,4 +1,4 @@
-#define DEFAULT_DOOMSDAY_TIMER 4500
+#define DEFAULT_DOOMSDAY_TIMER 5400
 #define DOOMSDAY_ANNOUNCE_INTERVAL 600
 
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(

--- a/orbstation/antagonists/traitor/objectives/final_objective/malware_injection.dm
+++ b/orbstation/antagonists/traitor/objectives/final_objective/malware_injection.dm
@@ -1,5 +1,6 @@
-#define APCS_REQUIRED_FOR_MALF 5
+#define APCS_REQUIRED_FOR_MALF 10
 #define INJECTOR_HACK_TIME 20 SECONDS
+#define MAXIMUM_HACKED_APCS 20
 
 #define POSSIBLE_DEPARTMENTS list(\
 	"Medbay" = list(/area/station/medical, /area/station/security/checkpoint/medical, /area/station/command/heads_quarters/cmo,),\
@@ -150,6 +151,9 @@
 	if(spent)
 		to_chat(user, span_alert("[src] is no longer functional."))
 		return FALSE
+	if(hacked_apcs.len >= MAXIMUM_HACKED_APCS)
+		to_chat(user, span_alert("[src] has already hacked the maximum amount of APCs."))
+		return FALSE
 	if(!target.operating || target.shorted || target.machine_stat & BROKEN)
 		to_chat(user, span_alert("[target] is non-functional, and won't respond to [src]."))
 		return FALSE
@@ -186,9 +190,9 @@
 
 // MALWARE INJECTION CONSOLE
 
-// 15 * 8 = 2 minutes total
+// 15 * 10 = 2 minutes and 30 seconds total
 #define TIME_PER_STAGE 15 SECONDS
-#define CORRUPTION_STAGES 8
+#define CORRUPTION_STAGES 10
 
 /obj/machinery/computer/malware
 	name = "malware injection console"
@@ -377,10 +381,10 @@
 		linked_apc.obj_flags &= ~EMAGGED
 		linked_apc.malfai = current
 		linked_apc.malfhack = TRUE
-		current.malf_picker.processing_time += 10 // 10 processing power per hacked APC
+		current.malf_picker.processing_time += 5 // 5 processing power per hacked APC
 	atom_break(ENERGY)
 
-/// Sets off the fire alarm in each subarea of the department, as well as closing and locking the doors of the room that the console is in. Alerts the AI.
+/// Sets off the fire alarm in each subarea of the department. Alerts the AI.
 /obj/machinery/computer/malware/proc/trigger_alarm(mob/living/user)
 	var/list/dept_areas = list()
 	for (var/areapath in required_area)
@@ -390,10 +394,6 @@
 	for(var/area/alarmed_area as anything in dept_areas)
 		if(alarmed_area)
 			alarmed_area.trigger_fire_alarms(user)
-	var/area/local = get_area(src)
-	// lock down the room the computer is in
-	for(var/obj/machinery/door/door in local)
-		local.close_and_lock_door(door)
 	var/message = "UNAUTHORIZED CODE INJECTION DETECTED. SYSTEM INTEGRITY FAILING."
 	to_chat(current, span_userdanger(span_big("[message]")))
 	current.radio.talk_into(current, "[message]") // and everyone else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Malware injection objective now requires 10 hacked APCs instead of 5
- Each APC is now worth 5 processing power instead of 10
- You can now only hack up to a maximum of 20 APCs (for 100 processing power)
- It now takes 2 and a half minutes for the malware injection console to make the AI go malf once the countdown starts instead of 2 minutes
- Starting the injection at the console no longer automatically locks all the doors in the room
- Malf AI doomsday device power now takes 9 minutes to destroy the station instead of 7 and a half minutes

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This attempts to address some balancing concerns we've had with the malware injection objective which have mostly arisen due to our server's low population. There are many rooms on the station that are often completely empty, making it very easy to hack APCs undetected. In addition to this, in our experience, once the countdown starts it becomes very difficult to reach the console - it's never successfully been prevented from occurring, which _should_ require more planning and forethought from the traitor to defend the location of the console. This is partially due to the console auto-locking all of the doors in the room shut, which we've discovered also includes blast doors! Finally, we've also increased the amount of time it takes for the self-destruct to go off once the AI activates it, which also applies to roundstart and midround malf AIs. Taking down a malf AI requires a lot of coordination from the crew, and this is considerably harder at our population than it would be on /tg/. The extra time feels warranted here.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Malware injection objective now requires 10 hacked APCs instead of 5, and each APC is now worth 5 processing power instead of 10. You can now only hack up to a maximum of 20 APCs (for 100 processing power).
balance: It now takes 2 and a half minutes for the malware injection console to make the AI go malf once the countdown starts instead of 2 minutes, and starting the injection at the console no longer automatically locks all the doors in the room.
balance: Malf AI doomsday device power now takes 9 minutes to destroy the station instead of 7 and a half minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
