### PR TITLE
orb escape shuttle bonus round

### DIFF
--- a/_maps/shuttles/emergency_orb.dmm
+++ b/_maps/shuttles/emergency_orb.dmm
@@ -67,7 +67,7 @@
 "cM" = (
 /obj/item/target/alien/anchored,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "db" = (
 /obj/machinery/light/directional/east,
 /obj/structure/rack,
@@ -140,7 +140,7 @@
 /obj/machinery/light/directional/north,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "dF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -179,7 +179,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "eD" = (
 /obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 1
@@ -261,9 +261,13 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "hY" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating/airless,
 /area/shuttle)
+"ic" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape/engine)
 "ig" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -272,8 +276,8 @@
 /area/shuttle)
 "iC" = (
 /obj/machinery/power/shuttle_engine/propulsion,
-/turf/open/floor/plating/airless,
-/area/shuttle)
+/turf/open/floor/plating,
+/area/shuttle/escape/engine)
 "iR" = (
 /obj/machinery/light/directional/east,
 /obj/structure/fireaxecabinet/directional/east,
@@ -373,7 +377,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "mT" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -454,7 +458,7 @@
 	},
 /obj/machinery/flasher/directional/east,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "qy" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral/half,
@@ -475,7 +479,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "rp" = (
-/obj/structure/closet/crate/cardboard,
+/obj/structure/closet/crate/cardboard{
+	anchored = 1
+	},
 /obj/machinery/light/very_dim/directional/east,
 /obj/effect/spawner/random/entertainment/cigar,
 /obj/effect/spawner/random/entertainment/gambling,
@@ -499,10 +505,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle)
 "sx" = (
-/obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/effect/spawner/random/entertainment/toy_figure,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle)
 "sy" = (
@@ -552,15 +558,11 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle)
 "tR" = (
-/obj/structure/closet/crate/secure/engineering,
+/obj/structure/closet/crate/secure/engineering{
+	anchored = 1
+	},
 /obj/effect/spawner/random/engineering/material_rare,
 /obj/effect/spawner/random/engineering/material_cheap,
-/turf/open/floor/mineral/titanium,
-/area/shuttle)
-"tS" = (
-/obj/structure/closet/crate/secure/gear,
-/obj/effect/spawner/random/contraband/armory,
-/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "uh" = (
@@ -579,14 +581,10 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "uD" = (
-/obj/structure/closet{
-	anchored = 1
+/obj/structure/table/wood/shuttle_bar,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
 	},
-/obj/effect/spawner/random/clothing/syndie,
-/obj/effect/spawner/random/clothing/syndie,
-/obj/machinery/light/very_dim/directional/west,
-/obj/effect/spawner/random/clothing/syndie,
-/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "uK" = (
@@ -616,7 +614,7 @@
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/stripes/white,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "wp" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -626,7 +624,7 @@
 	},
 /obj/effect/turf_decal/stripes/white,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "wt" = (
 /obj/structure/sign/flag/pride/lesbian,
 /turf/closed/wall/mineral/titanium,
@@ -683,10 +681,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/shuttle)
 "xT" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "yh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -707,7 +703,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "yy" = (
 /obj/machinery/door/airlock/material/glass,
 /turf/open/floor/mineral/titanium,
@@ -765,7 +761,7 @@
 "AO" = (
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "Bd" = (
 /obj/structure/table,
 /obj/effect/spawner/random/medical/medkit,
@@ -795,7 +791,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "Cd" = (
-/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	anchored = 1
+	},
 /obj/effect/spawner/random/entertainment/plushie_delux,
 /obj/effect/spawner/random/entertainment/plushie_delux,
 /turf/open/floor/mineral/titanium,
@@ -913,7 +911,7 @@
 	},
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "FV" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/mineral/titanium/white,
@@ -924,6 +922,12 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
+/area/shuttle)
+"Gl" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle)
 "Gw" = (
 /obj/structure/chair/comfy/shuttle{
@@ -964,13 +968,17 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle)
 "Kd" = (
-/obj/structure/closet/crate/secure/science,
+/obj/structure/closet/crate/secure/science{
+	anchored = 1
+	},
 /obj/effect/spawner/random/exotic/technology,
 /obj/effect/spawner/random/exotic/languagebook,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "Ks" = (
-/obj/structure/closet/crate/secure/engineering,
+/obj/structure/closet/crate/secure/engineering{
+	anchored = 1
+	},
 /obj/effect/spawner/random/engineering/tool_advanced,
 /obj/effect/spawner/random/engineering/tool_advanced,
 /obj/effect/spawner/random/engineering/tool_advanced,
@@ -1010,11 +1018,9 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle)
 "Ls" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/gun/energy/laser/practice,
+/obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "LH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/magazine,
@@ -1056,14 +1062,23 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "MZ" = (
-/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/closet{
+	anchored = 1
+	},
+/obj/effect/spawner/random/clothing/syndie,
+/obj/effect/spawner/random/clothing/syndie,
+/obj/effect/spawner/random/clothing/syndie,
+/obj/effect/spawner/random/clothing/syndie,
+/obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "Nk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle)
 "No" = (
-/obj/structure/closet/crate/secure/gear,
+/obj/structure/closet/crate/secure/gear{
+	anchored = 1
+	},
 /obj/machinery/light/very_dim/directional/north,
 /obj/effect/spawner/random/contraband/cannabis,
 /obj/effect/spawner/random/contraband/cannabis,
@@ -1112,16 +1127,19 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle)
 "OL" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/practice,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "OU" = (
 /obj/structure/table,
 /obj/item/storage/box/zipties,
+/obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "OX" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "Pt" = (
@@ -1183,12 +1201,12 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "RS" = (
-/obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle)
 "RU" = (
@@ -1200,6 +1218,9 @@
 	},
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/book/manual/wiki/surgery{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle)
 "Sg" = (
@@ -1220,6 +1241,8 @@
 "SJ" = (
 /obj/machinery/griddle,
 /obj/machinery/light/small/directional/west,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/mineral/titanium,
 /area/shuttle)
 "Tb" = (
@@ -1254,7 +1277,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "Tk" = (
 /obj/structure/closet{
 	anchored = 1
@@ -1262,7 +1285,6 @@
 /obj/effect/spawner/random/clothing/costume,
 /obj/effect/spawner/random/clothing/costume,
 /obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
-/obj/machinery/light/very_dim/directional/west,
 /obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/mineral/titanium,
@@ -1273,9 +1295,6 @@
 	},
 /obj/effect/spawner/random/medical/surgery_tool_advanced,
 /obj/effect/spawner/random/medical/surgery_tool_advanced,
-/obj/item/book/manual/wiki/surgery{
-	anchored = 1
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
@@ -1296,11 +1315,11 @@
 /obj/machinery/light/directional/east,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "TD" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "TJ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -1341,7 +1360,7 @@
 /obj/machinery/light/directional/south,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "Vg" = (
 /obj/machinery/door/airlock/command/glass,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
@@ -1440,7 +1459,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle)
 "XK" = (
 /mob/living/simple_animal/drone/snowflake/bardrone,
@@ -1451,7 +1470,7 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle)
+/area/shuttle/escape/brig)
 "YH" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/item/plate/large,
@@ -1487,14 +1506,14 @@ Cz
 WP
 Nk
 KQ
+Nk
 Cz
 Cz
 Cz
-Cz
-Cz
-Ug
 Nk
 Ug
+Nk
+Gl
 Cz
 zW
 zW
@@ -1534,7 +1553,7 @@ Cz
 Cz
 eq
 wp
-OL
+xT
 Nk
 ej
 ej
@@ -1557,9 +1576,9 @@ zW
 Cz
 Cz
 vw
-OL
-OL
-OL
+xT
+xT
+xT
 Yr
 DG
 ej
@@ -1581,7 +1600,7 @@ zW
 zW
 Cz
 dA
-OL
+xT
 FT
 qm
 Tj
@@ -1629,9 +1648,9 @@ Cz
 "}
 (7,1,1) = {"
 Cz
-xT
+Ls
 OU
-OL
+xT
 AO
 cM
 mN
@@ -1656,9 +1675,9 @@ Cz
 Cz
 Ls
 OL
-OL
-OL
-OL
+xT
+xT
+xT
 UZ
 Nk
 tb
@@ -1680,9 +1699,9 @@ Cz
 (9,1,1) = {"
 Cz
 dA
-OL
-OL
-OL
+xT
+xT
+xT
 RE
 Nk
 Nk
@@ -1704,9 +1723,9 @@ Cz
 "}
 (10,1,1) = {"
 Cz
-hY
-OL
-OL
+Ls
+xT
+xT
 RE
 Nk
 Nk
@@ -1730,7 +1749,7 @@ Cz
 (11,1,1) = {"
 Cz
 TA
-OL
+xT
 yt
 Nk
 Nk
@@ -1829,7 +1848,7 @@ Cz
 "}
 (15,1,1) = {"
 Cz
-tS
+hD
 MF
 MF
 MF
@@ -1880,8 +1899,8 @@ Cz
 (17,1,1) = {"
 Cz
 Kd
-jb
 MF
+jb
 MF
 MF
 MF
@@ -1903,7 +1922,7 @@ Gi
 Cz
 "}
 (18,1,1) = {"
-Cz
+hY
 Cz
 qG
 MF
@@ -1950,11 +1969,11 @@ US
 US
 vp
 Cz
-iC
+ic
 "}
 (20,1,1) = {"
 zW
-Cz
+hY
 Cz
 rp
 ch
@@ -1980,7 +1999,7 @@ zW
 (21,1,1) = {"
 zW
 zW
-Cz
+hY
 Cz
 Sr
 KW
@@ -1999,14 +2018,14 @@ uj
 db
 Cz
 Cz
-iC
+ic
 zW
 "}
 (22,1,1) = {"
 zW
 zW
 zW
-Cz
+hY
 Cz
 Cz
 Cd
@@ -2023,7 +2042,7 @@ oz
 Cz
 Cz
 Cz
-iC
+ic
 zW
 zW
 "}
@@ -2033,7 +2052,7 @@ zW
 zW
 zW
 zW
-Cz
+hY
 Cz
 Cz
 mX
@@ -2044,8 +2063,8 @@ Cz
 Cz
 Cz
 Cz
-Cz
-Cz
+Nk
+hY
 zW
 zW
 zW

--- a/_maps/shuttles/emergency_orbescape.dmm
+++ b/_maps/shuttles/emergency_orbescape.dmm
@@ -1,0 +1,258 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle)
+"b" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"d" = (
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	group_name = "OES Captain"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"e" = (
+/obj/machinery/light/directional/south,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/medical/medkit_rare,
+/obj/item/crowbar,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"f" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"g" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"h" = (
+/obj/machinery/button/flasher{
+	id = "ssssssbridgeflash";
+	pixel_x = -26;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"i" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"k" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"n" = (
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"o" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"q" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"s" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"t" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"u" = (
+/turf/template_noop,
+/area/template_noop)
+"w" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"x" = (
+/obj/item/toy/beach_ball/orb{
+	name = "THE ORB";
+	pixel_y = 5;
+	anchored = 1
+	},
+/turf/open/indestructible/permalube,
+/area/shuttle)
+"z" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle)
+"A" = (
+/obj/machinery/door/airlock/command/glass,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/docking_port/mobile/emergency/shuttle_build{
+	dir = 1;
+	name = "orb emergency shuttle escape shuttle"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"D" = (
+/obj/structure/window/reinforced/spawner/west,
+/mob/living/basic/amoung{
+	ai_controller = null;
+	name = "The Captain"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"H" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"K" = (
+/obj/machinery/light/directional/east,
+/obj/structure/fireaxecabinet/directional/east,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"L" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"S" = (
+/obj/machinery/door/airlock/command/glass,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/shutters/indestructible,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"T" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"U" = (
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"W" = (
+/obj/structure/sign/flag/pride/lesbian,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle)
+"X" = (
+/obj/machinery/light/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/fire,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"Y" = (
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+"Z" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle)
+
+(1,1,1) = {"
+u
+u
+a
+a
+S
+a
+a
+a
+a
+u
+"}
+(2,1,1) = {"
+u
+a
+a
+Z
+h
+Y
+o
+f
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+i
+t
+T
+s
+T
+t
+e
+a
+"}
+(4,1,1) = {"
+z
+q
+L
+T
+n
+x
+w
+T
+T
+A
+"}
+(5,1,1) = {"
+a
+a
+k
+g
+d
+D
+T
+g
+X
+z
+"}
+(6,1,1) = {"
+u
+a
+a
+H
+T
+K
+b
+U
+a
+a
+"}
+(7,1,1) = {"
+u
+u
+a
+a
+S
+a
+a
+W
+a
+u
+"}

--- a/orbstation/shuttles/shuttles.dm
+++ b/orbstation/shuttles/shuttles.dm
@@ -8,7 +8,7 @@
 	suffix = "orb"
 	name = "Orb Emergency Shuttle"
 	description = "The ultimate vessel for any and all fans of 'Orb', the OES houses everything one needs to escape in saftey. It is powered by everyone who believes in the ORB."
-	credit_cost = CARGO_CRATE_VALUE * 15
+	credit_cost = CARGO_CRATE_VALUE * 30
 
 // Emag shuttles
 
@@ -18,3 +18,11 @@
 	description = "The ultimate weapon of the Zetan armada, with an elite Zetan Bouncer guard deployed 24/7. The shuttle and the bouncer can both do karate."
 	credit_cost = CARGO_CRATE_VALUE * 10
 	emag_only = TRUE
+
+/datum/map_template/shuttle/emergency/orbescape
+	suffix = "orbescape"
+	name = "OES Escape Shuttle"
+	description = "The secret feature of the Orb Emergency Shuttle, the bridge that can detach in case of dire emergencies. It would be unfortunate if it was the main escape route for an entire station."
+	credit_cost = CARGO_CRATE_VALUE * 5
+	emag_only = TRUE
+	admin_notes = "this things tiny as fuck"


### PR DESCRIPTION
## About The Pull Request

makes the orb emergency shuttle more expensive

adds a new emag shuttle
![image](https://user-images.githubusercontent.com/116288367/205454921-6d27e2a2-c8e2-4a6b-b422-0c164364a9db.png)
the orb emergency shuttle escape shuttle

ive also adjusted the oes proper to actually have marked brig sections, removed the traitor gear spawn, and added in a new drink machine with cups in the storage room

## Why It's Good For The Game

im horrible and impulsive

## Changelog

:cl:
add: new(?) emag'd shuttle, the oes escape shuttle
balance: oes proper is now 30 cargo crates so 6000 credits which is not as expensive as the most expensive ones but more expensive than most. solaris can have little a neopetism in balance
/:cl:
