### PR TITLE
Revenants now require dead players to spawn.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -738,7 +738,6 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
 	//ORBSTATION EDIT
-	//if(GLOB.dead_mob_list.len < dead_mobs_required)
 	if(GLOB.dead_player_list < dead_players_required)
 		return FALSE
 	return ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -738,7 +738,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
 	//ORBSTATION EDIT
-	if(GLOB.dead_player_list < dead_players_required)
+	if(GLOB.dead_player_list.len < dead_players_required)
 		return FALSE
 	return ..()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -734,9 +734,12 @@
 	var/dead_mobs_required = 20
 	var/need_extra_spawns_value = 15
 	var/list/spawn_locs = list()
+	var/dead_players_required = 3 //ORBSTATION
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
-	if(GLOB.dead_mob_list.len < dead_mobs_required)
+	//ORBSTATION EDIT
+	//if(GLOB.dead_mob_list.len < dead_mobs_required)
+	if(GLOB.dead_player_list < dead_players_required)
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Revenant spawning, currently, only checks the "dead mobs list" to determine if there's enough dead things for a revenant to show up. Unfortunately, there are almost always more than 20 dead mobs in the game at roundstart, from things that spawn dead across the station, all ruins, and Lavaland itself, so this check is pointless. I've changed it to require there to be at least three dead _players_ before a revenant will spawn.

Some version of this could possibly be pushed upstream, though I think someone's working on a more complete rework to revenants there anyway.

## Why It's Good For The Game

We get a revenant spawning nearly every round due to the lack of alternate midround antags, and honestly, it's a little boring that the same ghost appears every round. Requiring the station to have already suffered some amount of death for an evil ghost to appear should cut down on the number of revenants, _and_ make their appearance more appropriate.