### PR TITLE
"Bioscrambler Victim" quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -20,7 +20,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/static/list/quirk_blacklist = list(
 		list("Tongue Tied", "Artificial Voice Box"), //ORBSTATION
 		list("Farsighted", "Illiterate"), //ORBSTATION
-		list("Prosthetic Limb", "Quadruple Amputee", "Alien Prosthesis"), //ORBSTATION
+		list("Prosthetic Limb", "Quadruple Amputee", "Alien Prosthesis", "Bioscrambler Victim"), //ORBSTATION
 		list("Blind", "Compulsive Door Closer"), //ORBSTATION
 		list("Blind", "Nearsighted", "Farsighted"), //ORBSTATION: added "Farsighted" to this list
 		list("Jolly", "Depression", "Apathetic", "Hypersensitive"),

--- a/orbstation/quirks/bioscrambler_victim.dm
+++ b/orbstation/quirks/bioscrambler_victim.dm
@@ -1,10 +1,9 @@
-/datum/quirk/alien_prosthesis
-	name = "Alien Prosthesis"
-	desc = "Due to a life-saving medical procedure, one of your limbs has been replaced with the limb of another species. It might be weird, but it mostly just looks cool."
-	icon = "hand"
+/datum/quirk/bioscrambler_victim
+	name = "Bioscrambler Victim"
+	desc = "In the past, a run-in with a bioscrambler anomaly left your body irrevocably scrambled. All your limbs are those of a different species!"
+	icon = "dna"
 	value = 0
-	var/slot_string = "limb"
-	medical_record_text = "A lifesaving medical experiment in the patient's past has left them with an unusual alien limb."
+	medical_record_text = "A bioscrambler accident has left the patient's body parts scrambled."
 
 	var/list/species_whitelist = list(
 		/datum/species/lizard,
@@ -19,27 +18,28 @@
 		/datum/species/shadow,
 	)
 
-/datum/quirk/alien_prosthesis/add_unique()
+/datum/quirk/bioscrambler_victim/add_unique(client/client_source)
+	add_bodypart(BODY_ZONE_L_ARM)
+	add_bodypart(BODY_ZONE_R_ARM)
+	add_bodypart(BODY_ZONE_L_LEG)
+	add_bodypart(BODY_ZONE_R_LEG)
+
+/datum/quirk/bioscrambler_victim/proc/add_bodypart(slot)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/bodypart/prosthetic
 
-	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-
-	var/list/bodypart_list = fill_bodypart_list(limb_slot)
+	var/list/bodypart_list = fill_bodypart_list(slot)
 
 	if(!bodypart_list.len)
-		stack_trace("Bodypart list for alien prosthesis is empty!")
+		stack_trace("Bodypart list for bioscrambler victim is empty!")
 		return
 
 	var/limbtype = pick(bodypart_list)
-
 	prosthetic = new limbtype()
-
 	prosthetic.species_color = sanitize_hexcolor("[pick("7F", "FF")][pick("7F", "FF")][pick("7F", "FF")]") //make it a random color
-
 	human_holder.del_and_replace_bodypart(prosthetic)
 
-/datum/quirk/alien_prosthesis/proc/fill_bodypart_list(slot)
+/datum/quirk/bioscrambler_victim/proc/fill_bodypart_list(slot)
 	var/list/bodypart_list = list()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5206,6 +5206,7 @@
 #include "orbstation\quirks\_quirk.dm"
 #include "orbstation\quirks\alien_prosthesis.dm"
 #include "orbstation\quirks\augmented.dm"
+#include "orbstation\quirks\bioscrambler_victim.dm"
 #include "orbstation\quirks\door_compulsion.dm"
 #include "orbstation\quirks\farsighted.dm"
 #include "orbstation\quirks\food_order_service.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new quirk, "Bioscrambler Victim"! This quirk is functionally the same as Alien Prosthesis, except it affects all four of your limbs instead of only one. Much like Alien Prosthesis, it doesn't really _do_ anything except make you look weirder.

![image](https://user-images.githubusercontent.com/105025397/215716428-7fa16f0f-854d-40f5-9c5c-a8bb38f985e7.png)
![image](https://user-images.githubusercontent.com/105025397/215716464-886eadd8-7c19-4cf0-b965-19a121e113f9.png)

Sometimes this looks real funky, but it's partly a consequence of how the limbs already fit together.

Incidentally, the species whitelists for both Bioscrambler Victim and Alien Prosthesis have been modified. Plasmaman and Mushroom limbs will no longer be rolled, but Ratfolk and Shadowperson limbs will. I've changed this mostly because the former two don't look very good when not attached to the intended torsos. If this is a point of contention, I can probably add plasmaman limbs back in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Much like Alien Prosthesis, this is just a silly cosmetic quirk. Silly cosmetic quirks are fun.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new "Bioscrambler Victim" quirk.
code: Modified the species whitelist for both "alien limb" quirks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
