### PR TITLE
Kidnapees are healed on departure

### DIFF
--- a/orbstation/antagonists/traitor/objectives/kidnapping.dm
+++ b/orbstation/antagonists/traitor/objectives/kidnapping.dm
@@ -3,3 +3,9 @@
 	sent_mob.heal_and_revive(80) // They'll heal you but mostly only enough to get out of crit
 	sent_mob.fully_heal(HEAL_ORGANS|HEAL_WOUNDS|HEAL_BLOOD|HEAL_TEMP|HEAL_ALL_REAGENTS)
 	return ..()
+
+/datum/traitor_objective/kidnapping/return_victim(mob/living/carbon/human/sent_mob)
+	if(!sent_mob || QDELETED(sent_mob))
+		return
+	. = ..()
+	to_chat(sent_mob, span_hypnophrase("Your mind is a blur... you have no memory of the moments before your kidnapping or the identity of your assailant."))

--- a/orbstation/antagonists/traitor/objectives/kidnapping.dm
+++ b/orbstation/antagonists/traitor/objectives/kidnapping.dm
@@ -1,0 +1,4 @@
+// Fully heal kidnapees, the syndicate don't leave evidence of tampering
+/datum/traitor_objective/kidnapping/handle_victim(mob/living/carbon/human/sent_mob)
+	sent_mob.fully_heal(HEAL_DAMAGE|HEAL_ORGANS|HEAL_WOUNDS|HEAL_BLOOD|HEAL_TEMP|HEAL_ALL_REAGENTS)
+	return ..()

--- a/orbstation/antagonists/traitor/objectives/kidnapping.dm
+++ b/orbstation/antagonists/traitor/objectives/kidnapping.dm
@@ -1,4 +1,5 @@
 // Fully heal kidnapees, the syndicate don't leave evidence of tampering
 /datum/traitor_objective/kidnapping/handle_victim(mob/living/carbon/human/sent_mob)
-	sent_mob.fully_heal(HEAL_DAMAGE|HEAL_ORGANS|HEAL_WOUNDS|HEAL_BLOOD|HEAL_TEMP|HEAL_ALL_REAGENTS)
+	sent_mob.heal_and_revive(80) // They'll heal you but mostly only enough to get out of crit
+	sent_mob.fully_heal(HEAL_ORGANS|HEAL_WOUNDS|HEAL_BLOOD|HEAL_TEMP|HEAL_ALL_REAGENTS)
 	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4960,6 +4960,7 @@
 #include "orbstation\antagonists\spider\egg_limit.dm"
 #include "orbstation\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\antagonists\traitor\objectives\double_cross.dm"
+#include "orbstation\antagonists\traitor\objectives\kidnapping.dm"
 #include "orbstation\antagonists\traitor\objectives\final_objective\malware_injection.dm"
 #include "orbstation\antagonists\wizard_journeyman\journeyman_outfit.dm"
 #include "orbstation\antagonists\wizard_journeyman\wizard_apartment.dm"


### PR DESCRIPTION
## About The Pull Request

We already made kidnapping _only_ work for living players to differentiate it from assassination with an extra step, but we had a couple of rounds where people bled to death and decayed wherever they were deposited.

Now the same proc which prints a message about being interrogated also:
- Revive you if you have died in transit somehow
- Heal you until you have no more than 80 damage (so out of crit, but still quite hurt)
- Repairs dying organs (a bonus for smokers)
- Purges all chems (whatever they're doing to get information out of your brain sobers you up)
- Fixes wounds 
- Places you at a healthy level of blood
- Puts you at a healthy temperature

## Why It's Good For The Game

It feels bad to pull off a kidnapping and then learn that they were essentially round removed by accident due to bleeding to death and being deposited in the ordnance freezer chamber.

## Changelog

:cl:
balance: Once the Syndicate are done interrogating you following a kidnapping, they'll fix you up to hide any evidence. 
/:cl:
