### PR TITLE
Midround Enemies Adjustments

### DIFF
--- a/orbstation/antagonists/rulesets_latejoin.dm
+++ b/orbstation/antagonists/rulesets_latejoin.dm
@@ -18,10 +18,4 @@
 //////////////////////////////////////////////
 
 /datum/dynamic_ruleset/latejoin/heretic_smuggler
-	enemy_roles = list(
-		JOB_HEAD_OF_SECURITY,
-		JOB_DETECTIVE,
-		JOB_WARDEN,
-		JOB_SECURITY_OFFICER,
-	)
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1) // the game is supposed to make one of your sac targets a security member

--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -59,6 +59,14 @@
 	required_candidates = 1
 	weight = 5
 	cost = 12
+	enemy_roles = list(
+		JOB_CAPTAIN,
+		JOB_DETECTIVE,
+		JOB_HEAD_OF_SECURITY,
+		JOB_SECURITY_OFFICER,
+		JOB_WARDEN,
+		JOB_CHAPLAIN,
+	)
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard_journeyman/ready(forced = FALSE)
 	if (!check_candidates())
@@ -94,12 +102,6 @@
 		JOB_AI,
 		JOB_CYBORG,
 		ROLE_POSITRONIC_BRAIN,
-	)
-	enemy_roles = list(
-		JOB_HEAD_OF_SECURITY,
-		JOB_DETECTIVE,
-		JOB_WARDEN,
-		JOB_SECURITY_OFFICER,
 	)
 	requirements = list(10,101,50,40,35,20,20,15,10,10)
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1) // the game is supposed to make one of your sac targets a security member


### PR DESCRIPTION
## About The Pull Request

Adds Captain to list of enemies for Waking Heretic (now matching the default enemies list)
Adds Chaplain to list of enemies for Journeyman Wizard

## Why It's Good For The Game

Makes some rare rulesets marginally more common, we like to see them
I am 99% sure that virtually everyone on the server already thought Captain was on the midround Heretic enemy list

## Changelog

:cl:
balance: Waking Heretics consider "Captain" a valid enemy
balance: Wizard Journeymen consider "Chaplain" a valid enemy
/:cl: