### PR TITLE
Selectively removes restaurant minigame from round end report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -507,27 +507,35 @@
 		if(!mr_moneybags || mr_moneybags.account_balance < current_acc.account_balance)
 			mr_moneybags = current_acc
 	parts += "<div class='panel stationborder'><span class='header'>Station Economic Summary:</span><br>"
-	parts += "<span class='service'>Service Statistics:</span><br>"
+
 	for(var/venue_path in SSrestaurant.all_venues)
 		var/datum/venue/venue = SSrestaurant.all_venues[venue_path]
 		tourist_income += venue.total_income
-		parts += "The [venue] served [venue.customers_served] customer\s and made [venue.total_income] credits.<br>"
-	parts += "In total, they earned [tourist_income] credits[tourist_income ? "!" : "..."]<br>"
 	log_econ("Roundend service income: [tourist_income] credits.")
+
+	if (tourist_income > 0)
+		parts += "<span class='service'>Service Statistics:</span><br>"
+		for(var/venue_path in SSrestaurant.all_venues)
+			var/datum/venue/venue = SSrestaurant.all_venues[venue_path]
+			if (venue.total_income == 0)
+				continue
+			parts += "The [venue] served [venue.customers_served] customer\s and made [venue.total_income] credits.<br>"
+		parts += "In total, they earned [tourist_income] credits[tourist_income ? "!" : "..."]<br>"
 	switch(tourist_income)
-		if(0)
-			parts += "[span_redtext("Service did not earn any credits...")]<br>"
+		//if(0) ORBSTATION: We don't use this
+			//parts += "[span_redtext("Service did not earn any credits...")]<br>"
 		if(1 to 2000)
 			parts += "[span_redtext("Centcom is displeased. Come on service, surely you can do better than that.")]<br>"
 			award_service(/datum/award/achievement/jobs/service_bad)
 		if(2001 to 4999)
 			parts += "[span_greentext("Centcom is satisfied with service's job today.")]<br>"
 			award_service(/datum/award/achievement/jobs/service_okay)
-		else
+		if(!0)
 			parts += "<span class='reallybig greentext'>Centcom is incredibly impressed with service today! What a team!</span><br>"
 			award_service(/datum/award/achievement/jobs/service_good)
 
-	parts += "<b>General Statistics:</b><br>"
+	if (tourist_income > 0)
+		parts += "<b>General Statistics:</b><br>"
 	parts += "There were [station_vault] credits collected by crew this shift.<br>"
 	if(total_players > 0)
 		parts += "An average of [station_vault/total_players] credits were collected.<br>"


### PR DESCRIPTION
## About The Pull Request

If nobody played the restaurant or bar minigame, the round end report will not include it.
![image](https://user-images.githubusercontent.com/7483112/206576599-2561dcb8-e6b9-4507-a5a8-cb84f48408bd.png)

If someone did, it will only include the venus which did.
![image](https://user-images.githubusercontent.com/7483112/206576610-73ed9d0f-a090-4f22-9d95-330ec38365fd.png)

## Why It's Good For The Game

This feature consistently at first confuses new players and then disappoints them.

## Changelog

:cl:
qol: Centcomm no longer submits disapproving yelp reviews of closed restaurants and cafes.
/:cl:
