### PR TITLE
"Restored" the lizard phobia.

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_INIT(phobia_regexes, list(
 	"greytide" = construct_phobia_regex("greytide"),
 	"guns" = construct_phobia_regex("guns"),
 	"insects" = construct_phobia_regex("insects"),
+	"lizards" = construct_phobia_regex("lizards"),
 	"ocky icky" = construct_phobia_regex("ocky icky"),
 	"robots" = construct_phobia_regex("robots"),
 	"security" = construct_phobia_regex("security"),
@@ -52,6 +53,7 @@ GLOBAL_LIST_INIT(phobia_regexes, list(
 GLOBAL_LIST_INIT(phobia_mobs, list(
 	"spiders" = typecacheof(list(/mob/living/simple_animal/hostile/giant_spider)),
 	"security" = typecacheof(list(/mob/living/simple_animal/bot/secbot)),
+	"lizards" = typecacheof(list(/mob/living/simple_animal/hostile/lizard)),
 	"skeletons" = typecacheof(list(/mob/living/simple_animal/hostile/skeleton)),
 	"snakes" = typecacheof(list(/mob/living/simple_animal/hostile/retaliate/snake)),
 	"robots" = typecacheof(list(


### PR DESCRIPTION
The complete removal of the "lizards" phobia back in May turned out to be the cause of some random CI test failures this whole time. I've placed it back in a minimal capacity, but left it unselectable and not possible to obtain as a random brain trauma.

The reason I've left it disabled is because there are exceedingly few lizard-related things that are _not_ adjacent to "you are scared of Tizirans" and that sucks.

Given how bizarre and sporadic the CI failure is, I'm not sure this will fix it. I just hope it will.