### PR TITLE
Created "Cybernetic Limbs" subcategory for mech fabricator.

### DIFF
--- a/orbstation/modules/research/designs/mechfabricator_designs.dm
+++ b/orbstation/modules/research/designs/mechfabricator_designs.dm
@@ -1,5 +1,7 @@
 //Mech Fabricator designs for Orbstation
 
+#define RND_SUBCATEGORY_MECHFAB_CYBORG_CYBER_LIMBS "/Cybernetic Limbs"
+
 /datum/design/digi_borg_l_leg
 	name = "Digitigrade Cyborg Left Leg"
 	id = "digi_borg_l_leg"
@@ -7,7 +9,9 @@
 	build_path = /obj/item/bodypart/l_leg/robot/digitigrade
 	materials = list(/datum/material/iron=10000)
 	construction_time = 200
-	category = list("Cyborg")
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CYBER_LIMBS
+	)
 
 /datum/design/digi_borg_r_leg
 	name = "Digitigrade Cyborg Right Leg"
@@ -16,4 +20,6 @@
 	build_path = /obj/item/bodypart/r_leg/robot/digitigrade
 	materials = list(/datum/material/iron=10000)
 	construction_time = 200
-	category = list("Cyborg")
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CYBER_LIMBS
+	)


### PR DESCRIPTION
Adds a new subcategory for cyborg parts, "Cybernetic Limbs", to the exosuit fabricator. Currently, it only contains the digitigrade cyborg limbs.

![image](https://user-images.githubusercontent.com/105025397/196421508-e10c82ee-3da6-4420-b172-57f71c933ac1.png)

Digitigrade cyberlimbs were not coded to use subcategories - with the overhauls to the mechfab interface, this caused them to be unavailable. This fixes that, and leaves space to easily add more cybernetic limbs in the future.