### PR TITLE
Renamed a culturally insensitive megafauna.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -212,7 +212,7 @@ Difficulty: Hard
 	animate(pixel_z = 0, time = 1)
 	for(var/mob/living/dizzy_target in get_hearers_in_view(7, src) - src)
 		dizzy_target.set_dizzy_if_lower(12 SECONDS)
-		to_chat(dizzy_target, span_danger("The wendigo screams loudly!"))
+		to_chat(dizzy_target, span_danger("Bambi screams loudly!")) //ORBSTATION EDIT
 	SLEEP_CHECK_DEATH(1 SECONDS, src)
 	spiral_attack()
 	update_cooldowns(list(COOLDOWN_UPDATE_SET_MELEE = 3 SECONDS, COOLDOWN_UPDATE_SET_RANGED = 3 SECONDS))
@@ -270,7 +270,7 @@ Difficulty: Hard
 	if(health > 0)
 		return
 	var/obj/effect/portal/permanent/one_way/exit = new /obj/effect/portal/permanent/one_way(starting)
-	exit.id = "wendigo arena exit"
+	exit.id = "Bambi's arena exit" //ORBSTATION EDIT
 	exit.add_atom_colour(COLOR_RED_LIGHT, ADMIN_COLOUR_PRIORITY)
 	exit.set_light(20, 1, COLOR_SOFT_RED)
 	return ..()

--- a/orbstation/overrides/bambi.dm
+++ b/orbstation/overrides/bambi.dm
@@ -1,0 +1,38 @@
+// Overrides the name of an Icebox megafauna to not be culturally insensitive.
+
+/datum/award/achievement/boss/wendigo_kill
+	name = "Bambi Killer"
+	desc = "You're going to have a hard time watching that movie again."
+
+/datum/award/achievement/boss/wendigo_crusher
+	name = "Bambi Crusher"
+	desc = "You're going to have a hard time watching that movie again."
+
+/datum/award/score/wendigo_score
+	name = "Bambis Killed"
+	desc = "Is that the correct plural?"
+
+/datum/map_template/ruin/icemoon/underground/wendigo_cave
+	name = "Bambi's Cave"
+
+/obj/item/clothing/suit/hooded/cloak/godslayer
+	desc = "A suit of armour fashioned from the remnants of a knight's armor, and parts of the monster known as \"Bambi\"."
+
+/obj/item/clothing/head/hooded/cloakhood/godslayer
+	desc = "The horns and skull of \"Bambi\", held together by the remaining icey energy of a demonic miner."
+
+/mob/living/simple_animal/hostile/megafauna/wendigo
+	name = "Bambi"
+	desc = "A demonic, bloodthirsty monster lovingly nicknamed by NanoTrasen miners. You probably aren't going to survive this."
+
+/obj/projectile/colossus/wendigo_shockwave
+	name = "Bambi shockwave"
+
+/obj/item/wendigo_blood
+	name = "bottle of Bambi's blood"
+
+/obj/item/crusher_trophy/wendigo_horn
+	name = "Bambi's horn"
+
+/obj/item/wendigo_skull
+	name = "Bambi's skull"

--- a/strings/arcade.json
+++ b/strings/arcade.json
@@ -197,7 +197,6 @@
 		"Tarantula",
 		"Tomato",
 		"Vampire",
-		"Wendigo",
 		"Werewolf",
 		"Wraith",
 		"Zombie"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4975,6 +4975,7 @@
 #include "orbstation\orb_species\ratfolk\ratfolk_language.dm"
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_external.dm"
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_internal.dm"
+#include "orbstation\overrides\bambi.dm"
 #include "orbstation\quirks\_quirk.dm"
 #include "orbstation\quirks\alien_prosthesis.dm"
 #include "orbstation\quirks\augmented.dm"


### PR DESCRIPTION
## About The Pull Request

I've overridden, in all cases, the name of the "deer monster" Icebox megafauna. Despite it being common in a lot of fiction, its name is not really meant to be said, nor is it meant to be used as a generic type of "spooky deer monster". So, its name is now "Bambi", because I think that's funny. Gallows humor on the part of NanoTrasen mining staff.

## Why It's Good For The Game

I don't think cultural insensitivity makes for particularly good game design.