### PR TITLE
Added an x-card for eye trauma.

### DIFF
--- a/code/__DEFINES/orb/traits.dm
+++ b/code/__DEFINES/orb/traits.dm
@@ -6,8 +6,10 @@
 #define TRAIT_XCARD_XENO_IMMUNE "xcard_xeno_immune"
 // Makes your brain's MMI not fit into a cyborg or AI core
 #define TRAIT_XCARD_BORG_IMMUNE "xcard_borg_immune"
+// Makes the "eyesnatch" objective never select you as a target
+#define TRAIT_XCARD_EYESNATCH_IMMUNE "xcard_eyesnatch_immune"
 // Makes you immune to bioscrambler limb-swapping (used for x-card, but may be applied to species with a unique shape too)
-#define TRAIT_BIOSCRAMBLER_IMMUNE "bioscrambler-immune"
+#define TRAIT_BIOSCRAMBLER_IMMUNE "bioscrambler_immune"
 // Multiplies the time it takes to craft items by FAST_CRAFTER_MOD
 #define TRAIT_FAST_CRAFTER "orb_fast_crafter"
 #define FAST_CRAFTER_MOD 0.5

--- a/code/__DEFINES/orb/traits.dm
+++ b/code/__DEFINES/orb/traits.dm
@@ -6,8 +6,8 @@
 #define TRAIT_XCARD_XENO_IMMUNE "xcard_xeno_immune"
 // Makes your brain's MMI not fit into a cyborg or AI core
 #define TRAIT_XCARD_BORG_IMMUNE "xcard_borg_immune"
-// Makes the "eyesnatch" objective never select you as a target
-#define TRAIT_XCARD_EYESNATCH_IMMUNE "xcard_eyesnatch_immune"
+// Makes the "eyesnatch" objective never select you as a target or offer itself to you; alternate "eyestab" interaction
+#define TRAIT_XCARD_EYE_TRAUMA "xcard_eye_trauma"
 // Makes you immune to bioscrambler limb-swapping (used for x-card, but may be applied to species with a unique shape too)
 #define TRAIT_BIOSCRAMBLER_IMMUNE "bioscrambler_immune"
 // Multiplies the time it takes to craft items by FAST_CRAFTER_MOD

--- a/code/datums/elements/eyestab.dm
+++ b/code/datums/elements/eyestab.dm
@@ -60,25 +60,46 @@
 
 	user.do_attack_animation(target)
 
