### PR TITLE
New Quirk: Augmented

### DIFF
--- a/orbstation/quirks/augmented.dm
+++ b/orbstation/quirks/augmented.dm
@@ -1,0 +1,17 @@
+/datum/quirk/augmented
+	name = "Fully Augmented"
+	desc = "You never asked for this. Or maybe you did. Either way, all your limbs are cybernetic."
+	icon = "bolt-auto"
+	value = 0
+	medical_record_text = "During physical examination, patient was found to have fully augmented limbs."
+
+/datum/quirk/augmented/add_unique()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/)
+
+/datum/quirk/augmented/post_add()
+	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with cybernetic parts. They are roughly analogous to organic limbs. However, \
+	you need to use a welding tool and cables to repair them, instead of standard medical treatment."))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4913,6 +4913,7 @@
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_external.dm"
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_internal.dm"
 #include "orbstation\quirks\alien_prosthesis.dm"
+#include "orbstation\quirks\augmented.dm"
 #include "orbstation\quirks\farsighted.dm"
 #include "orbstation\quirks\good_to_neutral_quirks.dm"
 #include "orbstation\quirks\plurality.dm"


### PR DESCRIPTION
## About The Pull Request

This creates the new perk, "Fully Augmented." This is an alternative to the "Quad Amputee" Quirk that exists in game, which provides you with 4 surplus prosthetic limbs, this provides you with 4 "cyborg" limbs. These are _roughly_ analogous to human limbs, having some positives and some drawbacks that even out.

## Why It's Good For The Game

Right now, without a change to permit the augmentation surgery to swap prostheses to cyborg limbs is an annoying process of amputating every limb and then doing the prosthetic surgery to replace them with a new one. While the idea of negative quirks being a hard-mode for gamers(tm) is an attitude that exists, we'd rather have the option to be metal and not actively weaker than everyone else.

Also, this is admittedly a bit of a stopgap until round-start character augmentations are implemented, and would most likely be rolled back afterwards to save everyone the headache. But there's no reason to not do something if the option is there!

## Changelog

:cl:
add: Adds the "Fully Augmented" Quirk. (Known Issue: There is not a single goddamn icon on https://fontawesome.com/search?o=r&s=solid that works for this quirk and we're tired of sitting on this PR at this point lmao, so out it goes)
/:cl:
