### PR TITLE
Disable random trauma event

### DIFF
--- a/orbstation/events/brain_trauma.dm
+++ b/orbstation/events/brain_trauma.dm
@@ -1,0 +1,3 @@
+/datum/round_event_control/brain_trauma
+	weight = 0
+	max_occurrences = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5112,6 +5112,7 @@
 #include "orbstation\datums\station_traits\ytp_announcer.dm"
 #include "orbstation\datums\status_effects\debuffs\farsighted.dm"
 #include "orbstation\events\anomalies.dm"
+#include "orbstation\events\brain_trauma.dm"
 #include "orbstation\events\indoor_weather.dm"
 #include "orbstation\events\portal_storm.dm"
 #include "orbstation\events\scrubber_clog.dm"


### PR DESCRIPTION
## About The Pull Request

I reenabled this by accident, it should be off.

## Why It's Good For The Game

It was a mistake for it to be enabled in the first place.

## Changelog

:cl:
fix: Re-disables the random brain trauma event.
/:cl:
