### PR TITLE
X-card overhauls; "Bioscrambler Immunity" quirk.

### DIFF
--- a/code/__DEFINES/orb/traits.dm
+++ b/code/__DEFINES/orb/traits.dm
@@ -6,6 +6,8 @@
 #define TRAIT_XCARD_XENO_IMMUNE "xcard_xeno_immune"
 // Makes your brain's MMI not fit into a cyborg or AI core
 #define TRAIT_XCARD_BORG_IMMUNE "xcard_borg_immune"
+// Makes you immune to bioscrambler limb-swapping (used for x-card, but may be applied to species with a unique shape too)
+#define TRAIT_BIOSCRAMBLER_IMMUNE "bioscrambler-immune"
 // Multiplies the time it takes to craft items by FAST_CRAFTER_MOD
 #define TRAIT_FAST_CRAFTER "orb_fast_crafter"
 #define FAST_CRAFTER_MOD 0.5

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -21,6 +21,8 @@
 	/// This references a tgui icon, so it can be FontAwesome or a tgfont (with a tg- prefix).
 	var/icon
 
+	var/xcard_quirk = FALSE //if true, this quirk will be displayed in the x-card section of the quirk list
+
 /datum/quirk/Destroy()
 	if(quirk_holder)
 		remove_from_current_holder()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -486,6 +486,9 @@
 	for(var/mob/living/carbon/nearby in range(swap_range, src))
 		if(nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
 			continue //We are protected
+		if(HAS_TRAIT(nearby, TRAIT_BIOSCRAMBLER_IMMUNE)) //ORBSTATION: bioscrambler has alternate effects
+			alt_swap(nearby)
+			continue
 		var/picked_zone = pick(zones)
 		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(picked_zone)
 		var/obj/item/bodypart/picked_part

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -38,6 +38,7 @@
 			"icon" = initial(quirk.icon),
 			"name" = quirk_name,
 			"value" = initial(quirk.value),
+			"xcard" = initial(quirk.xcard_quirk),
 		)
 
 	return list(

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -409,6 +409,9 @@
 			continue
 		if(nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
 			continue //We are protected
+		if(HAS_TRAIT(nearby, TRAIT_BIOSCRAMBLER_IMMUNE)) //ORBSTATION: bioscrambler has alternate effects
+			alt_swap(nearby)
+			continue //alternate effect resolved
 		var/picked_zone = pick(zones)
 		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(picked_zone)
 		var/obj/item/bodypart/picked_part

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -347,6 +347,7 @@
 		if(12 to INFINITY)
 			msg += "[span_notice("<b><i>[t_He] [t_is] just absolutely fucked up, you can look again to take a closer look...</i></b>")]\n"
 
+	msg += examine_xcards() //ORBSTATION: display x-cards on examine
 
 	if (length(msg))
 		. += span_warning("[msg.Join("")]")

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -14,7 +14,7 @@
 			TEST_FAIL("[quirk_type] has no icon!")
 			continue
 
-		if (istype(quirk_type, /datum/quirk/xcard)) //ORBSTATION: x-card quirks all use the same icon, and so the next text should be skipped
+		if(initial(quirk_type.xcard_quirk)) //ORBSTATION: x-card quirks all use the same icon, and so the next text should be skipped
 			continue
 
 		if (icon in used_icons)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -14,6 +14,9 @@
 			TEST_FAIL("[quirk_type] has no icon!")
 			continue
 
+		if (quirk_type.xcard_quirk) //ORBSTATION: x-card quirks all use the same icon, and so the next text should be skipped
+			continue
+
 		if (icon in used_icons)
 			TEST_FAIL("[icon] used in both [quirk_type] and [used_icons[icon]]!")
 			continue

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -14,7 +14,7 @@
 			TEST_FAIL("[quirk_type] has no icon!")
 			continue
 
-		if (quirk_type.xcard_quirk) //ORBSTATION: x-card quirks all use the same icon, and so the next text should be skipped
+		if (istype(quirk_type, /datum/quirk/xcard)) //ORBSTATION: x-card quirks all use the same icon, and so the next text should be skipped
 			continue
 
 		if (icon in used_icons)

--- a/orbstation/quirks/xcard/bioscrambler_immune.dm
+++ b/orbstation/quirks/xcard/bioscrambler_immune.dm
@@ -27,7 +27,6 @@
 			victim.adjustToxLoss(30)
 			victim.blur_eyes(20)
 			victim.set_timed_status_effect(10 SECONDS, /datum/status_effect/dizziness)
-	return
 
 //and the same thing again, for the bioscrambler armor. yes, the code is all copy-pasted there, too.
 /obj/item/clothing/suit/armor/reactive/bioscrambling/proc/alt_swap(mob/living/carbon/human/victim)

--- a/orbstation/quirks/xcard/bioscrambler_immune.dm
+++ b/orbstation/quirks/xcard/bioscrambler_immune.dm
@@ -1,0 +1,61 @@
+//alternative nasty effects for the Bioscrambler Anomaly, for use in the x-card quirk and in species unsuitable for limb-swapping
+/obj/effect/anomaly/bioscrambler/proc/alt_swap(mob/living/carbon/human/victim)
+	var/bad_effect = rand(1,3)
+	var/zones
+	var/picked_zone
+	var/obj/item/bodypart/picked_part
+	switch(bad_effect)
+		if(1) //dismember random limb
+			zones = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+			picked_zone = pick(zones)
+			picked_part = victim.get_bodypart(picked_zone)
+			if(picked_part)
+				victim.visible_message(span_danger("[victim]'s [picked_part.plaintext_zone] violently rips from [victim.p_their()] body, disintegrating in a shower of blood!"), span_userdanger("Your [picked_part.plaintext_zone] violently rips from your body, disintegrating in a shower of blood!"))
+				picked_part.dismember()
+				qdel(picked_part)
+		if(2) //break random bone
+			zones = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+			picked_zone = pick(zones)
+			picked_part = victim.get_bodypart(picked_zone)
+			if(picked_part)
+				to_chat(victim, span_userdanger("Your [picked_part.plaintext_zone] begins resonating violently!"))
+				var/type_wound = pick(list(/datum/wound/blunt/critical, /datum/wound/blunt/severe, /datum/wound/blunt/moderate))
+				picked_part.force_wound_upwards(type_wound)
+		if(3) //deal toxin damage and cause temporary sickness
+			to_chat(victim, span_userdanger("Your stomach churns as your body twists unnaturally!"))
+			victim.vomit()
+			victim.adjustToxLoss(30)
+			victim.blur_eyes(20)
+			victim.set_timed_status_effect(10 SECONDS, /datum/status_effect/dizziness)
+	return
+
+//and the same thing again, for the bioscrambler armor. yes, the code is all copy-pasted there, too.
+/obj/item/clothing/suit/armor/reactive/bioscrambling/proc/alt_swap(mob/living/carbon/human/victim)
+	var/bad_effect = rand(1,3)
+	var/zones
+	var/picked_zone
+	var/obj/item/bodypart/picked_part
+	switch(bad_effect)
+		if(1) //dismember random limb
+			zones = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+			picked_zone = pick(zones)
+			picked_part = victim.get_bodypart(picked_zone)
+			if(picked_part)
+				victim.visible_message(span_danger("[victim]'s [picked_part] violently rips from [victim.p_their()] body, disintegrating in a shower of blood!"), span_userdanger("Your [picked_part] violently rips from your body, disintegrating in a shower of blood!"))
+				picked_part.dismember()
+				qdel(picked_part)
+		if(2) //break random bone
+			zones = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+			picked_zone = pick(zones)
+			picked_part = victim.get_bodypart(picked_zone)
+			if(picked_part)
+				to_chat(victim, span_userdanger("Your [picked_part] begins resonating violently!"))
+				var/type_wound = pick(list(/datum/wound/blunt/critical, /datum/wound/blunt/severe, /datum/wound/blunt/moderate))
+				picked_part.force_wound_upwards(type_wound)
+		if(3) //deal toxin damage and cause temporary sickness
+			to_chat(victim, span_userdanger("Your stomach churns as your body twists unnaturally!"))
+			victim.vomit()
+			victim.adjustToxLoss(30)
+			victim.blur_eyes(20)
+			victim.set_timed_status_effect(10 SECONDS, /datum/status_effect/dizziness)
+	return

--- a/orbstation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/quirks/xcard/xcard-quirks.dm
@@ -32,7 +32,7 @@
 	name = "X-CARD: Facehuggers"
 	desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom."
 	mob_trait = TRAIT_XCARD_XENO_IMMUNE
-	examine_text = "immune to facehugger implantation, and will be injected with deadly neurotoxin instead."
+	examine_text = "immune to facehugger implantation, and will be injected with deadly xenotoxin instead."
 /*
 /datum/quirk/xcard/uncyborgable
 	name = "Cyborg Incompatibility"

--- a/orbstation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/quirks/xcard/xcard-quirks.dm
@@ -5,6 +5,8 @@
 	icon = "x" //all x-card quirks use a big "X" icon for clarity
 	value = 0 //x-card quirks are always free
 
+	var/examine_text //text when quirk owner is examined, if any
+
 /datum/quirk/xcard/bioscrambler_immune
 	name = "X-CARD: Bioscrambler"
 	desc = "Your physical form is abnormally stable, preventing your limbs from being replaced by bioscrambler \
@@ -13,27 +15,31 @@
 	mob_trait = TRAIT_BIOSCRAMBLER_IMMUNE //this is not ONLY an x-card trait, so it does not have "XCARD" in the name
 
 /datum/quirk/xcard/cult_convert_immune
-    name = "X-CARD: Cult Conversion"
-    desc = "Your powerful mental rigor prevents you from being forcefully recruited into cults. \
-            Instead, those awful cultists will sacrifice you in a shower of blood and viscera!"
-    mob_trait = TRAIT_XCARD_CULT_IMMUNE
+	name = "X-CARD: Cult Conversion"
+	desc = "Your powerful mental rigor prevents you from being forcefully recruited into cults. \
+			Instead, those awful cultists will sacrifice you in a shower of blood and viscera!"
+	mob_trait = TRAIT_XCARD_CULT_IMMUNE
+	examine_text = "immune to cult conversion, and will be gibbed if attempted."
 
 /datum/quirk/xcard/rev_convert_immune
-    name = "X-CARD: Revolution Conversion"
-    desc = "Your powerful mental rigor prevents you from being forcefully recruited into revolutions. \
-            Instead, conversion attempts will deal brain damage and brute damage to your head."
-    mob_trait = TRAIT_XCARD_REV_IMMUNE
+	name = "X-CARD: Revolution Conversion"
+	desc = "Your powerful mental rigor prevents you from being forcefully recruited into revolutions. \
+			Instead, conversion attempts will deal brain damage and brute damage to your head."
+	mob_trait = TRAIT_XCARD_REV_IMMUNE
+	examine_text = "immune to revolutionary conversion, and will suffer brain damage instead."
 
 /datum/quirk/xcard/facehugger_immune
-    name = "X-CARD: Facehuggers"
-    desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom."
-    mob_trait = TRAIT_XCARD_XENO_IMMUNE
+	name = "X-CARD: Facehuggers"
+	desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom."
+	mob_trait = TRAIT_XCARD_XENO_IMMUNE
+	examine_text = "immune to facehugger implantation, and will be injected with deadly neurotoxin instead."
 /*
 /datum/quirk/xcard/uncyborgable
-    name = "Cyborg Incompatibility"
-    desc = "Your brain is oddly-shaped, and will not fit into cyborg bodies or AI cores. \
-            (It can still be put into an MMI, and you can still become a cyborg or AI if you enter a positronic brain as a ghost.)"
-    mob_trait = TRAIT_XCARD_BORG_IMMUNE
+	name = "Cyborg Incompatibility"
+	desc = "Your brain is oddly-shaped, and will not fit into cyborg bodies or AI cores. \
+			(It can still be put into an MMI, and you can still become a cyborg or AI if you enter a positronic brain as a ghost.)"
+	mob_trait = TRAIT_XCARD_BORG_IMMUNE
+	examine_text = span_notice("[p_their(TRUE)] brain cannot be used to make a cyborg or AI, though it can be placed into an MMI.\n")
 */
 
 //proc to append x-card traits to examine text (everyone should be able to see these!)
@@ -41,15 +47,9 @@
 	var/list/xcard_list = list()
 	var/list/msg = list()
 
-	//bioscrambler immunity doesn't need to be noted here, as it's not relevant to other players
-	if(HAS_TRAIT(src, TRAIT_XCARD_CULT_IMMUNE))
-		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to cult conversion, and will be gibbed if attempted.\n")
-	if(HAS_TRAIT(src, TRAIT_XCARD_REV_IMMUNE))
-		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to revolutionary conversion, and will suffer brain damage instead.\n")
-	if(HAS_TRAIT(src, TRAIT_XCARD_XENO_IMMUNE))
-		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to facehugger implantation, and will be injected with deadly neurotoxin instead.\n")
-	if(HAS_TRAIT(src, TRAIT_XCARD_BORG_IMMUNE))
-		xcard_list += span_notice("[p_their(TRUE)] brain cannot be used to make a cyborg or AI, though it can be placed into an MMI.\n")
+	for (var/datum/quirk/xcard/quirk_type as anything in subtypesof(/datum/quirk/xcard))
+		if(initial(quirk_type.examine_text) && HAS_TRAIT(src, initial(quirk_type.mob_trait)))
+			xcard_list += span_notice("[p_they(TRUE)] [p_are()] [initial(quirk_type.examine_text)]\n")
 
 	if(length(xcard_list))
 		msg += span_notice("\n<b>[p_they(TRUE)] [p_have()] the following X-cards:</b>\n")

--- a/orbstation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/quirks/xcard/xcard-quirks.dm
@@ -1,37 +1,59 @@
-/datum/quirk/xcard_cult_convert_immune
-    name = "Cult Conversion Immunity"
+//quirk subtype for x-card, prevents having to manually flag quirks as an x-card quirk
+/datum/quirk/xcard
+	xcard_quirk = TRUE
+	abstract_parent_type = /datum/quirk/xcard
+	icon = "x" //all x-card quirks use a big "X" icon for clarity
+	value = 0 //x-card quirks are always free
+
+/datum/quirk/xcard/bioscrambler_immune
+	name = "X-CARD: Bioscrambler"
+	desc = "Your physical form is abnormally stable, preventing your limbs from being replaced by bioscrambler \
+			proximity. Instead, you will suffer from a random, highly detrimental effect when you would normally \
+			be bioscrambled."
+	mob_trait = TRAIT_BIOSCRAMBLER_IMMUNE //this is not ONLY an x-card trait, so it does not have "XCARD" in the name
+
+/datum/quirk/xcard/cult_convert_immune
+    name = "X-CARD: Cult Conversion"
     desc = "Your powerful mental rigor prevents you from being forcefully recruited into cults. \
-            Instead, those awful cultists will sacrifice you in a shower of blood and viscera! \
-            Please note that this quirk is intended only for those who find this content uncomfortable, \
-            not for modifications of roleplay or game mechanics."
-    icon = "face-smile-halo"
-    value = 0
+            Instead, those awful cultists will sacrifice you in a shower of blood and viscera!"
     mob_trait = TRAIT_XCARD_CULT_IMMUNE
 
-/datum/quirk/xcard_rev_convert_immune
-    name = "Revolution Conversion Immunity"
+/datum/quirk/xcard/rev_convert_immune
+    name = "X-CARD: Revolution Conversion"
     desc = "Your powerful mental rigor prevents you from being forcefully recruited into revolutions. \
-            Instead, conversion attempts will deal brain damage and brute damage to your head. \
-            Please note that this quirk is intended only for those who find this content uncomfortable, \
-            not for modifications of roleplay or game mechanics."
-    icon = "hammer-crash"
-    value = 0
+            Instead, conversion attempts will deal brain damage and brute damage to your head."
     mob_trait = TRAIT_XCARD_REV_IMMUNE
 
-/datum/quirk/xcard_facehugger_immune
-    name = "Facehugger Immunity"
-    desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom. \
-            Please note that this quirk is intended only for those who find this content uncomfortable, \
-            not for modifications of roleplay or game mechanics."
-    icon = "head-side-cough-slash"
-    value = 0
+/datum/quirk/xcard/facehugger_immune
+    name = "X-CARD: Facehuggers"
+    desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom."
     mob_trait = TRAIT_XCARD_XENO_IMMUNE
 /*
-/datum/quirk/xcard_uncyborgable
+/datum/quirk/xcard/uncyborgable
     name = "Cyborg Incompatibility"
     desc = "Your brain is oddly-shaped, and will not fit into cyborg bodies or AI cores. \
             (It can still be put into an MMI, and you can still become a cyborg or AI if you enter a positronic brain as a ghost.)"
-    icon = "head-side-brain"
-    value = 0
     mob_trait = TRAIT_XCARD_BORG_IMMUNE
 */
+
+//proc to append x-card traits to examine text (everyone should be able to see these!)
+/mob/living/carbon/human/proc/examine_xcards()
+	var/list/xcard_list = list()
+	var/list/msg = list()
+
+	//bioscrambler immunity doesn't need to be noted here, as it's not relevant to other players
+	if(HAS_TRAIT(src, TRAIT_XCARD_CULT_IMMUNE))
+		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to cult conversion, and will be gibbed if attempted.\n")
+	if(HAS_TRAIT(src, TRAIT_XCARD_REV_IMMUNE))
+		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to revolutionary conversion, and will suffer brain damage instead.\n")
+	if(HAS_TRAIT(src, TRAIT_XCARD_XENO_IMMUNE))
+		xcard_list += span_notice("[p_they(TRUE)] [p_are()] immune to facehugger implantation, and will be injected with deadly neurotoxin instead.\n")
+	if(HAS_TRAIT(src, TRAIT_XCARD_BORG_IMMUNE))
+		xcard_list += span_notice("[p_their(TRUE)] brain cannot be used to make a cyborg or AI, though it can be placed into an MMI.\n")
+
+	if(length(xcard_list))
+		msg += span_notice("\n<b>[p_they(TRUE)] [p_have()] the following X-cards:</b>\n")
+		msg += xcard_list
+
+	return msg
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4798,6 +4798,7 @@
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_internal.dm"
 #include "orbstation\quirks\plurality.dm"
 #include "orbstation\quirks\tongue_tied.dm"
+#include "orbstation\quirks\xcard\bioscrambler_immune.dm"
 #include "orbstation\quirks\xcard\revolution.dm"
 #include "orbstation\quirks\xcard\xcard-quirks.dm"
 #include "orbstation\quirks\xcard\xenotoxin.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -4,8 +4,10 @@ import { PreferencesMenuData, Quirk } from './data';
 import { useBackend, useLocalState } from '../../backend';
 import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
 
-const getValueClass = (value: number): string => {
-  if (value > 0) {
+const getValueClass = (value: number, xcard: boolean): string => {
+  if (xcard) {
+    return 'xcard';
+  } else if (value > 0) {
     return 'positive';
   } else if (value < 0) {
     return 'negative';
@@ -67,7 +69,10 @@ const QuirkList = (props: {
                 }}>
                 <Stack vertical fill>
                   <Stack.Item
-                    className={`${className}--${getValueClass(quirk.value)}`}
+                    className={`${className}--${getValueClass(
+                      quirk.value,
+                      quirk.xcard
+                    )}`}
                     style={{
                       'border-bottom': '1px solid black',
                       'padding': '2px',
@@ -104,6 +109,12 @@ const QuirkList = (props: {
 
         if (quirk.failTooltip) {
           return <Tooltip content={quirk.failTooltip}>{child}</Tooltip>;
+        } else if (quirk.xcard) {
+          return (
+            <Tooltip content="Please note that X-card quirks are intended only for those who find certain content uncomfortable. They are NOT intended for roleplay purposes, or to give mechanical advantages.">
+              {child}
+            </Tooltip>
+          );
         } else {
           return child;
         }
@@ -150,6 +161,11 @@ export const QuirksPage = (props, context) => {
 
         const quirks = Object.entries(quirkInfo);
         quirks.sort(([_, quirkA], [__, quirkB]) => {
+          if (quirkA.xcard && !quirkB.xcard) {
+            return -1;
+          } else if (!quirkA.xcard && quirkB.xcard) {
+            return 1;
+          }
           if (quirkA.value === quirkB.value) {
             return quirkA.name > quirkB.name ? 1 : -1;
           } else {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -51,6 +51,7 @@ export type Species = {
     positive: Perk[];
     negative: Perk[];
     neutral: Perk[];
+    xcard: Perk[];
   };
 
   diet?: {
@@ -80,6 +81,7 @@ export type Quirk = {
   icon: string;
   name: string;
   value: number;
+  xcard: boolean;
 };
 
 export type QuirkInfo = {

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -211,6 +211,7 @@ $department_map: (
           'positive': colors.$green,
           'neutral': colors.$white,
           'negative': colors.$red,
+          'xcard': colors.$blue,
         );
 
         @each $quality, $color-value in $quality_map {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There are two pieces to this PR. Strictly speaking, they should probably be separate PRs, but I kind of just made all of this at once.

First, the "X-card" quirks have had some overhauls made to them. They are all now children of an abstract "x-card" quirk, allowing them to share several redundant features for ease of use (a big "X" for an icon, a cost of 0, and a flag indicating that they're x-card quirks). X-card quirks will now display separately from others, in a nice blue color, right at the top of the list. They are all labeled with "X-CARD", and the text describing x-card quirks in general has been moved to a tooltip rather than being in each description (allowing the quirk descriptions to be significantly shorter).

![image](https://user-images.githubusercontent.com/105025397/193745634-38bbac15-a027-4556-9221-b3bcbb6ad0fb.png)

In addition, X-card quirks are now visible to any player who examines someone that has them. X-cards, as an OOC system, should not be obfuscated from anyone. (Note that x-card quirks that do NOT have any impact on other players will not be described on examine, as they are not relevant information - for example, the Bioscrambler X-card described later in this PR).

![image](https://user-images.githubusercontent.com/105025397/193745808-c3ae6432-d5cc-4df5-b000-bd75297a2b8b.png)

The second part of this PR concerns a new, requested x-card - "immunity" to bioscrambler anomalies. As some players are uncomfortable with their character being unpredictably and permanently transformed by the anomaly, this quirk will modify their behavior. Each bioscrambler pulse will cause one of three random effects to someone with this quirk - it will either disintegrate one of their limbs (destroying it entirely - arms and legs only, though!), break a random bone (at a random severity), or cause toxin damage, vomiting, and visual blurring from their guts trying to scramble themselves.

Note that this behavior has also been separately applied to the reactive bioscrambling armor. As all of the code is copy-pasted between the anomaly and the armor, the code for "alternate" bioscrambling has also been duplicated in the same way. This all may be worth refactoring later...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

X-cards are important. Significant amounts of content in SS13 is questionable, and players will not be comfortable with everything that might happen to them. The system needed some touching up for clarity and maintainability, and this has been provided with the visual and code overhauls. The examine text is also very important, so that players aren't surprised by someone's x-cards.

In addition to providing a requested x-card, the bioscrambling immunity trait provides a secondary purpose - if we add species in the future that are unsuitable for the bioscrambler (for example, species with notably different body shapes), this trait can be applied to the species as a whole. This avoids needing to do the same thing on a species-by-species basis.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added "X-CARD: Bioscrambler" quirk, providing alternate effects to the bioscrambler anomaly.
qol: Made x-card quirks display separately, in blue and at the top of the quirks list, for clarity and ease of use.
refactor: Made x-card quirks share an abstract parent to reduce code reuse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
