### PR TITLE
Chasms II: Return of the Chasms

### DIFF
--- a/orbstation/modules/mining/chasm_rescue.dm
+++ b/orbstation/modules/mining/chasm_rescue.dm
@@ -26,6 +26,10 @@
 	. = ..()
 	player_mobs -= gone
 
+// You can't attack this but monsters which fall in will try anyway
+/obj/effect/abstract/chasm_storage/attack_generic(mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
+	return FALSE
+
 /// 40% of the time fish up a player corpse if one exists
 /obj/item/chasm_detritus/Initialize(mapload)
 	if (prob(40) && retrieve_player_body())

--- a/orbstation/modules/mining/tendril.dm
+++ b/orbstation/modules/mining/tendril.dm
@@ -4,8 +4,11 @@
 		shake_camera(M, 15, 1)
 	playsound(get_turf(src),'sound/effects/explosionfar.ogg', 200, TRUE)
 	visible_message(span_boldannounce("With a last spasm of grasping limbs, the tendril retreats below the ground!"))
-	for(var/turf/near_turf in RANGE_TURFS(2,src))
+	for(var/turf/near_turf in RANGE_TURFS(3,src))
 		if(near_turf.density)
 			continue
-		new /obj/effect/temp_visual/goliath_tentacle/magic(near_turf)
+		if (get_dist(near_turf, src) <= 1)
+			near_turf.TerraformTurf(/turf/open/chasm/lavaland, /turf/open/chasm/lavaland, flags = CHANGETURF_INHERIT_AIR)
+		else
+			new /obj/effect/temp_visual/goliath_tentacle/magic(near_turf)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

In an earlier PR I made it so that Chasms do not instantly delete your mob, instead injuring you so that you can continue playing but might wish to return to the station for a little bit. I also made Tendrils not create chasms on destruction.
The net result of both of these changes was that chasms were both made non-deadly but also functionaly ceased to exist, which removed the purpose of the first change.

This PR reintroduces chasms to Tendrils, but it only creates them in the immediate surrounding area. The main purpose of this is so that you can't just click the tendril and back off, then return to grab your chest. If you do this then the chest will fall into a hole. But don't worry! You can still fish it out.

https://user-images.githubusercontent.com/7483112/208309605-2e8a64d3-817d-4e6e-a119-531ade1b04bb.mp4

It also fixes a bug PL noted where a runtime would happen when a mob fell into a chasm and didn't die, it would then try to fight the chasm and run into an unimplemented proc.

## Why It's Good For The Game

I did not intend to _entirely_ remove Chasms from the game, and it might still be nice to see them occasionally now that they are not instantly deadly.
Also it fixes a bug.

## Changelog

:cl:
fix: Removed a runtime where mobs fell into chasms and tried to attack them
add: Necropolis tendrils will once more create chasms when destroyed, but in a smaller area. Beware!
/:cl:
