### PR TITLE
Shows whitetexted objectives in default antag roundend report

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -275,11 +275,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	report += printplayer(owner)
 
-	/** ORBSTATION: We don't want to report success or failure
-	var/objectives_complete = TRUE
+	// ORBSTATION: We don't want to report success or failure
+	//var/objectives_complete = TRUE
 	if(objectives.len)
 		report += printobjectives(objectives)
-		for(var/datum/objective/objective in objectives)
+	/*	for(var/datum/objective/objective in objectives)
 			if(!objective.check_completion())
 				objectives_complete = FALSE
 				break


### PR DESCRIPTION

![kép](https://user-images.githubusercontent.com/2676196/211366271-3c6a6baa-8db9-45d1-8f0e-18a526397fcd.png)

 The objectives of antags who use the default roundend_report() were not displayed. This PR fixes that.