### PR TITLE
Disabled the client "suicide" verb.

### DIFF
--- a/orbstation/overrides/misc_overrides.dm
+++ b/orbstation/overrides/misc_overrides.dm
@@ -1,0 +1,3 @@
+// Disables the "suicide" client verb entirely.
+/mob/living/carbon/human/suicide()
+	return

--- a/orbstation/overrides/misc_overrides.dm
+++ b/orbstation/overrides/misc_overrides.dm
@@ -1,3 +1,9 @@
 // Disables the "suicide" client verb entirely.
 /mob/living/carbon/human/suicide()
 	return
+
+// Disables shooting yourself in the mouth with a gun
+/obj/item/gun/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params, bypass_timer)
+	if(user == target)
+		return
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4999,6 +4999,7 @@
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_external.dm"
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_internal.dm"
 #include "orbstation\overrides\bambi.dm"
+#include "orbstation\overrides\misc_overrides.dm"
 #include "orbstation\quirks\_quirk.dm"
 #include "orbstation\quirks\alien_prosthesis.dm"
 #include "orbstation\quirks\augmented.dm"


### PR DESCRIPTION
As the title says, this PR disables the "suicide" verb. This was the subject of some discussion not long ago, with the conclusion that making your character kill themself as a "funny joke" can be kind of upsetting, and spontaneously killing your character is not really something we want to encourage on our server to begin with. This is just a simple override that makes the verb do nothing.

RIP to the only real casualty, the pizza wand's ability to turn yourself into pizza.

EDIT: I've also disabled the ability to commit suicide by targeting your own mouth with a gun. That also shouldn't be there. Mind you, I'd like if there was a way to target yourself with wizard staffs/wands (this was the only way to do that), but a way that sucks less to do would be nice.