### PR TITLE
overriders abductor transform gland

### DIFF
--- a/orbstation/antagonists/transform_gland.dm
+++ b/orbstation/antagonists/transform_gland.dm
@@ -1,0 +1,12 @@
+///overrides the tgstation transform gland in favor of one more anno
+
+/obj/item/organ/internal/heart/gland/transform
+	abductor_hint = "anthropmorphic transmorphosizer. The abductee will stretch and squash, which is disorienting."
+	cooldown_low = 15 SECONDS
+	cooldown_high = 60 SECONDS
+
+/obj/item/organ/internal/heart/gland/transform/activate()
+	owner.AddElement(/datum/element/squish, rand(25 SECONDS, 90 SECONDS), prob(50))
+	owner.emote("scream")
+	owner.adjust_jitter(10 SECONDS)
+	owner.adjust_confusion(10 SECONDS)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4927,6 +4927,7 @@
 #include "orbstation\antagonists\rulesets_latejoin.dm"
 #include "orbstation\antagonists\rulesets_midround.dm"
 #include "orbstation\antagonists\steal_owned_items.dm"
+#include "orbstation\antagonists\transform_gland.dm"
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"
 #include "orbstation\antagonists\heretic\heretic_knowledge.dm"


### PR DESCRIPTION
## About The Pull Request

![dreamseeker_ZdcBH2TIUV](https://user-images.githubusercontent.com/116288367/209245898-6e34aecf-b1dd-4519-85d2-06f9a9f2886d.gif)

It is now the transform gland (but as in art program transform tool)
it also makes you scream, jitters you, and disorients you. but only for 10 seconds.

as a result of doing something a lot less dangerous it has a low cooldown

## Why It's Good For The Game

we dont want forceful transformations and while our abductor players have been good at avoiding using the transform gland we should just not have that risk happen

## Changelog

:cl:
add: new version of the transform gland for abductors
del: old version of the transform gland has been overridden
/:cl:

