### PR TITLE
Spiders can only lay 6 normal eggs each

### DIFF
--- a/orbstation/antagonists/spider/egg_limit.dm
+++ b/orbstation/antagonists/spider/egg_limit.dm
@@ -1,0 +1,43 @@
+// Brood mothers now get 6 eggs each, after that they only get more by eating people
+/datum/action/innate/spider/lay_eggs
+	/// How many eggs you get, these don't come back so use them wisely
+	var/eggs_count = 6
+
+/datum/action/innate/spider/lay_eggs/proc/update_desc()
+	desc = initial(desc)
+	desc += "<BR> You can lay [eggs_count] more of these eggs."
+
+/datum/action/innate/spider/lay_eggs/IsAvailable(feedback = FALSE)
+	. = ..()
+	if (!.)
+		return FALSE
+	if (eggs_count <= 0)
+		if (feedback)
+			owner.balloon_alert(owner, "no eggs left!")
+		return FALSE
+	return TRUE
+
+/datum/action/innate/spider/lay_eggs/lay_egg()
+	. = ..()
+	eggs_count--
+	announce_remaining()
+	UpdateButtons()
+
+/datum/action/innate/spider/lay_eggs/proc/announce_remaining()
+	owner.balloon_alert(owner, "[eggs_count] eggs remaining")
+
+/datum/action/innate/spider/lay_eggs/UpdateButtons(status_only, force)
+	. = ..()
+	update_desc()
+
+/datum/action/innate/spider/lay_eggs/enriched
+	eggs_count = INFINITY // Has its own tracking and this makes keeping it modular easier
+
+// Tracked with a different count
+/datum/action/innate/spider/lay_eggs/enriched/update_desc()
+	desc = initial(desc)
+	desc += "<BR> You can lay [charges] more of these eggs."
+
+// Tracked with a different count
+/datum/action/innate/spider/lay_eggs/enriched/announce_remaining()
+	owner.balloon_alert(owner, "[charges] eggs remaining")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4828,6 +4828,7 @@
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"
 #include "orbstation\antagonists\heretic\heretic_knowledge.dm"
+#include "orbstation\antagonists\spider\egg_limit.dm"
 #include "orbstation\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"
 #include "orbstation\antagonists\traitor\objectives\final_objective\malware_injection.dm"


### PR DESCRIPTION
## About The Pull Request

Spider midwifes can now lay 6 spider eggs ever. If you want more spider eggs you need more midwifes.
They can still lay enriched eggs after eating people, which can hatch into more midwifes.
The event usually spawns two midwife egg clusters, which means the potential for (pending ghost availability) 2 midwifes + 12 additional spider spawns.

## Why It's Good For The Game

Generally speaking Giant Spiders in our rounds have not led to an exciting time, as they're essentially "just xenos but more boring".
The main issue they have is that unlike xenos who essentially need to kill one human per additional recruit (at which point they start rolling pretty hard) spiders can fill a large, hidden area with eggs before ever revealing themselves and then unleash what feels like an infinite tide of spiders because even with few ghosts, they can "respawn" the instant they die.

This change ensures that there's a maximum amount of turtling which they can do before they have to reveal themselves to the crew.

This is definitely a nerf to spiders and they will probably find it much harder to "win", however my philosophy is that this is fine and that as a spider you shouldn't necessarily be expecting that you're going to eat the entire population of the space station, as opposed to scaring them enough to leave (or at least hurting them a lot).
So far spider victories we have seen have not felt particularly interesting or climactic.

## Changelog

:cl:
balance: Spider midwives can only lay 6 regular spider eggs in their lifetime.
/:cl: