### PR TITLE
The return of random brain trauma, but curated?

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,8 +1,7 @@
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
-	weight = 0
-	max_occurrences = 0
+	weight = 25
 	category = EVENT_CATEGORY_HEALTH
 	description = "A crewmember gains a random trauma."
 

--- a/orbstation/antagonists/wizard_journeyman/grand_ritual/grand_event_entries_events.dm
+++ b/orbstation/antagonists/wizard_journeyman/grand_ritual/grand_event_entries_events.dm
@@ -116,6 +116,12 @@
 	event_control_path = /datum/round_event_control/grid_check
 	wizard_message = "Your released energies discharge into the station's power net!"
 
+/datum/grand_event/event/weird_trauma
+	min_escalation = 2
+	max_escalation = 7
+	event_control_path = /datum/round_event_control/brain_trauma
+	wizard_message = "You unleash a terrible curse!"
+
 /datum/grand_event/event/heart_attack
 	min_escalation = 6
 	max_escalation = 7

--- a/orbstation/events/brain_trauma.dm
+++ b/orbstation/events/brain_trauma.dm
@@ -40,3 +40,11 @@
 	for(var/mob/dead/observer/ghost_player in GLOB.player_list)
 		return TRUE
 	return FALSE
+
+/datum/round_event/anomaly/brain_trauma/announce(fake)
+	if (prob(10))
+		priority_announce("Negotiation over cessation of hostilities with the Wizard Federation have broken down. \
+			Our negotiators believe it is possible that one of your staff may have been 'cursed' as retaliation.", "Political Update")
+		return
+	priority_announce("Unusual spikes of psychoactive cosmic radiation have been detected near the station. \
+		Please report any unusual perceptive effects to your resident psychologist.", "Meteorological Update")

--- a/orbstation/events/brain_trauma.dm
+++ b/orbstation/events/brain_trauma.dm
@@ -21,6 +21,7 @@
 		/datum/brain_trauma/special/death_whispers,
 		/datum/brain_trauma/special/existential_crisis,
 		/datum/brain_trauma/special/tenacity,
+		/datum/brain_trauma/special/beepsky,
 		/datum/brain_trauma/severe/hypnotic_trigger,)
 
 	if (ghosts_exist())

--- a/orbstation/events/brain_trauma.dm
+++ b/orbstation/events/brain_trauma.dm
@@ -1,0 +1,41 @@
+// Confine to a specific list of traumas
+/datum/round_event_control/brain_trauma
+	name = "Mysterious Brain Trauma"
+	description = "A crewmember experiences a terrible or occasionally helpful malady."
+
+/datum/round_event/brain_trauma/traumatize(mob/living/carbon/human/victim)
+	var/resistance = pick(
+		50;TRAUMA_RESILIENCE_BASIC,
+		30;TRAUMA_RESILIENCE_SURGERY,
+		20;TRAUMA_RESILIENCE_LOBOTOMY)
+
+	var/trauma_list = list(
+		/datum/brain_trauma/magic/poltergeist,
+		/datum/brain_trauma/magic/antimagic,
+		/datum/brain_trauma/magic/stalker,
+		/datum/brain_trauma/mild/hallucinations,
+		/datum/brain_trauma/mild/healthy,
+		/datum/brain_trauma/special/godwoken,
+		/datum/brain_trauma/special/bluespace_prophet,
+		/datum/brain_trauma/special/quantum_alignment,
+		/datum/brain_trauma/special/death_whispers,
+		/datum/brain_trauma/special/existential_crisis,
+		/datum/brain_trauma/special/tenacity,
+		/datum/brain_trauma/severe/hypnotic_trigger,)
+
+	if (ghosts_exist())
+		trauma_list += /datum/brain_trauma/special/imaginary_friend
+
+	var/trauma_type = pick(trauma_list)
+
+	if (trauma_type != /datum/brain_trauma/severe/hypnotic_trigger)
+		victim.gain_trauma(new trauma_type(), resistance)
+		return
+
+	var/static/list/trigger_phrases = list("Nanotrasen", "Syndicate", "Changeling", "Ian", "Poly", "Wizard", "Shuttle", "Bomb", "Help")
+	victim.gain_trauma(new /datum/brain_trauma/severe/hypnotic_trigger(pick(trigger_phrases)), resistance)
+
+/datum/round_event/brain_trauma/proc/ghosts_exist()
+	for(var/mob/dead/observer/ghost_player in GLOB.player_list)
+		return TRUE
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4864,6 +4864,7 @@
 #include "orbstation\datums\greyscale\config_types\greyscale_configs.dm"
 #include "orbstation\datums\station_traits\ytp_announcer.dm"
 #include "orbstation\events\anomalies.dm"
