### PR TITLE
randomizes orbstation pizza crates

### DIFF
--- a/orbstation/modules/cargo/orders.dm
+++ b/orbstation/modules/cargo/orders.dm
@@ -6,47 +6,87 @@
 					/obj/item/clothing/head/helmet/ham,
 					/obj/item/paper/guides/hamhelmet)
 
-/datum/supply_pack/organic/flatbread
+/// lists of pizza in the same path as the parent of the other pizza crates, so that they can be used for the universal pizza crate
+/datum/supply_pack/organic/pizza/
+	var/static/list/moth_pizza_list = list(
+		/obj/item/food/pizza/mothic_margherita = 10,
+		/obj/item/food/pizza/mothic_firecracker = 10,
+		/obj/item/food/pizza/mothic_five_cheese = 8,
+		/obj/item/food/pizza/mothic_white_pie = 10,
+		/obj/item/food/pizza/mothic_pesto = 10,
+		/obj/item/food/pizza/mothic_garlic = 10
+		)
+
+	var/static/list/flatbread_pizza_list = list(
+		/obj/item/food/pizza/flatbread/rustic = 10,
+		/obj/item/food/pizza/flatbread/italic = 10,
+		/obj/item/food/pizza/flatbread/imperial = 6,
+		/obj/item/food/pizza/flatbread/rawmeat = 10,
+		/obj/item/food/pizza/flatbread/stinging = 9,
+		/obj/item/food/pizza/flatbread/zmorgast = 8,
+		/obj/item/food/pizza/flatbread/fish = 10,
+		/obj/item/food/pizza/flatbread/mushroom = 10,
+		/obj/item/food/pizza/flatbread/nutty = 8,
+		)
+
+/datum/supply_pack/organic/pizza/flatbread
 	name = "Flatbread Crate"
 	desc = "Gay Lizard Medbay Rejoice! A taste of home for Tizirans everywhere. \
 			Best prices this side of the galaxy! All deliveries are guaranteed to be 99% anomaly-free."
-	cost = CARGO_CRATE_VALUE * 10 // Best prices this side of the galaxy.
-	contains = list(/obj/item/pizzabox/imperial_flatbread,
-					/obj/item/pizzabox/rustic_flatbread,
-					/obj/item/pizzabox/italic_flatbread,
-					/obj/item/pizzabox/rustic_flatbread,
-					/obj/item/pizzabox/italic_flatbread,
-				)
 	crate_name = "flatbread crate"
 
-/datum/supply_pack/organic/mothicpizza
+/datum/supply_pack/organic/pizza/flatbread/fill(obj/structure/closet/crate/new_crate)
+	pizza_types = flatbread_pizza_list
+	return ..()
+
+/datum/supply_pack/organic/pizza/mothic
 	name = "Mothic Pizza Crate"
 	desc = "Containing so much cheese that even a Ratfolk might have second thoughts. Not you though. \
 			Best prices this side of the galaxy! All deliveries are guaranteed to be 99% anomaly-free."
-	cost = CARGO_CRATE_VALUE * 10 // Best prices this side of the galaxy.
-	contains = list(/obj/item/pizzabox/mothic_margherita,
-					/obj/item/pizzabox/mothic_firecracker,
-					/obj/item/pizzabox/mothic_five_cheese,
-					/obj/item/pizzabox/mothic_pesto,
-					/obj/item/pizzabox/mothic_white_pie,
-				)
 	crate_name = "mothic pizza crate"
 
-/datum/supply_pack/organic/pizzamedley
+/datum/supply_pack/organic/pizza/mothic/fill(obj/structure/closet/crate/new_crate)
+	pizza_types = moth_pizza_list
+	return ..()
+
+/datum/supply_pack/organic/pizza/medley
 	name = "Universal Pizza Crate"
 	desc = "The Ultimate collection of Pizza and Flatbread, finally brought to stations across the galaxy! \
 			Best prices this side of the galaxy! All deliveries are guaranteed to be 99% anomaly-free."
 	cost = CARGO_CRATE_VALUE * 20 // Best prices this side of the galaxy.
-	contains = list(/obj/item/pizzabox/margherita,
-					/obj/item/pizzabox/mushroom,
-					/obj/item/pizzabox/meat,
-					/obj/item/pizzabox/pineapple,
-					/obj/item/pizzabox/mothic_firecracker,
-					/obj/item/pizzabox/mothic_five_cheese,
-					/obj/item/pizzabox/mothic_pesto,
-					/obj/item/pizzabox/imperial_flatbread,
-					/obj/item/pizzabox/rustic_flatbread,
-					/obj/item/pizzabox/italic_flatbread,
-				)
 	crate_name = "variety pizza crate"
+	infinite_pizza_chance = 2
+	bomb_pizza_chance = 6
 
