### PR TITLE
Increases cost of orb shuttle

### DIFF
--- a/orbstation/shuttles/shuttles.dm
+++ b/orbstation/shuttles/shuttles.dm
@@ -1,14 +1,8 @@
-/datum/map_template/shuttle/emergency/fish
-	suffix = "fish"
-	name = "Angler's Choice Emergency Shuttle"
-	description = "Trades such amenities as 'storage space' and 'sufficient seating' for an artifical environment ideal for fishing, plus ample supplies."
-	credit_cost = CARGO_CRATE_VALUE * 10
-
 /datum/map_template/shuttle/emergency/orb
 	suffix = "orb"
 	name = "Orb Emergency Shuttle"
 	description = "The ultimate vessel for any and all fans of 'Orb', the OES houses everything one needs to escape in saftey. It is powered by everyone who believes in the ORB."
-	credit_cost = CARGO_CRATE_VALUE * 30
+	credit_cost = 7999
 
 // Emag shuttles
 


### PR DESCRIPTION
## About The Pull Request

Makes the Orb Shuttle more expensive.
Also I deleted the redefinition of the angler shuttle because it already exists upstream so that isn't doing anything.

## Why It's Good For The Game

It's an extremely generous shuttle, we underpriced it for a while but it should take a _modicum_ of cargo effort to be able to buy it. It's still cheap as giant luxury shuttles go.

## Changelog

:cl:
balance: Due to a galactic shortage on orbs, the orb-powered escape shuttle has inflated in price.
/:cl: