### PR TITLE
There's always a bigger fish-shaped shuttle

### DIFF
--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -61,7 +61,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = secshuttle
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "bB" = (
 /obj/effect/turf_decal/tile/dark/half/contrasted{
@@ -103,10 +103,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "fh" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/shuttle/glass,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "fA" = (
 /obj/machinery/light/directional/east,
@@ -114,7 +112,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 5
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "gd" = (
@@ -246,10 +246,6 @@
 "kX" = (
 /turf/open/water/beach/biodome,
 /area/shuttle/escape)
-"lC" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
 "lW" = (
 /turf/open/chasm,
 /area/shuttle/escape)
@@ -375,13 +371,11 @@
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "rj" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
 /obj/docking_port/mobile/emergency{
 	name = "Angler's Choice emergency shuttle"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/shuttle/glass,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "rk" = (
 /obj/machinery/light/directional/south,
@@ -401,10 +395,8 @@
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "sj" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/shuttle/glass,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape/brig)
 "sr" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -423,7 +415,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/tiled/blue,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "ut" = (
 /obj/machinery/light/directional/south,
@@ -914,7 +906,7 @@
 "Tq" = (
 /obj/effect/turf_decal/tile/dark/anticorner/contrasted,
 /obj/item/kirbyplants/random,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "TL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -1146,7 +1138,7 @@ jL
 Me
 UW
 UW
-lC
+bl
 tw
 Pd
 Ie
@@ -1202,7 +1194,7 @@ aa
 nz
 wF
 Me
-lC
+aa
 PS
 AN
 Xx
@@ -1318,7 +1310,7 @@ aa
 XZ
 Me
 Me
-lC
+aa
 jL
 WY
 ZT
@@ -1378,7 +1370,7 @@ jL
 Me
 UW
 UW
-lC
+bl
 Jh
 Pd
 Ie

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -10,40 +10,97 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
 /turf/open/floor/iron/white,
+/area/shuttle/escape)
+"ax" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/radio{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "az" = (
 /obj/machinery/fishing_portal_generator,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/shuttle/escape)
-"aR" = (
-/obj/machinery/light/directional/north,
-/turf/open/water/beach/biodome,
+"aE" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
-"aT" = (
-/obj/machinery/vending/wallmed/directional/south,
+"aF" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark/half/contrasted,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
-"bl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area"
+"aR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/mineral/titanium/white,
+/obj/machinery/light/directional/south,
+/turf/open/misc/beach/coastline_t{
+	dir = 4
+	},
 /area/shuttle/escape)
+"aT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"bl" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = secshuttle
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"bB" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"cZ" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/bed/dogbed/mcgriff,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
 "ec" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"eC" = (
+/obj/item/toy/plush/space_lizard_plushie{
+	desc = "An adorable stuffed toy that resembles a very determined seafaring lizardperson. To ten thousand leagues and below, little guy.";
+	name = "Drinks-The-Salt"
+	},
+/turf/open/water/beach/biodome,
+/area/shuttle/escape)
+"eQ" = (
+/obj/structure/moisture_trap{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "fh" = (
 /obj/machinery/door/airlock/shuttle{
@@ -74,6 +131,25 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
+"gh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/toxin,
+/turf/open/floor/iron/white,
+/area/shuttle/escape)
 "gI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -83,15 +159,45 @@
 	dir = 4
 	},
 /area/shuttle/escape)
+"gX" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"gY" = (
+/obj/structure/chair/pew/right,
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "iA" = (
-/turf/open/floor/mineral/titanium/tiled/blue,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "jh" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/structure/chair/pew{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/tiled/white,
+/obj/effect/turf_decal/tile/dark/half/contrasted,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
+"jw" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape/brig)
 "jL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
@@ -144,9 +250,26 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"lW" = (
+/turf/open/chasm,
+/area/shuttle/escape)
+"mD" = (
+/obj/item/toy/beach_ball/branded,
+/turf/open/water/beach/biodome,
+/area/shuttle/escape)
 "nz" = (
-/obj/machinery/door/airlock/wood/glass,
+/obj/machinery/door/airlock/medical/glass,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"nB" = (
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "nY" = (
 /obj/structure/table/wood,
@@ -170,17 +293,85 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
+"og" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "oA" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"pk" = (
-/obj/structure/chair/pew/left{
+"oI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"pa" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/vending/wallmed/directional/south,
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/sign/warning/yes_smoking/circle/directional/south,
-/obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"pk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/shuttle/escape)
+"pQ" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"qe" = (
+/obj/structure/aquarium{
+	fluid_type = "Saltwater"
+	},
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"qA" = (
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"qO" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/fishing_line{
+	layer = 4;
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/fishing_hook{
+	pixel_y = 3;
+	layer = 5
+	},
+/obj/item/bait_can/worm{
+	pixel_x = -5;
+	pixel_y = 13
+	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "rj" = (
@@ -192,12 +383,29 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"rk" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "sh" = (
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
+"sj" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape/brig)
 "sr" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/mineral/titanium/tiled/yellow,
@@ -222,10 +430,13 @@
 /turf/open/water/beach/biodome,
 /area/shuttle/escape)
 "vH" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/tiled/white,
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"vV" = (
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/water/beach/biodome,
 /area/shuttle/escape)
 "wq" = (
 /obj/machinery/light/directional/east,
@@ -251,16 +462,25 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "xH" = (
-/obj/structure/chair/pew/left,
-/obj/effect/turf_decal/tile/dark/half/contrasted,
-/obj/effect/turf_decal/tile/dark{
+/obj/structure/sign/warning/yes_smoking/circle/directional/south,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"yr" = (
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/structure/chair/pew{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
-"yr" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/mineral/titanium/tiled/white,
+"zF" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "zP" = (
 /obj/structure/chair/pew/right,
@@ -277,6 +497,36 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
+"AV" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/obj/structure/chair/stool/directional/east,
+/obj/structure/fluff/beach_umbrella,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"Bq" = (
+/obj/structure/aquarium/prefilled,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/escape)
+"BA" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"Cu" = (
+/obj/machinery/light/directional/south,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "CG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -287,12 +537,16 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/stasis,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "CI" = (
-/obj/machinery/light/directional/east,
-/obj/structure/aquarium/prefilled,
-/turf/open/floor/mineral/titanium/tiled/blue,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "CS" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -325,10 +579,47 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
+"EC" = (
+/obj/structure/aquarium{
+	fluid_type = "Saltwater"
+	},
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"EQ" = (
+/obj/structure/chair/pew,
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "Fc" = (
 /obj/structure/chair/pew,
 /obj/effect/turf_decal/tile/dark/half/contrasted,
 /turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"FA" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/escape)
+"GJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/shuttle/escape)
 "GK" = (
 /obj/effect/turf_decal/tile/blue{
@@ -355,16 +646,22 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
 	},
-/obj/item/storage/medkit/toxin,
-/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Ib" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = secshuttle;
+	pixel_x = 5
+	},
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = 3
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Id" = (
@@ -383,6 +680,32 @@
 "Ih" = (
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
+"ID" = (
+/obj/effect/turf_decal/tile/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"IM" = (
+/obj/structure/table/wood,
+/obj/item/fishing_hook{
+	pixel_y = 3;
+	layer = 5
+	},
+/obj/item/fishing_line{
+	layer = 4;
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/bait_can/worm{
+	pixel_x = -5;
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "Jh" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/table/reinforced,
@@ -394,8 +717,10 @@
 "Ju" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/wrench,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 3;
+	pixel_x = -1
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Kg" = (
@@ -411,10 +736,28 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
+"KJ" = (
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "KW" = (
 /obj/machinery/door/airlock/wood/glass,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Lo" = (
+/obj/structure/chair/pew/left,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "Me" = (
 /turf/closed/wall/mineral/titanium,
@@ -423,6 +766,21 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/mineral/titanium/tiled/yellow,
+/area/shuttle/escape)
+"Mp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/turf/open/floor/iron/white,
 /area/shuttle/escape)
 "MO" = (
 /obj/machinery/light/directional/north,
@@ -444,36 +802,48 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/loading_area,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"Ou" = (
-/obj/structure/table/wood,
-/obj/item/fishing_hook{
-	pixel_y = 3;
-	layer = 5
-	},
-/obj/item/fishing_line{
-	layer = 4;
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/bait_can/worm{
-	pixel_x = -5;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t{
+"NM" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
 	},
+/obj/structure/chair/stool/directional/east,
+/obj/structure/fluff/beach_umbrella/cap,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"NW" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/folder/blue,
+/obj/item/assembly/flash/handheld{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/escape)
+"Ou" = (
+/obj/effect/turf_decal/tile/dark,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "OF" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"OR" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
@@ -486,9 +856,8 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "PQ" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/dark/half/contrasted,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "PS" = (
 /obj/structure/sign/departments/security,
@@ -502,47 +871,115 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/directional/east,
+/obj/item/defibrillator/compact/loaded{
+	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
+/area/shuttle/escape)
+"QN" = (
+/obj/machinery/door/airlock/mining/glass,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Rb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"Sf" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"SB" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark/half/contrasted,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "SE" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "Tn" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape)
 "Tq" = (
-/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"TL" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/mini{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"TN" = (
+/obj/structure/sign/calendar/directional/east,
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "UD" = (
-/obj/machinery/light/directional/west,
-/obj/structure/aquarium/prefilled,
-/turf/open/floor/mineral/titanium/tiled/blue,
+/obj/effect/turf_decal/tile/dark/half/contrasted,
+/obj/structure/chair/pew,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "UL" = (
-/obj/machinery/vending/wallmed/directional/north{
-	use_power = 0
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/aquarium{
-	fluid_type = "Saltwater"
-	},
-/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+/turf/open/misc/beach/coastline_t{
 	dir = 4
+	},
+/area/shuttle/escape)
+"US" = (
+/obj/structure/table/wood,
+/obj/item/book/random{
+	pixel_y = 3
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "UW" = (
 /turf/template_noop,
 /area/template_noop)
+"Vo" = (
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"Vq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/shuttle/escape)
 "VD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -551,8 +988,12 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/item/defibrillator/loaded,
-/obj/machinery/light/directional/north,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "VZ" = (
@@ -561,16 +1002,26 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/shuttle/escape)
+"Wj" = (
+/obj/structure/chair/pew,
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/item/toy/plush/carpplushie,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "WO" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "WT" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"WX" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "WY" = (
 /obj/machinery/vending/wallmed/directional/east,
@@ -591,12 +1042,12 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "XZ" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/light/directional/south,
-/obj/structure/aquarium{
-	fluid_type = "Saltwater"
-	},
-/obj/effect/turf_decal/tile/dark/anticorner/contrasted,
+/obj/machinery/door/airlock/mining/glass,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"YO" = (
+/obj/structure/chair/pew/left,
+/obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "ZO" = (
@@ -619,21 +1070,26 @@ UW
 UW
 UW
 UW
-jL
+Me
 rj
 Me
 aa
+aa
+aa
 Me
+fh
+Me
+sj
 Me
 aa
-fh
-jL
+aa
+Me
 UW
 UW
 UW
 UW
 UW
-jL
+Me
 Me
 Me
 UW
@@ -641,14 +1097,19 @@ UW
 (2,1,1) = {"
 UW
 UW
+Me
 aa
 Me
-Me
+OR
+Lo
+Id
+Sf
+YO
 WT
 xH
-Id
-pk
 Me
+pk
+FA
 VD
 CG
 kd
@@ -656,23 +1117,28 @@ Me
 UW
 UW
 UW
-lC
-lC
+Me
+jL
 xx
 SE
 Me
 "}
 (3,1,1) = {"
 UW
-aa
-aa
+Me
+jL
 tR
 aa
 sh
 Fc
 nY
 ec
-aa
+EQ
+KJ
+SB
+Me
+Mp
+ah
 ah
 DM
 Hk
@@ -687,8 +1153,8 @@ Ie
 Kg
 "}
 (4,1,1) = {"
-Me
-oA
+UW
+aa
 ZO
 DU
 aa
@@ -696,9 +1162,14 @@ sh
 Fc
 Hb
 ec
-aa
+EQ
+vH
+jh
+jL
+gh
+Vq
 Qw
-DM
+GJ
 GK
 oc
 Me
@@ -711,17 +1182,22 @@ Ie
 Kg
 "}
 (5,1,1) = {"
+Me
+oA
+oI
+qA
 aa
+sh
 UD
 vH
 yr
-Me
-OF
-zP
-Ih
-aT
+Wj
+US
+aF
 jL
-aa
+jL
+nz
+Me
 aa
 nz
 wF
@@ -736,21 +1212,26 @@ Kg
 "}
 (6,1,1) = {"
 aa
-WO
+Bq
+NW
+aE
+Me
+OF
+zP
+Ih
 iA
-iA
-KW
-sh
+gY
 Ih
-Ih
-Ih
-Ih
-Ih
-Ih
-Ih
-Ih
-Ih
-Ih
+ID
+Vo
+Id
+Id
+Id
+og
+Id
+Id
+Id
+CI
 bl
 Nc
 Ib
@@ -760,21 +1241,84 @@ Kg
 "}
 (7,1,1) = {"
 aa
-CI
-jh
-yr
+WO
+aT
+qA
+KW
+sh
+Ih
+Ih
+Ih
+Ih
+Ih
+Tn
+Tn
+Tn
+Tn
+Tn
+Tn
+Tn
+Tn
+Tn
+PQ
+jw
+Nc
+gX
+Pd
+Ie
+Kg
+"}
+(8,1,1) = {"
+aa
+Bq
+ax
+aE
 Me
-UL
+nB
+Ih
+Ih
+Ih
+Ih
+Ou
+pQ
+BA
+bB
+bB
+bB
+BA
+bB
+TN
+bB
 Tq
-Tq
-XZ
+bl
+Nc
+Ju
+cZ
+Ie
+Kg
+"}
+(9,1,1) = {"
+Me
+oA
+Rb
+qA
+aa
+qe
+NM
+IM
+qO
+AV
+EC
+jL
+WX
+QN
+WX
 jL
 aa
-aa
-nz
-Tn
+XZ
 Me
-PQ
+Me
+lC
 jL
 WY
 ZT
@@ -782,17 +1326,22 @@ xA
 Ie
 Kg
 "}
-(8,1,1) = {"
-Me
-oA
+(10,1,1) = {"
+UW
+aa
 VZ
-iA
+zF
 aa
-Ou
+UL
 gI
+UL
+UL
 gI
-Ou
-aa
+aR
+Me
+eQ
+rk
+jL
 ko
 az
 DB
@@ -801,22 +1350,27 @@ Me
 UW
 Me
 jL
-Ju
+TL
 Kl
 Ie
 Kg
 "}
-(9,1,1) = {"
+(11,1,1) = {"
 UW
-aa
-aa
+Me
+jL
 wq
 aa
 kX
 kX
+mD
+kX
 kX
 kX
 aa
+lW
+pa
+jL
 gd
 sr
 Ml
@@ -830,17 +1384,22 @@ Pd
 Ie
 Kg
 "}
-(10,1,1) = {"
+(12,1,1) = {"
 UW
 UW
+Me
 aa
 Me
-Me
-aR
+vV
+eC
+kX
 kX
 kX
 ut
 Me
+lW
+Cu
+jL
 MO
 jY
 jL
@@ -848,18 +1407,20 @@ Me
 UW
 UW
 UW
-PQ
-lC
+Me
+jL
 fA
 SE
 Me
 "}
-(11,1,1) = {"
+(13,1,1) = {"
 UW
 UW
 UW
 UW
-jL
+Me
+aa
+aa
 aa
 aa
 aa
@@ -868,12 +1429,15 @@ Me
 aa
 aa
 jL
+aa
+aa
+Me
 UW
 UW
 UW
 UW
 UW
-jL
+Me
 Me
 Me
 UW

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -104,7 +104,8 @@
 /area/shuttle/escape)
 "fh" = (
 /obj/machinery/door/airlock/shuttle/glass,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "fA" = (
 /obj/machinery/light/directional/east,
@@ -196,6 +197,7 @@
 	name = "Holding Area"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "jL" = (
@@ -255,7 +257,7 @@
 /area/shuttle/escape)
 "nz" = (
 /obj/machinery/door/airlock/medical/glass,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "nB" = (
 /obj/machinery/vending/wallmed/directional/north{
@@ -376,10 +378,14 @@
 /area/shuttle/escape)
 "rj" = (
 /obj/docking_port/mobile/emergency{
-	name = "Angler's Choice emergency shuttle"
+	name = "Angler's Choice emergency shuttle";
+	height = 13;
+	width = 27;
+	dwidth = 6
 	},
 /obj/machinery/door/airlock/shuttle/glass,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "rk" = (
 /obj/machinery/light/directional/south,
@@ -419,7 +425,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "ut" = (
 /obj/machinery/light/directional/south,
@@ -676,9 +682,6 @@
 "Ih" = (
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
-"IB" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape/brig)
 "ID" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
@@ -749,7 +752,7 @@
 "KW" = (
 /obj/machinery/door/airlock/wood/glass,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Lo" = (
 /obj/structure/chair/pew/left,
@@ -1042,7 +1045,8 @@
 /area/shuttle/escape/brig)
 "XZ" = (
 /obj/machinery/door/airlock/mining/glass,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/dark/full,
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "YO" = (
 /obj/structure/chair/pew/left,
@@ -1082,7 +1086,7 @@ sj
 Me
 aa
 aa
-IB
+Me
 UW
 UW
 UW

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -59,7 +59,7 @@
 "bl" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = secshuttle
+	id = "secshuttle"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -265,6 +265,10 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 1
 	},
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
+"nN" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "nY" = (
@@ -647,7 +651,7 @@
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	id = secshuttle;
+	id = "secshuttle";
 	pixel_x = 5
 	},
 /obj/machinery/recharger{
@@ -906,7 +910,7 @@
 "Tq" = (
 /obj/effect/turf_decal/tile/dark/anticorner/contrasted,
 /obj/item/kirbyplants/random,
-/turf/open/floor/plating/airless,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "TL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -1310,7 +1314,7 @@ aa
 XZ
 Me
 Me
-aa
+nN
 jL
 WY
 ZT

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -196,7 +196,7 @@
 	name = "Holding Area"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "jL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -401,7 +401,7 @@
 "sj" = (
 /obj/machinery/door/airlock/shuttle/glass,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape/brig)
+/area/shuttle/escape)
 "sr" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/mineral/titanium/tiled/yellow,
@@ -676,6 +676,9 @@
 "Ih" = (
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
+"IB" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/brig)
 "ID" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
@@ -1079,7 +1082,7 @@ sj
 Me
 aa
 aa
-Me
+IB
 UW
 UW
 UW

--- a/orbstation/shuttles/shuttles.dm
+++ b/orbstation/shuttles/shuttles.dm
@@ -1,4 +1,4 @@
-/datum/map_template/shuttle/emergency/pubby
+/datum/map_template/shuttle/emergency/fish
 	suffix = "fish"
 	name = "Angler's Choice Emergency Shuttle"
 	description = "Trades such amenities as 'storage space' and 'sufficient seating' for an artifical environment ideal for fishing, plus ample supplies."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Following playtesting frequent feedback was "this shuttle is too small and cramped, especially the one-tile wide hallway".
As I _don't_ want this to be a troll shuttle that makes people mad, I decided to remedy this by adding more seating and making the corridor wider.

![image](https://user-images.githubusercontent.com/7483112/192609138-c525e017-2eb6-41a9-8c0b-b5dd423eaa20.png)

There's now two medical stasis beds instead of one, a couple of extra toys, and some chasms you can fish in for last minute miner rescue (or throw people into if that's your thing).
The Warden now also gets their own desk in the back of the ship, with a button which closes some shutters in case you don't want people to see what's going on in there.
Combine that with the sandbags and flasher and you should be able to hold off any crew who are still mad you bought a fishing-themed shuttle.


~~I am PRing this because I am not sure I am going to figure out a fix for this but for some reason, the shuttle brig fails to come along with the shuttle unless the medical airlock tile is randomly also designated as part of the shuttle brig.
I'm going to poke around with it a but longer to see if I can fix it but I haven't had much luck so far. I can't think of any logical reason why this should be so, as other shuttles including the smaller version of this one did not have this requirement.~~
Ok that is fixed, thanks PL for your suggestions.

## Why It's Good For The Game

People didn't think this shuttle was big enough so now it is bigger.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Angler's Choice emergency shuttle is now larger, if not particularly better-stocked with relevant supplies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
