### PR TITLE
Made the new quirks system function.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -186,7 +186,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		balance += value
 		new_quirks += quirk_name
 
-	if (balance > 0)
+	//ORBSTATION: Do not check balance, it isn't real.
+	/*if (balance > 0)
 		var/balance_left_to_remove = balance
 
 		for (var/positive_quirk in positive_quirks)
@@ -195,7 +196,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			new_quirks -= positive_quirk
 
 			if (balance_left_to_remove <= 0)
-				break
+				break*/
 
 	// It is guaranteed that if no quirks are invalid, you can simply check through `==`
 	if (new_quirks.len == quirks.len)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -427,8 +427,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			.++
 
 /datum/preferences/proc/validate_quirks()
-	if(GetQuirkBalance() < 0)
-		all_quirks = list()
+	//if(GetQuirkBalance() < 0)
+		//all_quirks = list()
+	return //ORBSTATION: we do not want to check the quirk balance, actually
 
 /// Sanitizes the preferences, applies the randomization prefs, and then applies the preference to the human mob.
 /datum/preferences/proc/safe_transfer_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)


### PR DESCRIPTION
So it turns out, #267 was broken - the data validation on quirks was not edited, so it would not save any configuration of quirks that would not have been possible on the old system. I've removed all checking for quirk balance from the middleware, so now it should function as intended.

We may want to merge this as soon as possible, although if someone wants to make sure I did this right, feel free.