### PR TITLE
Mindshielding a player prevents them from becoming a midround antagonist

### DIFF
--- a/orbstation/antagonists/dynamic.dm
+++ b/orbstation/antagonists/dynamic.dm
@@ -54,3 +54,11 @@ GLOBAL_VAR_INIT(traitor_limit_antag_count, 0)
 	if (GLOB.traitor_limit_antag_count > 0)
 		GLOB.traitor_limit_antag_count--
 	return ..()
+
+/// Midround antagonists will not select mindshielded players.
+/datum/dynamic_ruleset/midround/trim_list(list/L = list())
+	. = ..()
+	for (var/mob/candidate as anything in .)
+		if (!HAS_TRAIT(candidate, TRAIT_MINDSHIELD))
+			continue
+		. -= candidate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implanting a player with a mind shield implant will prevent them from becoming a mid round antagonist, until the implant is removed again (alongside its usual effects of protection from brainwashing).
A case of these implants is present in the armoury on every map and contains four implants, so to use them you will need the cooperation of the HoS, Warden, or Captain.

This is meant to be an aid to security feeling overstressed, not a tool to convert the entire crew into dependable allies.
Do not go around pestering people to implant them. Don't implant this into people against their will without confirming it in LOOC.
If people end up abusing this, we will have to take it away again.

## Why It's Good For The Game

Some people have noted that they have difficulty finding time to roleplay while playing as Security because they are always too busy, while also not feeling able to deputise crew because they might turn on them at any moment.
This doesn't entirely eliminate that possibility (this doesn't remove _existing_ antagonist status) but might help them feel a little safer to trust that someone else will go respond to that radio message.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Mind shield implants now prevent a player from becoming a mid-round antagonist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
