### PR TITLE
Translation key expansion pack!

### DIFF
--- a/orbstation/objects/items/radio_keys.dm
+++ b/orbstation/objects/items/radio_keys.dm
@@ -71,3 +71,33 @@
 	desc = "A hi-tech radio encryption key that allows the wearer to understand sylvan when the radio is worn."
 	cost = PAYCHECK_CREW * 12
 	contains = list(/obj/item/encryptionkey/pod)
+
+/datum/supply_pack/misc/translation_key_pack
+	name = "Surplus Translation Key Crate"
+	desc = "Crew having trouble understanding each other? This box contains three high-tech radio translation keys, \
+			in fine condition despite sitting in a dusty warehouse for four years. You don't get to pick the languages \
+			they translate to, but they're at a discount!"
+	cost = CARGO_CRATE_VALUE * 7.5
+	contains = list()
+
+/// list of keys that might appear, slightly weighted
+	var/list/key_types = list(
+		/obj/item/encryptionkey/moth = 3,
+		/obj/item/encryptionkey/tiziran = 3,
+		/obj/item/encryptionkey/ethereal = 3,
+		/obj/item/encryptionkey/felinid = 3,
+		/obj/item/encryptionkey/ratfolk = 3,
+		/obj/item/encryptionkey/plasmaman = 2,
+		/obj/item/encryptionkey/slime = 2,
+		/obj/item/encryptionkey/pod = 2,
+		/obj/item/encryptionkey/uncommon = 2,
+		/obj/item/encryptionkey/common = 1,
+	)
+
+/datum/supply_pack/misc/translation_key_pack/fill(obj/structure/closet/crate/new_crate)
+	. = ..()
+	var/list/rng_key_list = key_types.Copy()
+	for(var/i in 1 to 3)
+		var/randomize_key = pick_weight(rng_key_list)
+		rng_key_list -= randomize_key
+		new randomize_key(new_crate)

--- a/orbstation/objects/items/radio_keys.dm
+++ b/orbstation/objects/items/radio_keys.dm
@@ -1,0 +1,73 @@
+// A set of extra encryption keys for orbstation
+
+/obj/item/encryptionkey/ratfolk
+	name = "\improper Ratfolk translation key"
+	desc = "An encryption key that automatically encodes ratvaric heard through the radio into common. The signal's a little squeaky."
+	icon_state = "translation_cypherkey"
+	translated_language = /datum/language/ratvaric
+	greyscale_config = null
+	greyscale_colors = null
+
+/obj/item/encryptionkey/common
+	name = "\improper Galactic Common translation key"
+	desc = "An encryption key that automatically translates common heard through the radio. The signal's bog standard."
+	icon_state = "translation_cypherkey"
+	translated_language = /datum/language/common
+	greyscale_config = null
+	greyscale_colors = null
+
+/obj/item/encryptionkey/uncommon
+	name = "\improper Galactic Uncommon translation key"
+	desc = "An encryption key that automatically translates uncommon heard through the radio into common. The signal's a bit indistinct."
+	icon_state = "translation_cypherkey"
+	translated_language = /datum/language/uncommon
+	greyscale_config = null
+	greyscale_colors = null
+
+/obj/item/encryptionkey/slime
+	name = "\improper Slime translation key"
+	desc = "An encryption key that automatically translates slimetongue heard through the radio. The signal's strangely wet."
+	icon_state = "translation_cypherkey"
+	translated_language = /datum/language/slime
+	greyscale_config = null
+	greyscale_colors = null
+
+/obj/item/encryptionkey/pod
+	name = "\improper Podperson translation key"
+	desc = "An encryption key that automatically translates sylvan heard through the radio. The signal sounds like rustling leaves."
+	icon_state = "translation_cypherkey"
+	translated_language = /datum/language/sylvan
+	greyscale_config = null
+	greyscale_colors = null
+
+// Goodie packs for each key
+
+/datum/supply_pack/goody/ratfolk_encryption_key
+	name = "Ratvaric radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand ratvaric when the radio is worn."
+	cost = PAYCHECK_CREW * 12
+	contains = list(/obj/item/encryptionkey/ratfolk)
+
+/datum/supply_pack/goody/common_encryption_key
+	name = "Galactic Common radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand galactic common when the radio is worn."
+	cost = PAYCHECK_CREW * 16 //expensive because Common is already widely spoken - less demand
+	contains = list(/obj/item/encryptionkey/common)
+
+/datum/supply_pack/goody/uncommon_encryption_key
+	name = "Galactic Uncommon radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand galactic uncommon when the radio is worn."
+	cost = PAYCHECK_CREW * 12
+	contains = list(/obj/item/encryptionkey/uncommon)
+
+/datum/supply_pack/goody/slime_encryption_key
+	name = "Slime radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand slimetongue when the radio is worn."
+	cost = PAYCHECK_CREW * 12
+	contains = list(/obj/item/encryptionkey/slime)
+
+/datum/supply_pack/goody/podperson_encryption_key
+	name = "Sylvan radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand sylvan when the radio is worn."
+	cost = PAYCHECK_CREW * 12
+	contains = list(/obj/item/encryptionkey/pod)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5058,6 +5058,7 @@
 #include "orbstation\objects\items\pride_flags.dm"
 #include "orbstation\objects\items\quirk_posters.dm"
 #include "orbstation\objects\items\radio_gloves.dm"
+#include "orbstation\objects\items\radio_keys.dm"
 #include "orbstation\objects\items\spell_injectors.dm"
 #include "orbstation\objects\items\storage.dm"
 #include "orbstation\orb_modules\flavor_text\antag_flavor_removal.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds five new radio translation keys that you can order as cargo goodies: Common, Uncommon, Ratfolk, Slime, and Podperson. As with other translation keys, these grant the given languages while placed inside of a worn headset.

![image](https://user-images.githubusercontent.com/105025397/210459865-89a5b6f5-8c7e-4d62-bf42-7dc542a5b7dd.png)

Note that the Galactic Common key is slightly more expensive than the others - both because it makes sense that less of these are made, and because it negates the effect of the Foreigner quirk (while still making it possible to overcome).

Also adds the "Surplus Translation Key Crate", a crate orderable through cargo for 1500 cr that contains three randomly-chosen translation keys. Useful if you don't particularly care _which_ languages you want to translate, and it's at a discount!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As is, the Foreigner quirk is one of those that makes the game almost impossible to play, since you can't communicate with basically anyone if you have it. In a game that is largely about communication. This grants a method to overcome that without making the quirk entirely pointless.

As for the other four keys, I wanted there to be keys for all of our roundstart species, and I figured one for Uncommon couldn't hurt as well. Given how rarely Uncommon is spoken, that one in particular could have extra utility in secret communication with a buddy. Just watch out for that pesky Curator...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added five new radio translation keys, as well as a surplus box containing a random three.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
