### PR TITLE
standardizes pizza crate chances of being anomalous/bomb

### DIFF
--- a/orbstation/modules/cargo/orders.dm
+++ b/orbstation/modules/cargo/orders.dm
@@ -61,8 +61,6 @@
 			Best prices this side of the galaxy! All deliveries are guaranteed to be 99% anomaly-free."
 	cost = CARGO_CRATE_VALUE * 20 // Best prices this side of the galaxy.
 	crate_name = "variety pizza crate"
-	infinite_pizza_chance = 2
-	bomb_pizza_chance = 6
 
 /// copies previously made lists of pizza for use in a list of pizzas to eventually fill the pizza crate
 /datum/supply_pack/organic/pizza/medley/fill(obj/structure/closet/crate/new_crate)


### PR DESCRIPTION
## About The Pull Request

removes edits that scales rng chance of pizza crates hving anomaly or bomb off of amount of pizza getting

## Why It's Good For The Game

people keep complaining about it

no higher anomalous chance because i dont want to only boost the good one

note: this does not change anything about arnold, energy, or weed pizzas. bomb and anomaly pizza will still show up.

## Changelog

:cl:
del: removed edited vars for universal pizza crate
/:cl:

