### PR TITLE
Readds e-lance crafting recipe

### DIFF
--- a/orbstation/datums/components/crafting/recipes.dm
+++ b/orbstation/datums/components/crafting/recipes.dm
@@ -4,3 +4,16 @@
 	time = 2 SECONDS
 	reqs = list(/obj/item/organ/internal/eyes = 1, /obj/item/stack/sheet/cloth = 1)
 	category = CAT_MISC
+
+/datum/crafting_recipe/lance
+	name = "Explosive Lance (Grenade)"
+	result = /obj/item/spear/explosive
+	reqs = list(/obj/item/spear = 1,
+				/obj/item/grenade = 1)
+	blacklist = list(/obj/item/spear/bonespear, /obj/item/spear/bamboospear)
+	parts = list(/obj/item/spear = 1,
+				/obj/item/grenade = 1)
+	time = 1.5 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the crafting recipe for the e-lance back into the game, effectively reverting https://github.com/tgstation/tgstation/pull/71256 .

## Why It's Good For The Game

E-lances are fun, and nobody here has messed around with them much. If they become a balance problem in the future, we can remove them again.

## Changelog

Readds the e-lance crafting recipe, put in `orbstation/datums/components/crafting/recipes.dm`.

:cl:
add: e-lances are back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
