### PR TITLE
Flavor text updates

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -22,7 +22,7 @@
 	if(obscure_examine)
 		return list("<span class='warning'>You're struggling to make out any details...")
 
-	var/obscured = check_obscured_slots()
+	var/obscured = ((wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE)))
 
 	//ORBSTATION: Display "short flavor text" before inventory
 	if(!obscured)

--- a/orbstation/orb_modules/flavor_text/antag_flavor_removal.dm
+++ b/orbstation/orb_modules/flavor_text/antag_flavor_removal.dm
@@ -1,0 +1,24 @@
+//Overrides to prevent non-crew antags from yoinking your character's flavor text. They aren't supposed to be your character!
+/datum/antagonist/wizard/equip_wizard()
+	..()
+	var/mob/living/carbon/human/H = owner.current
+	H.dna.features["flavor_text"] = null
+	H.dna.features["flavor_text_short"] = null
+
+/datum/antagonist/wizard_journeyman/equip_wizard()
+	..()
+	var/mob/living/carbon/human/H = owner.current
+	H.dna.features["flavor_text"] = null
+	H.dna.features["flavor_text_short"] = null
+
+/datum/antagonist/abductor/finalize_abductor()
+	..()
+	var/mob/living/carbon/human/H = owner.current
+	H.dna.features["flavor_text"] = null
+	H.dna.features["flavor_text_short"] = null
+
+/datum/antagonist/ert/equipERT()
+	..()
+	var/mob/living/carbon/human/H = owner.current
+	H.dna.features["flavor_text"] = null
+	H.dna.features["flavor_text_short"] = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4902,6 +4902,7 @@
 #include "orbstation\objects\items\radio_gloves.dm"
 #include "orbstation\objects\items\spell_injectors.dm"
 #include "orbstation\objects\items\storage.dm"
+#include "orbstation\orb_modules\flavor_text\antag_flavor_removal.dm"
 #include "orbstation\orb_modules\flavor_text\examine_procs.dm"
 #include "orbstation\orb_modules\flavor_text\flavor_text_prefs.dm"
 #include "orbstation\orb_species\species_defines.dm"


### PR DESCRIPTION
Just a few minor updates to flavor text to address feedback that should have been addressed a while ago. Sorry about that.

Firstly, I've fixed the code for hiding flavor text when your face is covered. This should actually be consistent now. It's possible I still haven't done this quite right, but time will tell for sure.

Secondly, I've stripped flavor text from antags that aren't supposed to be your character (wizards, ERTs, and abductors) but which don't bother to spawn a character with different DNA.

If there's any further things I should fix regarding flavor text, let me know.