### PR TITLE
Improved chasm rescue

### DIFF
--- a/orbstation/modules/mining/chasm_rescue.dm
+++ b/orbstation/modules/mining/chasm_rescue.dm
@@ -1,0 +1,54 @@
+/**
+ * Adds a higher chance to fish up dead players than anything else.
+ */
+/obj/effect/abstract/chasm_storage
+	/// List of mobs controlled by players who have fallen in here
+	var/list/player_mobs = list()
+
+/// Don't get boiled by ash while down there
+/obj/effect/abstract/chasm_storage/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_WEATHER_IMMUNE, ROUNDSTART_TRAIT)
+
+/// Add fallen mobs with ckeys to a high priority list
+/obj/effect/abstract/chasm_storage/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
+	if (!ismob(arrived))
+		return
+	var/mob/fallen_mob = arrived
+	if (!fallen_mob.ckey)
+		return
+	if (fallen_mob in player_mobs)
+		return
+	player_mobs += fallen_mob
+
+/obj/effect/abstract/chasm_storage/Exited(atom/movable/gone, direction)
+	. = ..()
+	player_mobs -= gone
+
+/// 40% of the time fish up a player corpse if one exists
+/obj/item/chasm_detritus/Initialize(mapload)
+	if (prob(40) && retrieve_player_body())
+		return INITIALIZE_HINT_QDEL
+	return ..()
+
+/// Retrieves a corpse if there is one
+/obj/item/chasm_detritus/proc/retrieve_player_body()
+	to_chat(world, "trying to rescue corpse")
+	if (!GLOB.chasm_storage.len)
+		to_chat(world, "no chasms")
+		return FALSE
+
+	var/list/chasm_contents = list()
+	var/list/chasm_storage_resolved = recursive_list_resolve(GLOB.chasm_storage)
+	for (var/obj/effect/abstract/chasm_storage/storage as anything in chasm_storage_resolved)
+		for (var/thing as anything in storage.player_mobs)
+			chasm_contents += thing
+
+	if (!length(chasm_contents))
+		to_chat(world, "no bodies")
+		return FALSE
+
+	var/atom/movable/body = pick(chasm_contents)
+	body.forceMove(get_turf(src))
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4839,6 +4839,7 @@
 #include "orbstation\mob\simple_animal\friendly\amoung.dm"
 #include "orbstation\modules\client\looc.dm"
 #include "orbstation\modules\client\preferences\_preference.dm"
+#include "orbstation\modules\mining\chasm_rescue.dm"
 #include "orbstation\modules\mining\voucher_sets.dm"
 #include "orbstation\modules\research\designs\mechfabricator_designs.dm"
 #include "orbstation\modules\research\techweb\all_nodes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the ease of rescuing miners from chasms in two ways:
- People in chasms are now safe from weather and will not be husked, they will continue to decay at regular speed.
- Mobs with an assigned ckey will have a 40% chance to spawn from chasm contents before performing the usual contents check.
I am not currently sending this upstream because I don't really want to deal with the discussion about how easy it _should_ be and haven't seen the same complaints from there as here, if I notice someone mention it then I might port this feature.

## Why It's Good For The Game

While you can rescue people from chasms in practice this has usually been a 30+ minute process, which is understandably frustrating.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bodies which were once players are now more likely than other objects to be fished out of chasms
fix: Bodies in chasms are no longer boiled by lavaland's weather
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
