### PR TITLE
The decarpening

### DIFF
--- a/orbstation/antagonists/carp/minor_rift.dm
+++ b/orbstation/antagonists/carp/minor_rift.dm
@@ -1,4 +1,4 @@
-#define RIFT_CHARGE_TIME 15 MINUTES
+#define RIFT_CHARGE_TIME 10 MINUTES
 #define CHARGE_COMPLETED 2
 
 /**
@@ -9,9 +9,9 @@
 	armor_type = /datum/armor/none
 	max_charge = INFINITY
 	/// Create an NPC carp this often
-	var/npc_carp_interval = 30 SECONDS
+	var/npc_carp_interval = 40 SECONDS
 	/// Team to assign new carps to
-	var/datum/team/carp_team/team = new()
+	var/datum/team/carp_team/team
 	/// What time was it when we were created
 	var/spawn_time
 	/// Where are all our little guys headed
@@ -19,13 +19,15 @@
 
 /obj/structure/carp_rift/minor/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, .proc/make_carp), npc_carp_interval, TIMER_DELETE_ME)
+	AddComponent(/datum/component/gps, "Anomalous Organic Signal")
+	team = new(starting_members = list(), z_level = z)
+	make_carp()
 	addtimer(CALLBACK(src, .proc/fully_charge), RIFT_CHARGE_TIME, TIMER_DELETE_ME)
 	spawn_time = world.time
 
 /obj/structure/carp_rift/minor/show_charge_level()
 	if (charge_state == CHARGE_COMPLETED)
-		return span_warning("This one is fully charged. In this state, it is poised to transport a much larger amount of carp than normal.")
+		return span_warning("This one is fully charged. It should have deleted itself by now, what the hell?")
 
 	var/percent_charged = (world.time - spawn_time) / (RIFT_CHARGE_TIME)
 	return span_notice("It seems to be [round(percent_charged * 100)]% charged.")
@@ -43,30 +45,19 @@
 
 /// Decide how the fish are going to wander through the station
 /obj/structure/carp_rift/minor/proc/find_migration_path()
-	var/list/valid_areas = list()
-	var/list/station_areas = GLOB.the_station_areas
-	for (var/area/potential_area as anything in SSmapping.areas_in_z["[z]"])
-		if (!is_type_in_list(potential_area, station_areas))
-			continue
-		valid_areas += potential_area
-
-	var/turf/station_turf = get_safe_random_station_turf(valid_areas)
-	if (!station_turf)
+	if (!team)
 		return list()
-	var/turf/exit_turf = get_edge_target_turf(station_turf, pick(GLOB.alldirs))
-	return list(WEAKREF(station_turf), WEAKREF(exit_turf))
+	return list(team.destination, team.exit)
 
 /// Called after 10 minutes of existing, the rift spawns ghosts twice as fast
 /obj/structure/carp_rift/minor/proc/fully_charge()
-	charge_state = CHARGE_COMPLETED
-	var/area/A = get_area(src)
-	priority_announce("Spatial object has reached peak energy charge in [initial(A.name)], please stand-by.", "Central Command Wildlife Observations")
-	icon_state = "carp_rift_charged"
-	set_light_color(LIGHT_COLOR_YELLOW)
-	update_light()
-	carp_interval = 30 // No SECONDS define, this is incremented by delta time
-	npc_carp_interval = 10 SECONDS
+	priority_announce("Spatial object has reached peak energy charge, please stand-by.", "Central Command Wildlife Observations")
 	team.succeed()
+	var/datum/round_event_control/summon_carp = locate(/datum/round_event_control/carp_migration) in SSevents.control
+	if (summon_carp)
+		summon_carp.runEvent()
+	playsound(get_turf(src), 'sound/magic/charge.ogg', 100, TRUE)
+	qdel(src)
 
 #undef RIFT_CHARGE_TIME
 #undef CHARGE_COMPLETED

--- a/orbstation/antagonists/carp/minor_rift.dm
+++ b/orbstation/antagonists/carp/minor_rift.dm
@@ -35,6 +35,10 @@
 /obj/structure/carp_rift/minor/on_spawned(mob/living/newcarp)
 	newcarp.mind.add_antag_datum(/datum/antagonist/rift_carp, team)
 
+/obj/structure/carp_rift/minor/Destroy()
+	. = ..()
+	QDEL_NULL(migration_path)
+
 /// Creates a new fish and sets it off towards the space station
 /obj/structure/carp_rift/minor/proc/make_carp()
 	if (!length(migration_path))

--- a/orbstation/antagonists/carp/rift_carp.dm
+++ b/orbstation/antagonists/carp/rift_carp.dm
@@ -58,6 +58,9 @@
 
 /// Decide how the fish are going to wander through the station
 /datum/team/carp_team/proc/find_migration_path(z_level)
+	if (!list(GLOB.the_station_areas))
+		return // This can run in the unit tests before the station is initialised
+
 	var/list/valid_areas = list()
 	var/list/station_areas = GLOB.the_station_areas
 	for (var/area/potential_area as anything in SSmapping.areas_in_z["[z_level]"])

--- a/orbstation/antagonists/carp/rift_carp.dm
+++ b/orbstation/antagonists/carp/rift_carp.dm
@@ -58,9 +58,6 @@
 
 /// Decide how the fish are going to wander through the station
 /datum/team/carp_team/proc/find_migration_path(z_level)
-	if (!length(GLOB.the_station_areas))
-		return // This can run in the unit tests before the station is initialised
-
 	var/list/valid_areas = list()
 	var/list/station_areas = GLOB.the_station_areas
 	for (var/area/potential_area as anything in SSmapping.areas_in_z["[z_level]"])
@@ -68,6 +65,8 @@
 			continue
 		valid_areas += potential_area
 
+	if (!length(valid_areas))
+		return // For when this is run during unit tests
 	var/turf/station_turf = get_safe_random_station_turf(valid_areas)
 	destination = WEAKREF(station_turf)
 	var/turf/exit_turf = get_edge_target_turf(station_turf, pick(GLOB.alldirs))

--- a/orbstation/antagonists/carp/rift_carp.dm
+++ b/orbstation/antagonists/carp/rift_carp.dm
@@ -58,7 +58,7 @@
 
 /// Decide how the fish are going to wander through the station
 /datum/team/carp_team/proc/find_migration_path(z_level)
-	if (!list(GLOB.the_station_areas))
+	if (!length(GLOB.the_station_areas))
 		return // This can run in the unit tests before the station is initialised
 
 	var/list/valid_areas = list()

--- a/orbstation/antagonists/carp/rift_carp.dm
+++ b/orbstation/antagonists/carp/rift_carp.dm
@@ -9,6 +9,8 @@
 	ui_name = "AntagInfoRiftCarp"
 	/// Team of carp from the same rift
 	var/datum/team/carp_team/team
+	/// Where we headed boys?
+	var/destination
 
 /datum/antagonist/rift_carp/create_team(datum/team/carp_team/new_team)
 	if(!new_team)
@@ -22,7 +24,13 @@
 
 /datum/antagonist/rift_carp/on_gain()
 	objectives += team.objectives
+	destination = get_area_name(team.destination.resolve())
 	return ..()
+
+/datum/antagonist/rift_carp/ui_static_data(mob/user)
+	var/list/data = list()
+	data["destination"] = destination
+	return data
 
 /datum/antagonist/rift_carp/greet()
 	. = ..()
@@ -31,34 +39,48 @@
 /// Display all the carp at once in the round end
 /datum/team/carp_team
 	member_name = "\improper Space Carp"
+	/// Did we win?
 	var/succeeded = FALSE
+	/// Where are we going?
+	var/datum/weakref/destination
+	/// Where are we going after that?
+	var/datum/weakref/exit
 
-/datum/team/carp_team/New()
+/datum/team/carp_team/New(starting_members, z_level)
 	..()
 	name = "Carp Rift [pick(GLOB.greek_letters)]"
+	find_migration_path(z_level)
 	var/datum/objective/custom/custom_objective = new()
 	custom_objective.team = src
 	custom_objective.name = "Protect the Carp Rift"
 	custom_objective.explanation_text = "Protect the rift you emerged from until it is fully charged. The Carp stream must flow!"
 	objectives += custom_objective
 
+/// Decide how the fish are going to wander through the station
+/datum/team/carp_team/proc/find_migration_path(z_level)
+	var/list/valid_areas = list()
+	var/list/station_areas = GLOB.the_station_areas
+	for (var/area/potential_area as anything in SSmapping.areas_in_z["[z_level]"])
+		if (!is_type_in_list(potential_area, station_areas))
+			continue
+		valid_areas += potential_area
+
+	var/turf/station_turf = get_safe_random_station_turf(valid_areas)
+	destination = WEAKREF(station_turf)
+	var/turf/exit_turf = get_edge_target_turf(station_turf, pick(GLOB.alldirs))
+	exit = WEAKREF(exit_turf)
+
 /// Called when rift is fully charged
 /datum/team/carp_team/proc/succeed()
 	succeeded = TRUE
 	for (var/datum/mind/member as anything in members)
-		to_chat(member, span_greentext("The carp rift has charged! Make sure your fellow Carp have a safe path for their migration!"))
+		to_chat(member, span_greentext("The rift was defended until it closed! Good job!"))
 
 /datum/team/carp_team/roundend_report()
 	var/list/result = list()
 
-	if(succeeded)
-		result += "<span class='greentext big'>[name] was successfully defended!</span>"
-		result += "<span class='greentext'>The next spawning season will be bountiful!</span>"
-	else
-		result += "<span class='redtext big'>[name] was destroyed!</span>"
-		result += "<span class='redtext'>The carp will have to migrate through another path...</span>"
-
-	result += "<span class='header'>The defenders of [name] were:</span>"
+	result += "<span class='header'>[name] [(succeeded) ? "closed by itself" : "was closed before it expired"].<br></span>"
+	result += "<span class='big'>The defenders of [name] were:<br></span>"
 	for(var/datum/mind/carp_mind in members)
 		result += printplayer(carp_mind)
 

--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -152,8 +152,9 @@
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_flag = ROLE_SENTIENCE
 	required_candidates = 1
-	weight = 5
+	weight = 3
 	cost = 12
+	repeatable = FALSE
 	/// Rift we made
 	var/obj/structure/carp_rift/minor/rift
 	/// List of all the places carp can spawn
@@ -172,7 +173,8 @@
 	var/turf/landing_area = pick(spawn_points)
 	rift = new (landing_area)
 	notify_ghosts("A carp rift has opened!", source=rift, action=NOTIFY_ORBIT, header="Carp Rift Opened")
-	priority_announce("A large organic energy flux has been recorded on the station outskirts, please stand by.", "Lifesign Alert")
+	var/area/target_area = get_area_name(rift.team.destination.resolve())
+	priority_announce("A large organic energy flux has been recorded on the station outskirts, coordinates marked on GPS. Staff stationed in [target_area] please stand by.", "Lifesign Alert")
 
 	var/mob/living/basic/carp/mega/big_boy = new(landing_area)
 	big_boy.key = applicant.key

--- a/tgui/packages/tgui/interfaces/AntagInfoRiftCarp.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoRiftCarp.tsx
@@ -1,9 +1,16 @@
+import { useBackend } from '../backend';
 import { Window } from '../layouts';
 import { Section, Stack } from '../components';
 
-export const AntagInfoRiftCarp = () => {
+type Info = {
+  destination: string;
+};
+
+export const AntagInfoRiftCarp = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const { destination } = data;
   return (
-    <Window width={400} height={300} theme="wizard">
+    <Window width={400} height={380} theme="wizard">
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item textAlign="center" fontSize="20px">
@@ -21,6 +28,11 @@ export const AntagInfoRiftCarp = () => {
                   it is the duty of every carp to ensure that it is not
                   destroyed so that more carp can continue their voyage, and
                   that they have a clear path to their destination.
+                </Stack.Item>
+                <Stack.Item>
+                  You feel instinctually that you and your kin urgently need to
+                  head to {destination}. Follow your siblings if you get lost,
+                  they know the way.
                 </Stack.Item>
                 <Stack.Item>
                   Space Carp are somewhat intelligent animals and are sometimes


### PR DESCRIPTION
## About The Pull Request

Various adjustments to dynamic Random Carp Event.

- The rift now has a GPS signal and the announcement informs the crew of this fact.
- The initial announcement also announces the location the carp will be trying to head for.
- Player carp are also informed about this rather than just having to follow the NPCs.
- NPC carp now spawn every 40 seconds rather than every 30 and the rift lasts for 10 minutes instead of 15. This should result in 15 NPC carp spawning in total.
- When the rift expires it now triggers the Carp Migration random event and then deletes itself, rather than staying around and spawning carp even more frequently. This gives the crew an incentive to go into space and deal with it, but not one that should result in mass carnage.
- Carp no longer get greentext at the end of the round, sorry carp.
- The weight of the dynamic event has been reduced and it is marked as a one-time event which won't repeat.

## Why It's Good For The Game

We experienced a couple of rounds where this was both more destructive than it is intended to be and also where the crew didn't really know what to do about it.
By making it a temporal event with an ending rather than one which continues to antagonise you until defeated it should limit the effect to a more manageable level.

## Changelog

:cl:
balance: Minor carp rifts now give out a GPS signal and inform you of where the carp that emerge are headed to.
balance: Minor carp rifts now spawn carp slower and stop spawning them after 10 minutes, but summon a final wave if they are left alone until that point.
/:cl:
