### PR TITLE
Changed the roundend category for wizards to just say "Wizards".

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /datum/antagonist/wizard
 	name = "\improper Space Wizard"
-	roundend_category = "wizards/witches"
+	roundend_category = "wizards"
 	antagpanel_category = "Wizard"
 	job_rank = ROLE_WIZARD
 	antag_hud_name = "wizard"
@@ -388,7 +388,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 /datum/team/wizard/roundend_report()
 	var/list/parts = list()
 
-	parts += "<span class='header'>Wizards/witches of [master_wizard.owner.name] team were:</span>"
+	parts += "<span class='header'>Wizards of [master_wizard.owner.name] team were:</span>"
 	parts += master_wizard.roundend_report()
 	parts += " "
 	parts += "<span class='header'>[master_wizard.owner.name] apprentices and minions were:</span>"

--- a/orbstation/antagonists/wizard_journeyman/wizard_journeyman.dm
+++ b/orbstation/antagonists/wizard_journeyman/wizard_journeyman.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_EMPTY(journeymanstart)
 
 /datum/antagonist/wizard_journeyman
 	name = "\improper Space Wizard Journeyman"
-	roundend_category = "wizards/witches"
+	roundend_category = "wizards"
 	antagpanel_category = "Wizard"
 	job_rank = ROLE_WIZARD
 	antag_hud_name = "wizard"


### PR DESCRIPTION
As the title says. The roundend category for wizards, formerly, was "Wizards/Witches". However, it is my deeply held opinion that these are very different things, which have been conflated together by a mediocre fantasy author deciding that a witch is a female wizard. Not to mention that the antagonist is already only called the "wizard".

Plus, this way there's more space than ever for us to make our own "witch" antagonist that plays by entirely different rules. You know. If we wanted.