### PR TITLE
Throwing arm does not increase throw speed

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -195,8 +195,6 @@
 		power_throw--
 	if(HAS_TRAIT(thrown_thing, TRAIT_DWARF))
 		power_throw++
-	if(has_throwingarm)
-		power_throw++
 	if(neckgrab_throw)
 		power_throw++
 	visible_message(span_danger("[src] throws [thrown_thing][power_throw ? " really hard!" : "."]"), \

--- a/orbstation/quirks/throwing_arm.dm
+++ b/orbstation/quirks/throwing_arm.dm
@@ -1,6 +1,6 @@
 /datum/quirk/throwingarm
 	name = "Throwing Arm"
-	desc = "Your arms have a lot of heft to them! Objects that you throw just always seem to fly further and faster than everyone elses, and you never miss a toss."
+	desc = "Your arms have a lot of heft to them! Objects that you throw just always seem to fly further than everyone elses, and you never miss a toss."
 	icon = "baseball"
 	value = 5
 	mob_trait = TRAIT_THROWINGARM


### PR DESCRIPTION
 
## About The Pull Request

This PR removes the throw speed bonus from power throw.

## Why It's Good For The Game

This adds embed chance to items that shouldn't usually have it, and further increases the base chance on them by 10%... The throw range is okay, imho. Sol is on vacation so I will take it upon me to fix it :pensive:
