### PR TITLE
Tweaks to make heretic sacrifice realm a bit less annoying

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -358,7 +358,6 @@
 	// Orbstation: If the sacrifice target has the paraplegic quirk, temporarily heal their trauma so they can move until the minigame ends.
 	if(sac_target.has_quirk(/datum/quirk/paraplegic))
 		sac_target.cure_trauma_type(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
-		addtimer(CALLBACK(src, .proc/restore_paraplegia, sac_target), SACRIFICE_REALM_DURATION, TIMER_STOPPABLE)
 	LAZYSET(return_timers, REF(sac_target), win_timer)
 
 /**
@@ -371,10 +370,6 @@
 		return
 
 	to_chat(sac_target, span_hypnophrase("The worst is behind you... Not much longer! Hold fast, or expire!"))
-
-/// Orbstation: Gives the target their paraplegia back if it was removed when they got sacrificed.
-/datum/heretic_knowledge/hunt_and_sacrifice/proc/restore_paraplegia(mob/living/carbon/human/sac_target)
-	sac_target.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /**
  * This proc is called from [proc/begin_sacrifice] if the target survived the shadow realm, or [COMSIG_LIVING_DEATH] if they don't.
@@ -402,6 +397,10 @@
 	sac_target.remove_status_effect(/datum/status_effect/unholy_determination)
 	sac_target.reagents?.del_reagent(/datum/reagent/inverse/helgrasp/heretic)
 	sac_target.clear_mood_event("shadow_realm")
+
+	// Orbstation: Gives the target their paraplegia back if it was removed when they got sacrificed.
+	if(sac_target.has_quirk(/datum/quirk/paraplegic))
+		sac_target.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
 
 	// Wherever we end up, we sure as hell won't be able to explain
 	sac_target.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/slurring/heretic)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -3,7 +3,7 @@
 /// How long we put the target so sleep for (during sacrifice).
 #define SACRIFICE_SLEEP_DURATION 12 SECONDS
 /// How long sacrifices must stay in the shadow realm to survive.
-#define SACRIFICE_REALM_DURATION 2.5 MINUTES
+#define SACRIFICE_REALM_DURATION 1.5 MINUTES
 
 /**
  * Allows the heretic to sacrifice living heart targets.
@@ -259,7 +259,6 @@
 		sac_target.legcuffed = null
 		sac_target.update_worn_legcuffs()
 
-	sac_target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 85, 150)
 	sac_target.do_jitter_animation()
 	log_combat(heretic_mind.current, sac_target, "sacrificed")
 
@@ -356,6 +355,10 @@
 	addtimer(CALLBACK(src, .proc/after_helgrasp_ends, sac_target), helgrasp_time)
 	// Win condition
 	var/win_timer = addtimer(CALLBACK(src, .proc/return_target, sac_target), SACRIFICE_REALM_DURATION, TIMER_STOPPABLE)
+	// Orbstation: If the sacrifice target has the paraplegic quirk, temporarily heal their trauma so they can move until the minigame ends.
+	if(sac_target.has_quirk(/datum/quirk/paraplegic))
+		sac_target.cure_trauma_type(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
+		addtimer(CALLBACK(src, .proc/restore_paraplegia, sac_target), SACRIFICE_REALM_DURATION, TIMER_STOPPABLE)
 	LAZYSET(return_timers, REF(sac_target), win_timer)
 
 /**
@@ -368,6 +371,10 @@
 		return
 
 	to_chat(sac_target, span_hypnophrase("The worst is behind you... Not much longer! Hold fast, or expire!"))
+
+/// Orbstation: Gives the target their paraplegia back if it was removed when they got sacrificed.
+/datum/heretic_knowledge/hunt_and_sacrifice/proc/restore_paraplegia(mob/living/carbon/human/sac_target)
+	sac_target.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /**
  * This proc is called from [proc/begin_sacrifice] if the target survived the shadow realm, or [COMSIG_LIVING_DEATH] if they don't.
@@ -397,8 +404,8 @@
 	sac_target.clear_mood_event("shadow_realm")
 
 	// Wherever we end up, we sure as hell won't be able to explain
-	sac_target.adjust_timed_status_effect(40 SECONDS, /datum/status_effect/speech/slurring/heretic)
-	sac_target.adjust_timed_status_effect(40 SECONDS, /datum/status_effect/speech/stutter)
+	sac_target.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/slurring/heretic)
+	sac_target.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/stutter)
 
 	// They're already back on the station for some reason, don't bother teleporting
 	if(is_station_level(sac_target.z))

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_moodlets.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_moodlets.dm
@@ -11,5 +11,5 @@
 
 /datum/mood_event/shadow_realm_live_sad
 	description = "The hands! The horrible, horrific hands! I see them when I close my eyes!"
-	mood_change = -6
+	mood_change = -10
 	timeout = 10 MINUTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Sacrificed people will only have to be in the shadow realm for one and a half minutes instead of two and a half minutes
- Being sacrificed no longer gives you brain damage
- If a paraplegic is sacrificed, they will temporarily regain control of their legs while in the sacrifice realm
- The stuttering and slurring effects after being sent back to the station now last for 30 seconds instead of 40
- To counterbalance the lack of a mood debuff from brain damage, the mood debuff for surviving being sacrificed is now a -10 debuff instead of -6

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The sacrifice realm minigame is a pretty cool part of heretic that helps make getting sacrificed feel scary without permanently taking someone out of the round. However, it currently lasts way too long - the helgrasp only lasts a minute, meaning that after that you have to hang around for another minute and a half while not much happens, and that's pretty boring. Another problem is that once you _do_ get back, the brain traumas you can get from being brain damaged are often really obnoxious - in the most annoying cases, they can remove your ability to speak clearly, which is a problem if the game decides to teleport you back to an extremely remote location that no one ever goes to. The mood debuff should be enough to hammer in the lingering ramifications of being sacrificed without forcing you to go to medbay and spend even more time in surgery, which might not even be a viable option depending on what's happening in the round. Finally, being a paraplegic makes the minigame almost impossible to survive, as Dalm can attest to, which seems unfair considering that none of the positive quirks can really help you in the minigame.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The hand-dodging minigame from being sacrificed by a heretic now lasts a minute and a half instead of two and a half minutes. If a paraplegic is sacrificed, their legs will temporarily regain mobility while in the sacrifice realm. Being sacrificed no longer gives you brain damage, and the stuttering and slurring effects after being returned have been slightly shortened. The mood debuff for being sacrificed is now larger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
