### PR TITLE
Fixes ratfolk sometimes having incorrect tail sprites.

### DIFF
--- a/orbstation/orb_species/ratfolk/ratfolk_organs_external.dm
+++ b/orbstation/orb_species/ratfolk/ratfolk_organs_external.dm
@@ -39,3 +39,7 @@
 	desc = "A severed rat tail."
 	feature_key = "rat_tail"
 	preference = "feature_rat_tail"
+	dna_block = DNA_RAT_TAIL_BLOCK
+
+/obj/item/organ/external/tail/ratfolk/get_global_feature_list()
+	return GLOB.rat_tails_list


### PR DESCRIPTION
When admin-spawned from a ghost or transformed from a changeling, ratfolk consistently have the wrong tails. I fixed that.

Related closely to this: https://github.com/tgstation/tgstation/pull/70532

Ratfolk tails, much like lizard tails, were set to use the wrong DNA block. They also did not override get_global_feature_list(). With these two things fixed, rat tails now work properly.