### PR TITLE
Minor Carp Rifts (from the event) can succesfully turn ghosts into Carp

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -218,10 +218,13 @@
 		to_chat(user, span_warning("The rift already summoned enough carp!"))
 		return FALSE
 
+	var/mob/living/newcarp
 	if(!dragon)
-		return
-	var/mob/living/newcarp = new dragon.minion_to_spawn(loc)
-	newcarp.faction = dragon.owner.current.faction
+		newcarp = new /mob/living/simple_animal/hostile/carp(loc)
+	if (dragon)
+		newcarp = new dragon.minion_to_spawn(loc)
+		newcarp.faction = dragon.owner.current.faction
+
 	newcarp.AddElement(/datum/element/nerfed_pulling, GLOB.typecache_general_bad_things_to_easily_move)
 	newcarp.AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!")
 
@@ -229,7 +232,7 @@
 		ckey_list += user.ckey
 	newcarp.key = user.key
 	newcarp.set_name()
-	dragon.carp += newcarp.mind
+	dragon?.carp += newcarp.mind
 	to_chat(newcarp, span_boldwarning("You have arrived in order to assist the space dragon with securing the rifts. Do not jeopardize the mission, and protect the rifts at all costs!"))
 	carp_stored--
 	if(carp_stored <= 0 && charge_state < CHARGE_COMPLETED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where the Minor Carp Rift from the event never allowed any ghosts to take control of fish.

## Why It's Good For The Game

It's fun to be a little fish sometimes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Carp rifts with no associated dragon can still manifest carp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
