### PR TITLE
Made mindshield implants remove the "hypnotized victim" antag.

### DIFF
--- a/code/modules/antagonists/hypnotized/hypnotized.dm
+++ b/code/modules/antagonists/hypnotized/hypnotized.dm
@@ -17,3 +17,7 @@
 /datum/antagonist/hypnotized/Destroy()
 	QDEL_NULL(trauma)
 	return ..()
+
+/datum/antagonist/hypnotized/on_mindshield(mob/implanter)
+	owner.remove_antag_datum(/datum/antagonist/hypnotized)
+	return COMPONENT_MINDSHIELD_DECONVERTED

--- a/code/modules/antagonists/hypnotized/hypnotized.dm
+++ b/code/modules/antagonists/hypnotized/hypnotized.dm
@@ -17,7 +17,3 @@
 /datum/antagonist/hypnotized/Destroy()
 	QDEL_NULL(trauma)
 	return ..()
-
-/datum/antagonist/hypnotized/on_mindshield(mob/implanter)
-	owner.remove_antag_datum(/datum/antagonist/hypnotized)
-	return COMPONENT_MINDSHIELD_DECONVERTED

--- a/orbstation/antagonists/hypnotized/hypnotized.dm
+++ b/orbstation/antagonists/hypnotized/hypnotized.dm
@@ -1,0 +1,3 @@
+/datum/antagonist/hypnotized/on_mindshield(mob/implanter)
+	owner.remove_antag_datum(/datum/antagonist/hypnotized)
+	return COMPONENT_MINDSHIELD_DECONVERTED

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4813,6 +4813,7 @@
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"
 #include "orbstation\antagonists\heretic\heretic_knowledge.dm"
+#include "orbstation\antagonists\hypnotized\hypnotized.dm"
 #include "orbstation\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"
 #include "orbstation\antagonists\traitor\objectives\final_objective\malware_injection.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says, being implanted with a mindshield implant will now immediately remove the "hypnotized victim" antag from you if you have it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This already works for brainwashed victims, so it's odd that it doesn't work for an extremely similar "mind controlled crew member" antag. Especially since, if you already _have_ a mindshield implant, you can't be hypnotized. It's much more consistent this way.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Mindshield implants now remove "hypnotized" status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
