### PR TITLE
Disabled three potentially dysphoria-causing disease symptoms.

### DIFF
--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -7,7 +7,8 @@
  * Bonus: Makes the mob grow a massive beard, regardless of gender.
 */
 
-/datum/symptom/beard
+//ORBSTATION: REMOVED WHOLE SYMPTOM
+/*/datum/symptom/beard
 	name = "Facial Hypertrichosis"
 	desc = "The virus increases hair production significantly, causing rapid beard growth."
 	stealth = 0
@@ -32,5 +33,5 @@
 		if(index > 0 && H.facial_hairstyle != beard_order[index])
 			to_chat(H, span_warning("Your chin itches."))
 			H.facial_hairstyle = beard_order[index]
-			H.update_body_parts()
+			H.update_body_parts()*/
 

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -6,7 +6,9 @@
  * Near critcal level
  * Bonus: Makes the mob lose hair.
 */
-/datum/symptom/shedding
+
+//ORBSTATION: REMOVED WHOLE SYMPTOM
+/*/datum/symptom/shedding
 	name = "Alopecia"
 	desc = "The virus causes rapid shedding of head and body hair."
 	stealth = 0
@@ -45,4 +47,4 @@
 		H.hairstyle = "Bald"
 	else
 		H.hairstyle = "Balding Hair"
-	H.update_body_parts()
+	H.update_body_parts()*/

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -7,7 +7,8 @@
  * Bonus: Changes the voice of the affected mob. Causing confusion in communication.
 */
 
-/datum/symptom/voice_change
+//ORBSTATION: REMOVED WHOLE SYMPTOM
+/*/datum/symptom/voice_change
 	name = "Voice Change"
 	desc = "The virus alters the pitch and tone of the host's vocal cords, changing how their voice sounds."
 	stealth = -1
@@ -66,3 +67,4 @@
 	if(scramble_language)
 		A.affected_mob.remove_blocked_language(subtypesof(/datum/language), LANGUAGE_VOICECHANGE)
 		A.affected_mob.remove_all_languages(LANGUAGE_VOICECHANGE) // In case someone managed to get more than one anyway.
+*/

--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -10,13 +10,13 @@ new /datum/disease_ability/action/sneeze,
 new /datum/disease_ability/action/infect,
 new /datum/disease_ability/symptom/mild/cough,
 new /datum/disease_ability/symptom/mild/sneeze,
-new /datum/disease_ability/symptom/medium/shedding,
-new /datum/disease_ability/symptom/medium/beard,
+//new /datum/disease_ability/symptom/medium/shedding,
+//new /datum/disease_ability/symptom/medium/beard,
 new /datum/disease_ability/symptom/medium/hallucigen,
 new /datum/disease_ability/symptom/medium/choking,
 new /datum/disease_ability/symptom/medium/confusion,
 new /datum/disease_ability/symptom/medium/vomit,
-new /datum/disease_ability/symptom/medium/voice_change,
+//new /datum/disease_ability/symptom/medium/voice_change,
 new /datum/disease_ability/symptom/medium/visionloss,
 new /datum/disease_ability/symptom/medium/deafness,
 new /datum/disease_ability/symptom/powerful/narcolepsy,
@@ -326,13 +326,15 @@ new /datum/disease_ability/symptom/powerful/youth
 
 /******MEDIUM******/
 
-/datum/disease_ability/symptom/medium/shedding
-	symptoms = list(/datum/symptom/shedding)
+//ORBSTATION REMOVAL
+/*/datum/disease_ability/symptom/medium/shedding
+	symptoms = list(/datum/symptom/shedding)*/
 
-/datum/disease_ability/symptom/medium/beard
+//ORBSTATION REMOVAL
+/*/datum/disease_ability/symptom/medium/beard
 	symptoms = list(/datum/symptom/beard)
 	short_desc = "Cause all victims to grow a luscious beard."
-	long_desc = "Cause all victims to grow a luscious beard. Ineffective against Santa Claus."
+	long_desc = "Cause all victims to grow a luscious beard. Ineffective against Santa Claus."*/
 
 /datum/disease_ability/symptom/medium/hallucigen
 	symptoms = list(/datum/symptom/hallucigen)
@@ -354,10 +356,11 @@ new /datum/disease_ability/symptom/powerful/youth
 	short_desc = "Cause victims to vomit."
 	long_desc = "Cause victims to vomit. Slightly increases transmissibility. Vomiting also also causes the victims to lose nutrition and removes some toxin damage."
 
-/datum/disease_ability/symptom/medium/voice_change
+//ORBSTATION REMOVAL
+/*/datum/disease_ability/symptom/medium/voice_change
 	symptoms = list(/datum/symptom/voice_change)
 	short_desc = "Change the voice of victims."
-	long_desc = "Change the voice of victims, causing confusion in communications."
+	long_desc = "Change the voice of victims, causing confusion in communications."*/
 
 /datum/disease_ability/symptom/medium/visionloss
 	symptoms = list(/datum/symptom/visionloss)


### PR DESCRIPTION
I've disabled three advanced virus symptoms that I thought likely to cause dysphoria. They are: "beard" (forces your character to grow a beard), "shedding" (makes your character's hair fall out), and "voice change" (makes your character's voice change, causing their name to be randomized in chat).

I'm not certain what impact removing three options may have on things like sentient virus and virology in general, but also, I feel any possible impact is worth _not_ having things that don't do much other than make people uncomfortable in the game. Worst case, we come up with new symptoms later to add in to replace these.