### PR TITLE
Character selection dropdown; more character slots.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1 //Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 8
+	var/max_save_slots = 12
 
 	//non-preference stuff
 	var/muted = 0
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			load_path(C.ckey)
 			unlock_content = !!C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 13
+				max_save_slots = 20
 
 	// give them default keybinds and update their movement keys
 	key_bindings = deep_copy_list(GLOB.default_hotkeys)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -1,6 +1,6 @@
 import { exhaustiveCheck } from 'common/exhaustive';
 import { useBackend, useLocalState } from '../../backend';
-import { Button, Stack } from '../../components';
+import { Stack, Dropdown, Flex } from '../../components';
 import { Window } from '../../layouts';
 import { PreferencesMenuData } from './data';
 import { PageButton } from './PageButton';
@@ -19,27 +19,29 @@ enum Page {
 }
 
 const CharacterProfiles = (props: {
-  activeSlot: number;
+  activeSlot: number; // SKYRAT EDIT CHANGE
   onClick: (index: number) => void;
   profiles: (string | null)[];
 }) => {
-  const { profiles } = props;
-
+  const { profiles, activeSlot, onClick } = props;
+  // SKYRAT EDIT CHANGE
   return (
-    <Stack justify="center" wrap>
-      {profiles.map((profile, slot) => (
-        <Stack.Item key={slot}>
-          <Button
-            selected={slot === props.activeSlot}
-            onClick={() => {
-              props.onClick(slot);
-            }}
-            fluid>
-            {profile ?? 'New Character'}
-          </Button>
-        </Stack.Item>
-      ))}
-    </Stack>
+    <Flex align="center" justify="center">
+      <Flex.Item width="25%">
+        <Dropdown
+          width="100%"
+          selected={activeSlot}
+          displayText={profiles[activeSlot]}
+          options={profiles.map((profile, slot) => ({
+            value: slot,
+            displayText: profile ?? 'New Character',
+          }))}
+          onSelected={(slot) => {
+            onClick(slot);
+          }}
+        />
+      </Flex.Item>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
## About The Pull Request

Firstly, character selection is now a dropdown menu rather than a series of buttons. With the number of character slots we have available, the buttons were kind of ugly - especially if we wanted to add anymore. A dropdown is much cleaner and even has scroll buttons! The code for this was directly taken from Skyrat.

![image](https://user-images.githubusercontent.com/105025397/200157055-96105d3e-ddf0-413d-97c3-79e404f0d331.png)

To go along with this PR, I've also listened to player requests and raised the number of character slots again. You now get 12 slots as a regular user, and a whopping _20_ if you're a BYOND subscriber. With all the character options we've been adding, this should hopefully be enough to make all the characters you could ever want. And then some.