### PR TITLE
sandboxvend - reactive armor fix

### DIFF
--- a/orbstation/modules/vending/sandboxvendor.dm
+++ b/orbstation/modules/vending/sandboxvendor.dm
@@ -59,7 +59,7 @@
 				/obj/item/clothing/shoes/magboots/advance = 999,
 				/obj/item/radio/headset/headset_cent/commander = 999,
 				/obj/item/storage/belt/military = 999,
-				/obj/item/clothing/suit/armor/reactive/teleport = 999,
+				/obj/item/clothing/suit/armor/reactive = 999,
 				/obj/item/assembly/signaler/anomaly/pyro = 999,
 				/obj/item/assembly/signaler/anomaly/grav = 999,
 				/obj/item/assembly/signaler/anomaly/flux = 999,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

small fix to reactive armor in the vendor accidentally being set to have a core already

## Why It's Good For The Game

a

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: wrong entry in sandboxvend causing reactive armor to have a core already
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
