### PR TITLE
Removes null-coalescing operator from table shuffle since it seems to be runtiming

### DIFF
--- a/orbstation/modules/table_shuffle/table_shuffle_subsystem.dm
+++ b/orbstation/modules/table_shuffle/table_shuffle_subsystem.dm
@@ -415,8 +415,9 @@ SUBSYSTEM_DEF(table_shuffle)
 				item.forceMove(O)
 				item_log[ITEMLOG_DESTINATION_STRUCTURE]=O
 				item = log_decay(opt,item,item_log) // may return null
-				item?.pixel_x = 0
-				item?.pixel_y = 0
+				if(isobj(item))
+					item.pixel_x = 0
+					item.pixel_y = 0
 				return
 			// otherwise fall through
 		if(2)


### PR DESCRIPTION
## About The Pull Request

Fixing one runtime that PL found, probably due to out of date BYOND, but whatever.