### PR TITLE
Felinids now dislike CUCUMBERS and don't dislike RAW food.

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -19,6 +19,8 @@
 #define BUGS (1<<18)
 #define GORE (1<<19)
 
+#define CUCUMBER (1<<20)
+
 /// A list of food type names, in order of their flags
 #define FOOD_FLAGS list( \
 	"MEAT", \
@@ -41,6 +43,7 @@
 	"ORANGES", \
 	"BUGS", \
 	"GORE", \
+	"CUCUMBER", \
 )
 
 /// IC meaning (more or less) for food flags
@@ -65,6 +68,7 @@
 	"Oranges", \
 	"Bugs", \
 	"Gore", \
+	"Cucumbers", \
 )
 
 #define DRINK_NICE 1

--- a/orbstation/objects/items/cucumbers.dm
+++ b/orbstation/objects/items/cucumbers.dm
@@ -1,0 +1,24 @@
+// Implements cucumber food group
+/obj/item/food/grown/cucumber
+	foodtypes = VEGETABLES | CUCUMBER
+
+/obj/item/food/pickle
+	foodtypes = VEGETABLES | CUCUMBER
+
+/obj/item/food/salad/greek_salad
+	foodtypes = VEGETABLES | DAIRY | CUCUMBER
+
+/obj/item/food/springroll
+	foodtypes = GRAIN | VEGETABLES | CUCUMBER
+
+/obj/item/food/meat_poke
+	foodtypes = SEAFOOD | MEAT | VEGETABLES | CUCUMBER
+
+/obj/item/food/fish_poke
+	foodtypes = SEAFOOD | VEGETABLES | CUCUMBER
+
+/obj/item/food/burger/superbite
+	foodtypes = GRAIN | MEAT | DAIRY | CUCUMBER
+
+/obj/item/food/danish_hotdog
+	foodtypes = GRAIN | MEAT | VEGETABLES | CUCUMBER

--- a/orbstation/species/felinid.dm
+++ b/orbstation/species/felinid.dm
@@ -1,0 +1,3 @@
+/datum/species/human/felinid
+	disliked_food = GROSS | CLOTH | NUTS
+	liked_food = SEAFOOD | ORANGES | BUGS | GORE

--- a/orbstation/species/felinid.dm
+++ b/orbstation/species/felinid.dm
@@ -1,3 +1,3 @@
 /datum/species/human/felinid
-	disliked_food = GROSS | CLOTH | NUTS
+	disliked_food = GROSS | CLOTH | CUCUMBER
 	liked_food = SEAFOOD | ORANGES | BUGS | GORE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4864,6 +4864,7 @@
 #include "orbstation\modules\table_shuffle\table_shuffle_config.dm"
 #include "orbstation\modules\table_shuffle\table_shuffle_subsystem.dm"
 #include "orbstation\modules\table_shuffle\table_shuffle_verbs.dm"
+#include "orbstation\objects\items\cucumbers.dm"
 #include "orbstation\objects\items\dancing_pole.dm"
 #include "orbstation\objects\items\spell_injectors.dm"
 #include "orbstation\objects\items\storage.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4887,6 +4887,7 @@
 #include "orbstation\quirks\xcard\xcard-quirks.dm"
 #include "orbstation\quirks\xcard\xenotoxin.dm"
 #include "orbstation\shuttles\shuttles.dm"
+#include "orbstation\species\felinid.dm"
 #include "orbstation\species\jellypeople.dm"
 #include "orbstation\species\lizardpeople.dm"
 #include "orbstation\species\ethereal\respawn_penalties.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/SpeciesPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/SpeciesPage.tsx
@@ -8,6 +8,7 @@ import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
 const FOOD_ICONS = {
   [Food.Bugs]: 'bug',
   [Food.Cloth]: 'tshirt',
+  [Food.Cucumber]: 'staff-snake',
   [Food.Dairy]: 'cheese',
   [Food.Fried]: 'bacon',
   [Food.Fruit]: 'apple-alt',
@@ -27,6 +28,7 @@ const FOOD_ICONS = {
 const FOOD_NAMES: Record<keyof typeof FOOD_ICONS, string> = {
   [Food.Bugs]: 'Bugs',
   [Food.Cloth]: 'Clothing',
+  [Food.Cucumber]: 'Cucumbers',
   [Food.Dairy]: 'Dairy',
   [Food.Fried]: 'Fried food',
   [Food.Fruit]: 'Fruit',

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -7,6 +7,7 @@ export enum Food {
   Breakfast = 'BREAKFAST',
   Bugs = 'BUGS',
   Cloth = 'CLOTH',
+  Cucumber = 'CUCUMBER',
   Dairy = 'DAIRY',
   Fried = 'FRIED',
   Fruit = 'FRUIT',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/7483112/197911674-31faf0f6-d7bb-4259-8d9d-ac77b1aa5732.png)

Felinids are now AMBIVALENT about food which is RAW.
Felinids now DISLIKE food which is CUCUMBERS.
It's scary and looks like a snake.

Cucumber juice is fine because you can't tell it's a cucumber any more.

## Why It's Good For The Game

In ages past a foolish man name Jacquerel made some changes to Felinids in order to facilitate them eating rats.
What he did instead was made it impossible for them to enjoy eating rats.
This ancient mistake of the past has now been remedied.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Felinids now feel ambivalent about whether or not food is cooked, and can happily eat dead mice as God intended. They're a little more distrustful of cucumbers, in exchange.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