-	if (target == user)
-		user.visible_message(
-			span_danger("[user] stabs [user.p_them()]self in the eyes with [item]!"),
-			span_userdanger("You stab yourself in the eyes with [item]!"),
-		)
+	if(HAS_TRAIT(target, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
+		if (target == user)
+			user.visible_message(
+				span_danger("[user] stabs [user.p_them()]self in the face with [item]!"),
+				span_userdanger("You stab yourself in the face with [item]!"),
+			)
+		else
+			target.visible_message(
+				span_danger("[user] stabs [target] in the face with [item]!"),
+				span_userdanger("[user] stabs you in the face with [item]!"),
+			)
 	else
-		target.visible_message(
-			span_danger("[user] stabs [target] in the eye with [item]!"),
-			span_userdanger("[user] stabs you in the eye with [item]!"),
-		)
+		if (target == user)
+			user.visible_message(
+				span_danger("[user] stabs [user.p_them()]self in the eyes with [item]!"),
+				span_userdanger("You stab yourself in the eyes with [item]!"),
+			)
+		else
+			target.visible_message(
+				span_danger("[user] stabs [target] in the eye with [item]!"),
+				span_userdanger("[user] stabs you in the eye with [item]!"),
+			)
 
 	if (target_limb)
 		target.apply_damage(damage, BRUTE, target_limb)
 	else
 		target.take_bodypart_damage(damage)
 
-	target.add_mood_event("eye_stab", /datum/mood_event/eye_stab)
+	if(HAS_TRAIT(target, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
+		target.add_mood_event("face_stab", /datum/mood_event/face_stab)
+	else
+		target.add_mood_event("eye_stab", /datum/mood_event/eye_stab)
 
 	log_combat(user, target, "attacked", "[item.name]", "(Combat mode: [user.combat_mode ? "On" : "Off"])")
+
+	if(HAS_TRAIT(target, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
+		if(prob(30)) //30% chance that a piercing wound happens
+			var/type_wound = pick(list(/datum/wound/pierce/severe, /datum/wound/pierce/moderate))
+			target_limb.force_wound_upwards(type_wound)
+		return
 
 	var/obj/item/organ/internal/eyes/eyes = target.getorganslot(ORGAN_SLOT_EYES)
 	if (!eyes)

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -46,6 +46,9 @@
 	heads_of_staff = TRUE
 
 /datum/traitor_objective/eyesnatching/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(HAS_TRAIT(generating_for.current, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
+		return FALSE
+
 	var/list/possible_targets = list()
 	var/try_target_late_joiners = FALSE
 	if(generating_for.late_joiner)
@@ -64,7 +67,7 @@
 		if(possible_target.has_antag_datum(/datum/antagonist/traitor))
 			continue
 
-		if(HAS_TRAIT(possible_target, TRAIT_XCARD_EYESNATCH_IMMUNE)) //ORBSTATION
+		if(HAS_TRAIT(possible_target, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
 			continue
 
 		if(heads_of_staff)
@@ -164,7 +167,7 @@
 	if(!head || !istype(head))
 		return ..()
 
-	if(HAS_TRAIT(victim, TRAIT_XCARD_EYESNATCH_IMMUNE))
+	if(HAS_TRAIT(victim, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
 		to_chat(user, span_warning("You get the feeling that you shouldn't use [src] on [victim]."))
 		return ..()
 

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -64,6 +64,9 @@
 		if(possible_target.has_antag_datum(/datum/antagonist/traitor))
 			continue
 
+		if(HAS_TRAIT(possible_target, TRAIT_XCARD_EYESNATCH_IMMUNE)) //ORBSTATION
+			continue
+
 		if(heads_of_staff)
 			if(!(possible_target.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
@@ -159,6 +162,10 @@
 		return ..()
 
 	if(!head || !istype(head))
+		return ..()
+
+	if(HAS_TRAIT(victim, TRAIT_XCARD_EYESNATCH_IMMUNE))
+		to_chat(user, span_warning("You get the feeling that you shouldn't use [src] on [victim]."))
 		return ..()
 
 	user.do_attack_animation(victim, used_item = src)

--- a/orbstation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/quirks/xcard/xcard-quirks.dm
@@ -34,11 +34,12 @@
 	mob_trait = TRAIT_XCARD_XENO_IMMUNE
 	examine_text = "immune to facehugger implantation, and will be injected with deadly xenotoxin instead."
 
-/datum/quirk/xcard/eyesnatch_immune
-	name = "X-CARD: Eyesnatching"
-	desc = "The traitor objective to steal someone's eyes will never select you as its target, and eyesnatching \
-			devices will not work on you."
-	mob_trait = TRAIT_XCARD_EYESNATCH_IMMUNE
+/datum/quirk/xcard/eye_trauma
+	name = "X-CARD: Eye Trauma"
+	desc = "Various sources of eye trauma will not be applied to you. Particularly, the traitor objective to steal someone's \
+	 eyes will never select you as its target, eyesnatching devices will not work on you, and the objective will \
+	 not be offered to you."
+	mob_trait = TRAIT_XCARD_EYE_TRAUMA
 	//no need for examine text - if someone tries using an eyesnatch device on someone that isn't their target I don't know what to tell them
 
 /*
@@ -65,3 +66,8 @@
 
 	return msg
 
+//alternate mood event for the eyestab x-card
+/datum/mood_event/face_stab
+	description = "I just got stabbed in the face!"
+	mood_change = -4
+	timeout = 3 MINUTES

--- a/orbstation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/quirks/xcard/xcard-quirks.dm
@@ -33,6 +33,14 @@
 	desc = "Facehuggers are unable to infect you, and will instead bite your face, injecting a unique venom."
 	mob_trait = TRAIT_XCARD_XENO_IMMUNE
 	examine_text = "immune to facehugger implantation, and will be injected with deadly xenotoxin instead."
+
+/datum/quirk/xcard/eyesnatch_immune
+	name = "X-CARD: Eyesnatching"
+	desc = "The traitor objective to steal someone's eyes will never select you as its target, and eyesnatching \
+			devices will not work on you."
+	mob_trait = TRAIT_XCARD_EYESNATCH_IMMUNE
+	//no need for examine text - if someone tries using an eyesnatch device on someone that isn't their target I don't know what to tell them
+
 /*
 /datum/quirk/xcard/uncyborgable
 	name = "Cyborg Incompatibility"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new X-Card quirk, "X-CARD: Eye Trauma", which guards against a couple of eye trauma-related things.

When selected, you will never be selected as a target for the eyesnatching objective, and anyone attempting to use an eyesnatcher on you will get a special message and not accomplish anything. Note that, while eyesnatchers already don't work on someone who isn't your target, they normally play out a 5-second progress bar which might still be unpleasant for people with this quirk - so I've made even that impossible. You will ALSO never _receive_ the objective if you're a traitor.

Additionally, any item which has the "eyestab" component on it (deals a special, particularly brutal attack if used targeting someone's eyes) will now do an alternate "face stab" attack instead. Instead of dealing eye damage, the face stab has a 30% chance of causing a pierce wound to the head, either moderate or severe in intensity (chosen randomly).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People are uncomfortable with eye trauma. This is a good one to x-card.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added an X-card for eye trauma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
