### PR TITLE
Changelings now store their targets' height.

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -510,6 +510,7 @@
 
 	new_profile.age = target.age
 	new_profile.physique = target.physique
+	new_profile.height = target.get_mob_height() //ORBSTATION EDIT
 
 	// Grab the target's quirks.
 	for(var/datum/quirk/target_quirk as anything in target.quirks)
@@ -750,6 +751,8 @@
 	user.physique = chosen_profile.physique
 	user.grad_style = LAZYLISTDUPLICATE(chosen_profile.grad_style)
 	user.grad_color = LAZYLISTDUPLICATE(chosen_profile.grad_color)
+
+	user.set_mob_height(chosen_profile.height) //ORBSTATION EDIT
 
 	chosen_dna.transfer_identity(user, TRUE)
 

--- a/orbstation/modules/client/preferences/height_pref.dm
+++ b/orbstation/modules/client/preferences/height_pref.dm
@@ -22,3 +22,11 @@
 
 /datum/preference/choiced/height/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_mob_height(height_list[value])
+
+//Adds height to the changeling profile so that all changeling disguises forever are not blown.
+/datum/changeling_profile
+	var/height
+
+/datum/changeling_profile/copy_profile(datum/changeling_profile/new_profile)
+	..()
+	new_profile.height = height


### PR DESCRIPTION
I screwed up when implementing heights as a character preference, and did not account for changelings. This would result in changelings always being of their starting height, regardless of who they're trying to mimic. While funny, this is obviously not desirable. This is now fixed.