+/// copies previously made lists of pizza for use in a list of pizzas to eventually fill the pizza crate
+/datum/supply_pack/organic/pizza/medley/fill(obj/structure/closet/crate/new_crate)
+	var/list/medley_flat = flatbread_pizza_list.Copy()
+	var/list/medley_moth = moth_pizza_list.Copy()
+	var/list/medley_human = pizza_types.Copy()
+	var/list/used_pizzas = list()
+	/// loops twice, picking 2 from each, making sure that 2 lizard, 2 moth, and 2 non specialized pizzas are generated
+	for(var/i in 1 to 2)
+		used_pizzas += pick_n_take(medley_flat)
+		used_pizzas += pick_n_take(medley_moth)
+		used_pizzas += pick_n_take(medley_human)
+	var/list/remaining_pizzas = medley_flat + medley_moth + medley_human
+	/// fills the used_ pizzas list with 4 more pizzas for a total of 10
+	for(var/i in 1 to 4)
+		used_pizzas += pick_n_take(remaining_pizzas)
+	/// same pizza code as in upstream
+	for(var/i in 1 to 10)
+		if(add_anomalous(new_crate))
+			continue
+		if(add_boombox(new_crate))
+			continue
+		add_medley_pizza(new_crate, used_pizzas)
+
+/// actually puts the generated pizza list inside of the crate, leaves up to 2 of the genereated pizzas off if an bomb or infinite pizza box is generated
+/datum/supply_pack/organic/pizza/medley/proc/add_medley_pizza(obj/structure/closet/crate/new_crate, list/used_pizzas)
+	var/get_pizza = popleft(used_pizzas)
+	used_pizzas -= get_pizza
+	var/obj/item/pizzabox/new_pizza_box = new(new_crate)
+	new_pizza_box.pizza = new get_pizza
+	new_pizza_box.boxtag = new_pizza_box.pizza.boxtag
+	new_pizza_box.boxtag_set = TRUE
+	new_pizza_box.update_appearance(UPDATE_ICON | UPDATE_DESC)

--- a/orbstation/modules/cargo/orders.dm
+++ b/orbstation/modules/cargo/orders.dm
@@ -90,3 +90,19 @@
 	new_pizza_box.boxtag = new_pizza_box.pizza.boxtag
 	new_pizza_box.boxtag_set = TRUE
 	new_pizza_box.update_appearance(UPDATE_ICON | UPDATE_DESC)
+
+/datum/supply_pack/organic/randomized/dough
+	name = "Bakery Crate"
+	desc = "Contains a randomized collection of dough from all over the universe, for all of your baking needs."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(
+		/obj/item/food/dough = 10,
+		/obj/item/food/cakebatter = 7,
+		/obj/item/food/rootdough = 10,
+		/obj/item/food/mothic_pizza_dough = 4,
+		)
+
+/datum/supply_pack/organic/randomized/dough/fill(obj/structure/closet/crate/newcrate)
+	for(var/i in 1 to 10)
+		var/item = pick(contains)
+		new item(newcrate)

--- a/orbstation/modules/organic/pizzabox.dm
+++ b/orbstation/modules/organic/pizzabox.dm
@@ -16,10 +16,53 @@
 /obj/item/pizzabox/italic_flatbread
 	pizza = /obj/item/food/pizza/flatbread/italic
 
+/obj/item/food/pizza/flatbread/italic
+	boxtag = "Takeaway Flats"
+
 /obj/item/pizzabox/rustic_flatbread
 	pizza = /obj/item/food/pizza/flatbread/rustic
+
+/obj/item/food/pizza/flatbread/rustic
+	boxtag = "Countryside Special"
 
 /obj/item/pizzabox/imperial_flatbread
 	pizza = /obj/item/food/pizza/flatbread/imperial
 
+/obj/item/food/pizza/flatbread/imperial
+	boxtag = "Tizira's Pride"
 
+/obj/item/pizzabox/rawmeat_flatbread
+	pizza = /obj/item/food/pizza/flatbread/rawmeat
+
+/obj/item/food/pizza/flatbread/rawmeat
+	boxtag = "Real Meatlovers"
+
+/obj/item/pizzabox/stinging_flatbread
+	pizza = /obj/item/food/pizza/flatbread/stinging
+
+/obj/item/food/pizza/flatbread/stinging
+	boxtag = "Electric Jamboree"
+
+/obj/item/pizzabox/zmorgast_flatbread
+	pizza = /obj/item/food/pizza/flatbread/zmorgast
+
+/obj/item/food/pizza/flatbread/zmorgast
+	boxtag = "Sweedish Surprise"
+
+/obj/item/pizzabox/fish_flatbread
+	pizza = /obj/item/food/pizza/flatbread/fish
+
+/obj/item/food/pizza/flatbread/fish
+	boxtag = "Grilled Fish"
+
+/obj/item/pizzabox/mushroom_flatbread
+	pizza = /obj/item/food/pizza/flatbread/mushroom
+
+/obj/item/food/pizza/flatbread/mushroom
+	boxtag = "Mushroom Mambo"
+
+/obj/item/pizzabox/nutty_flatbread
+	pizza = /obj/item/food/pizza/flatbread/nutty
+
+/obj/item/food/pizza/flatbread/nutty
+	boxtag = "Korta Kombo"


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/116288367/203667234-414fdc6d-b28f-4285-9e15-d8d9bc35c382.png)
i never want to fucking come back here ever again

## Why It's Good For The Game

any of the 6 moth pizzas and any of the 9 flatbreads can spit out 5 random pizzas instead of a static list of them
they can also both get a chance at being the infinite pizza box or a bomb
the universal pizza crate will ALWAYS have 2 pizzas of every class and then 4 completely random pizzas
This is ALL SUPER IMPROVED from previous orbstation pizza crates
## Changelog

:cl:
qol: NT pizza suppliers have expanded their offerings once more!
balance: reports are coming in of higher likely hood mysterious, dangerous pizzas... (but not robo i didnt add that to these at all)
/:cl:
