### PR TITLE
Sacrifice victims now receive a custom "Mansus" phobia.

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT(phobia_regexes, list(
 	"strangers" = construct_phobia_regex("strangers"),
 	"the supernatural" = construct_phobia_regex("the supernatural"),
 	"blood" = construct_phobia_regex("blood"),
+	"the mansus" = construct_phobia_regex("the mansus"), //ORBSTATION ADDITION
 ))
 
 GLOBAL_LIST_INIT(phobia_mobs, list(
@@ -96,6 +97,9 @@ GLOBAL_LIST_INIT(phobia_mobs, list(
 		/mob/living/basic/cockroach,
 		/mob/living/simple_animal/hostile/bee,
 	)),
+	"the mansus" = typecacheof(list(
+		/mob/living/simple_animal/hostile/heretic_summon,
+	))
 ))
 
 GLOBAL_LIST_INIT(phobia_objs, list(
@@ -465,6 +469,29 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/reagent_containers/blood,
 		/obj/item/reagent_containers/syringe,
 		/obj/machinery/iv_drip,
+	)),
+
+	"the mansus" = typecacheof(list(
+		/obj/effect/floating_blade,
+		/obj/effect/heretic_influence,
+		/obj/effect/heretic_rune,
+		/obj/effect/rune,
+		/obj/effect/visible_heretic_influence,
+		/obj/item/clothing/head/hooded/cult_hoodie,
+		/obj/item/clothing/mask/madness_mask,
+		/obj/item/clothing/neck/heretic_focus,
+		/obj/item/clothing/neck/eldritch_amulet,
+		/obj/item/clothing/suit/hooded/cultrobes,
+		/obj/item/codex_cicatrix,
+		/obj/item/cult_bastard,
+		/obj/item/melee/cultblade,
+		/obj/item/melee/rune_carver,
+		/obj/item/melee/sickly_blade,
+		/obj/item/toy/eldritch_book,
+		/obj/item/toy/reality_pierce,
+		/obj/item/reagent_containers/cup/beaker/eldritch,
+		/obj/item/gun/ballistic/rifle/lionhunter,
+		/obj/item/melee/touch_attack/mansus_fist,
 	)),
 ))
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -397,7 +397,7 @@
 	sac_target.remove_status_effect(/datum/status_effect/unholy_determination)
 	sac_target.reagents?.del_reagent(/datum/reagent/inverse/helgrasp/heretic)
 	sac_target.clear_mood_event("shadow_realm")
-	sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/supernatural, TRAUMA_RESILIENCE_MAGIC)
+	sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/mansus, TRAUMA_RESILIENCE_MAGIC) //ORBSTATION EDIT: different phobia
 
 	// Orbstation: Gives the target their paraplegia back if it was removed when they got sacrificed.
 	if(sac_target.has_quirk(/datum/quirk/paraplegic))

--- a/orbstation/antagonists/heretic/heretic_phobia.dm
+++ b/orbstation/antagonists/heretic/heretic_phobia.dm
@@ -1,0 +1,25 @@
+// A custom phobia for the heretic to give to people they sacrifice, permanently.
+// Very similar to the supernatural phobia, but more curated - because it's weird that sacrifices make you afraid of
+// wizards and skeletons.
+
+/datum/brain_trauma/mild/phobia/mansus
+	phobia_type = "the mansus"
+	random_gain = FALSE
+	var/list/garbage_text = list(
+		"bF7pTtzKE{xiiR6K?:#e>++",
+		"0X~o$^f?j&W/IFfaFZ]",
+		"HA4>S$t&mDSHANDb~=A#^DS",
+		"\[`}<`j)?(K5#;C",
+		"(/Q(@@@XX/'u-hZ/e)X\"pMPUG@j1*",
+		"FATAL ERROR 20442: THERE IS NOT ENOUGH STORAGE TO REPRESENT THE ARRAY VALUE",
+		"the supernY#@@P^eletont&$m5#animer&q\"I\[_j?a!spiracies",
+		"phobia of phobia of phobia of phobia of ph",
+		"\[REDACTED BY ORDER OF NT DEPARTMENT 333]",
+	)
+
+/datum/brain_trauma/mild/phobia/mansus/New(new_phobia_type)
+	. = ..()
+	gain_text = "<span class='hypnophrase'>Your mind reels. The hands cloud your every thought... Fear grips you.</span>"
+	lose_text = "<span class='notice'>The hands are a distant memory now. You're not sure what you were afraid of...</span>"
+	scan_desc = "phobia of "
+	scan_desc += pick(garbage_text)

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -419,5 +419,12 @@
 	"hemorrhaging",
 	"iv",
 	"transfusion"
+	],
+"the mansus": [
+	"hand",
+	"hands",
+	"mansus",
+	"grasp",
+	"r'ch t'h tr'th"
 	]
 }

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4858,6 +4858,7 @@
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"
 #include "orbstation\antagonists\heretic\heretic_knowledge.dm"
+#include "orbstation\antagonists\heretic\heretic_phobia.dm"
 #include "orbstation\antagonists\spider\egg_limit.dm"
 #include "orbstation\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"


### PR DESCRIPTION
## About The Pull Request

Added a new phobia, "the mansus". This phobia is similar to the "supernatural" phobia, but with a more narrowed focus - causing fear of all heretic items and summons, as well as the Mansus Grasp spell itself, plus a few cult items (I figure the layman can't really tell the difference). This phobia cannot be randomly gained or selected with the Phobia quirk, and is given permanently to sacrifice targets in place of the "supernatural" phobia currently given.

For fun, this phobia has unique text when gained/lost, as well as randomly-selected glitch/error text upon medical scanning.

## Why It's Good For The Game

I think it's a bit silly that getting sacrificed by a heretic makes you suddenly start screaming and freaking out because you saw a wizard hat. I think it's potentially game-ruining for a chaplain to start constantly screaming at their own jumpsuit and weapon. Making a custom, more focused phobia preserves the effect of "people who are sacrificed have a harder time fighting the heretic afterward" without all the baggage that comes with the supernatural phobia.

The idea has been tossed around to replace this phobia with a more custom sort of "curse" that accomplishes the same effect in a more mechanically interesting and flavorful way, and I may try to put something together to that effect in the future. For now, though, I think this is a good stopgap.

## Changelog

:cl:
add: Added a new "mansus" phobia given permanently to sacrifice victims.
/:cl: