### PR TITLE
Removes random space hole in emergency bar shuttle

### DIFF
--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -572,6 +572,17 @@
 /area/shuttle/escape)
 "oh" = (
 )
+"sy" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/cup/glass/shaker,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
 "EL" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -839,7 +850,7 @@ Zp
 ad
 aY
 aj
-oh
+sy
 be
 bT
 bk


### PR DESCRIPTION
## About The Pull Request

There was a hole here.

## Why It's Good For The Game

It's gone now.

## Changelog

:cl:
fix: Due to patron complaints, bar staff have once again plugged the otherwise popular "hole into space" in the Emergency Bar shuttle using a table of luxury cigars.
/:cl: