### PR TITLE
Batons can be used while wearing insuls

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -122,12 +122,6 @@
 	if(clumsy_check(user, target))
 		return BATON_ATTACK_DONE
 
-	if(!chunky_finger_usable && ishuman(user))
-		var/mob/living/carbon/human/potential_chunky_finger_human = user
-		if(potential_chunky_finger_human.check_chunky_fingers() && user.is_holding(src))
-			balloon_alert(potential_chunky_finger_human, "fingers are too big!")
-			return BATON_ATTACK_DONE
-
 	if(!active || LAZYACCESS(modifiers, RIGHT_CLICK))
 		return BATON_DO_NORMAL_ATTACK
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/71285
People in insuls can use batons again

## Why It's Good For The Game

We havent had a single person use hulk on our server. We'll deal with batonhulk when we get to it

## Changelog

Deletes the code added in the above PR. This may cause minor merge conflicts, but I figure that's probably better than overriding the whole method and then potentially missing out on (now overridden) changes and not realizing it.

:cl:
balance: you can use batons while wearing insuls again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
