### PR TITLE
(Hopefully) fixes AIs being unable to track plural IDs via crew monitor

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -46,6 +46,14 @@
 			continue
 
 		var/name = L.name
+
+		// Orbstation: making tracking work with plural system chips
+		if(ishuman(L))
+			var/mob/living/carbon/human/human_mob = L
+			var/obj/item/card/id/id_card = human_mob.get_idcard(hand_first = FALSE)
+			if(id_card?.plural_system)
+				name = id_card.registered_name
+
 		while(name in track.names)
 			track.namecounts[name]++
 			name = text("[] ([])", name, track.namecounts[name])


### PR DESCRIPTION
## About The Pull Request

This should fix a problem where AIs were unable to track people with IDs that had a plural system chip attached via the crew monitor. Now, if an ID has a plural system chip attached, the game will used the ID's _registered_ name, which remains unaltered by the chip, allowing the character to be tracked as normal.

This modified code should only affect people whose IDs use a plural system chip, so it probably won't break tracking of other mobs (ie, the majority of characters)? Crew monitor tracking appears to be weird and kind of buggy in general, which made testing this really frustrating.

## Why It's Good For The Game

Hopefully makes tracking via crew monitor as an AI more reliable

## Changelog

:cl:
fix: Fixed AIs being unable to track people wearing ID cards with plural system chips via crew monitor.
/:cl:
