### PR TITLE
Made the alternate jester outfit obtainable.

### DIFF
--- a/orbstation/clothing/vendors.dm
+++ b/orbstation/clothing/vendors.dm
@@ -21,6 +21,15 @@
 	orb_premium = list(
 		/obj/item/clothing/suit/hooded/wintercoat/cosmic = 1,
 	)
+	orb_product_categories = list(
+		list(
+			"name" = "Entertainers",
+			"products" = list(
+				/obj/item/clothing/under/rank/civilian/clown/jester/alt = 1,
+				/obj/item/clothing/head/costume/jester/alt = 1,
+			),
+		),
+	)
 
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	orb_products = list(

--- a/orbstation/overrides/clothing.dm
+++ b/orbstation/overrides/clothing.dm
@@ -1,0 +1,5 @@
+// Anything that modifies existing clothing.
+
+//Makes the alternate jester cap hide hair and ears.
+/obj/item/clothing/head/costume/jester/alt
+	flags_inv = HIDEEARS|HIDEHAIR

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5103,6 +5103,7 @@
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_external.dm"
 #include "orbstation\orb_species\ratfolk\ratfolk_organs_internal.dm"
 #include "orbstation\overrides\bambi.dm"
+#include "orbstation\overrides\clothing.dm"
 #include "orbstation\overrides\languages.dm"
 #include "orbstation\overrides\misc_overrides.dm"
 #include "orbstation\quirks\_quirk.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it possible to buy the alternate jester outfit from the AutoDrobe. This was already in the game, but not obtainable anywhere - for some reason.

![image](https://user-images.githubusercontent.com/105025397/211184124-3cf91f6f-fbe9-4c60-8964-2aea0bb722ea.png)

Also edited flags to make the hat cover up hair and ears as it should.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a good look. Why not?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Made the alternate jester suit possible to obtain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
