### PR TITLE
Fix for CI complaining about table shuffle non-events

### DIFF
--- a/orbstation/modules/table_shuffle/table_shuffle_subsystem.dm
+++ b/orbstation/modules/table_shuffle/table_shuffle_subsystem.dm
@@ -80,7 +80,14 @@ SUBSYSTEM_DEF(table_shuffle)
 	// note that "affected areas" only counts areas where events happened.
 	// There are going to be several areas either immediately skipped or which
 	// have nothing happen.
-	var/msg = "Table shuffle averaged [round(event_total / affected_area_amt)] events among [affected_area_amt] affected areas, [high_rollers.len] being high rollers."
+	var/msg
+	if(affected_area_amt > 0)
+		msg = "Table shuffle averaged [round(event_total / affected_area_amt)] events among [affected_area_amt] affected areas, [high_rollers.len] being high rollers."
+	else
+		if(event_total > 0) // shouldn't happen if the above doesn't
+			msg = "Table shuffle had [event_total] phantom events this round."
+		else
+			msg = "Table shuffle had no events this round."
 	to_chat(world, span_boldannounce("[msg]"))
 	log_world(msg)
 


### PR DESCRIPTION
## About The Pull Request

Table shuffle code will no longer divide by zero during CI testing.

This was supposed to be a part of the last table shuffle code fix but it apparently broke out of prison, solved three murders, saved the prince and/or princess,  defeated a demon lord, punched a nazi in the face, then snuck back into its cell when nobody was looking.  I know because it was there, but it wasn't committed somehow.  And also because I guess those other things definitely happened and weren't made up.