+#include "orbstation\events\brain_trauma.dm"
 #include "orbstation\events\carp_rift.dm"
 #include "orbstation\events\indoor_weather.dm"
 #include "orbstation\events\portal_storm.dm"


### PR DESCRIPTION
## About The Pull Request

We removed the Random Brain Trauma event from triggering because while it is theoretically medbay enrichment, a lot of the time it simply meant a character receiving extremely debilitating and frankly also uninteresting effects for no reason, unavoidably.

I am tentatively bringing it back, but curated to only do stuff which is kind of weird.
A lot of these are... really not brain traumas by any stretch of the imagination, but perhaps should instead be understood as "weird curses which happen to be cured by some kind of brain ritual".
Accordingly I also reflavoured the event name and description.
Here's what can happen now:

- **Poltergeist**, self-explanatory. Nearby objects intermittently throw themselves at you.
- **Antimagic**, also self-explanatory. You disbelieve in magic so hard that it stops being able to effect you. Almost entirely positive... unless you want to be _performing_ magic that is.
- **Stalker**, you will be pursued by a slow moving but unstoppable imaginary creature which nobody else can see. It Follows.
- **Hallucinations**, self-explanatory. Some people just start with this as a quirk.
- **Healthy**, your health hud stops updating. Also you regain stamina slightly faster, for some reason.
- **Godwoken**, you will occasionally make a random Voice of God proclamation.
- **Bluespace Prophet**, you start to be able to see "rifts" you can activate to teleport around. Actually extremely powerful, with essentially no reason you would want anyone to cure this.
- **Quantum Alignment**, periodically swap places with someone.
- **Existential Crisis**, periodically become temporarily invulnerable but also unable to interact with objects.
- **Tenacity**, you no longer experience being criticall wounded (hard _or_ soft), instead you are totally active until you instantly keel over dead. Again there's not really many downsides to this one because it essentially doubles your effective HP, apart from that you might not see your actual death coming.
- **Imaginary Friend**, the one people really really want to see return. You just get a ghost to chill out with you.

And the ones I am less sure about:
- **Death Whispers**, you sometimes hear what dead people are saying, Deadchat is usually so OOC that unless they catch on, this probably wouldn't be good.
- **Justice**, you hallucinate ethereal beepskys chasing after you, which do a small amount of stamina damage once they catch you. This is maybe too silly, but on the other hand... it is funny and actually less annoying in practice than I expected.
- **Hypnotic Trigger**. every time you hear a specific Code Phrase you become hypnotically suggestible. If it happens again then it overwrites your previous hypnotic suggestion. This is very fun but also has the potential to be really annoying if people keep saying the trigger, however there's no way for anyone to know what it is.

## Why It's Good For The Game

Mostly just that some of these effects are kind of fun (even the ones which are annoying) but we never see them happen.
The weird ones are much more common than they would have been with the old version.
This also means we'll be doing brain surgery more often, and I think it's nice for medbay to have more things to learn how to do.

## Changelog

:cl:
add: Crew have been reporting an increase in unusual psychological events. Always remember that you can contact your station Psychologist if you need someone to talk to.
/:cl:
