### PR TITLE
Lets podpeople choose between water or the fruit juices as a blood type

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -79,6 +79,8 @@
 #define NOSTOMACH 10
 #define NO_DNA_COPY 11
 #define DRINKSBLOOD 12
+// ORB ADDITION, for pod blood preferences
+#define POD_BLOOD 13
 
 /// Use this if you want to change the race's color without the player being able to pick their own color. AKA special color shifting
 #define DYNCOLORS 13

--- a/code/modules/client/preferences/species_features/pod.dm
+++ b/code/modules/client/preferences/species_features/pod.dm
@@ -38,3 +38,25 @@
 	data[SUPPLEMENTAL_FEATURE_KEY] = "hair_color"
 
 	return data
+
+/datum/preference/choiced/pod_blood
+	savefile_key = "feature_pod_blood"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	main_feature_name = "Bloodtype"
+	relevant_species_trait = POD_BLOOD
+
+/datum/preference/choiced/pod_blood/create_default_value()
+	return "Juices" // The juices are a fun and unique thing we have! lets make them a character default
+
+/datum/preference/choiced/pod_blood/init_possible_values()
+	var/list/values = list()
+
+	values["Water"] = "Water"
+	values["Juices"] = "Juices"
+
+	return values
+
+/datum/preference/choiced/pod_blood/apply_to_human(mob/living/carbon/human/target, value)
+	target.dna.features["pod_blood"] = value
+

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -3,7 +3,7 @@
 	name = "\improper Podperson"
 	plural_form = "Podpeople"
 	id = SPECIES_PODPERSON
-	species_traits = list(MUTCOLORS, EYECOLOR, HAS_FLESH, HAS_BONE)
+	species_traits = list(MUTCOLORS, EYECOLOR, HAS_FLESH, HAS_BONE, POD_BLOOD)
 	inherent_traits = list(
 		TRAIT_PLANT_SAFE,
 	)
@@ -114,8 +114,8 @@
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
 			SPECIES_PERK_ICON = "tint",
-			SPECIES_PERK_NAME = initial(exotic_blood.name),
-			SPECIES_PERK_DESC = "Podpeople blood is Water or a random fruit juice, which can make recieving medical treatment harder.",
+			SPECIES_PERK_NAME = "Unique Blood",
+			SPECIES_PERK_DESC = "Podpeople blood can be either water, or a random easily sourcable fruit juice",
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,

--- a/orbstation/_globalvars/pod_bloodtypes.dm
+++ b/orbstation/_globalvars/pod_bloodtypes.dm
@@ -1,8 +1,7 @@
-GLOBAL_LIST_INIT(pod_bloodtypes, list(
-	/datum/reagent/water,
+GLOBAL_LIST_INIT(pod_bloodtypes_juice, list(
 	/datum/reagent/consumable/pineapplejuice,
 	/datum/reagent/consumable/orangejuice,
 	/datum/reagent/consumable/limejuice,
 	/datum/reagent/consumable/tomatojuice,
-	/datum/reagent/consumable/lemonjuice
+	/datum/reagent/consumable/lemonjuice,
 ))

--- a/orbstation/species/podpeople/random_blood.dm
+++ b/orbstation/species/podpeople/random_blood.dm
@@ -1,6 +1,7 @@
-
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
-	exotic_blood = pick(GLOB.pod_bloodtypes)
+	var/value = C.dna?.features?["pod_blood"]
+	if(value == "Water")
+		exotic_blood = /datum/reagent/water
+	else if (value == "Juices")
+		exotic_blood = pick(GLOB.pod_bloodtypes_juice)
 	. = ..()
-
-

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
@@ -84,3 +84,8 @@ export const heterochromatic: Feature<string> = {
   name: 'Heterochromatic (Right Eye) color',
   component: FeatureColorInput,
 };
+
+export const feature_pod_blood: Feature<string> = {
+  name: 'Podperson blood',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request
Gives the podperson species the character option to have either the default water blood or the selection of fruit juices accessible at the drink dispenser.

~~Also makes it easy to add more bloodtype reagent options if we ever want to add them.~~

## Why It's Good For The Game

I like having this be an option, I initially had ideas for other groups of blood reagents to choose from but just having the water/juice selection thing is fine

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

:cl:
add: Podperson blood is now a character preference! Choose between plain water or an easily sourced fruit juice.
/:cl: