### PR TITLE
Disabled the random permanent mutation of features.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -746,15 +746,17 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())
 		CRASH("[src] does not have DNA")
-	var/num = rand(1, DNA_UNI_IDENTITY_BLOCKS)
-	dna.set_uni_feature_block(num, random_string(GET_UI_BLOCK_LEN(num), GLOB.hex_characters))
+	//ORBSTATION REMOVAL
+	//var/num = rand(1, DNA_UNI_IDENTITY_BLOCKS)
+	//dna.set_uni_feature_block(num, random_string(GET_UI_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutations_overlay_update=1)
 
 /mob/living/carbon/proc/random_mutate_unique_features()
 	if(!has_dna())
 		CRASH("[src] does not have DNA")
-	var/num = rand(1, DNA_FEATURE_BLOCKS)
-	dna.set_uni_feature_block(num, random_string(GET_UF_BLOCK_LEN(num), GLOB.hex_characters))
+	//ORBSTATION REMOVAL
+	//var/num = rand(1, DNA_FEATURE_BLOCKS)
+	//dna.set_uni_feature_block(num, random_string(GET_UF_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutcolor_update = TRUE, mutations_overlay_update = TRUE)
 
 /mob/living/carbon/proc/clean_dna()

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -47,8 +47,8 @@
 	if (SSradiation.wearing_rad_protected_clothing(H))
 		return
 
-	//H.random_mutate_unique_identity()
-	//H.random_mutate_unique_features()
+	H.random_mutate_unique_identity()
+	H.random_mutate_unique_features()
 
 	if(prob(50))
 		if(prob(90))


### PR DESCRIPTION
Reverts #116 in favor of a better solution. See that PR for the justification.

I've directly disabled the random_mutate_unique procs, which would randomly scramble things like species color and external organs and the like - _permanently_. Previously, I only disabled this for radiation storms, but after complaints from this happening from other sources (particularly unstable mutagen), I've decided to disable it at the source.

In the future, it could be fun to make this work again but in a way where it can be undone by mutadone.