### PR TITLE
Reverts Final Objective retuning

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -11,12 +11,9 @@
 
 /datum/traitor_objective/ultimate
 	abstract_type = /datum/traitor_objective/ultimate
-	// to get a final objective, you must have 900 total reputation points,
-	// and have completed objectives worth a cumulative total of 400 reputation points
-	// basically, you need to do high-risk high-reward objectives like assassination and sabotage
-	progression_minimum = 90 MINUTES
+	progression_minimum = 120 MINUTES
 
-	var/progression_points_in_objectives = 40 MINUTES
+	var/progression_points_in_objectives = 20 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
 /datum/traitor_objective/ultimate/can_generate_objective(generating_for, list/possible_duplicates)


### PR DESCRIPTION
## About The Pull Request

Simply put this sets the required reputation to achieve a final objective back to the level it is on tg, as well as the amount of reputation required from doing objectives vs just waiting.

## Why It's Good For The Game

Currently on Orb it is much too easy to consistently and quickly unlock a traitor's final objective.
This increases the rep requirement by 33% which arguably might be too much, but we can always change it again and arguably "too rare" is better than "too common" anyway, we actually _don't_ want a final objective to be an expected "every round" event.

Additionally while this changes the minimum rep to "two hours of passive gain" it also decreases the minimum actively gained rep to half of what it was.
Hitting the minimum _requirement_ would now only require two assassinations (or just one for Head of Staff) to qualify... provided you meet the othe requirement of 120 minutes worth of rep total.

_Hopefully_ this means that they would be more common in rounds which are running long but _don't_ require people to be mainlining tasks in order to see them at all. This kind of tuning is kind of a "play it by ear" sort of thing though and probably we'll just have to try it and see what happens.

I do still intend to do final objective drafting & middle objectives at some future point, but that'd be upstream.
And it's not even the first thing I intend to do when the freeze is over 😓 
If we still have a consistent problem here after these changes though I guess I will bump it in priority and we can trial it here first.

## Changelog

:cl:
balance: Unlocking a final objective now requires more reputation than it did previously, but less of it needs to be from actively completing tasks. On a very long round, just doing a couple of objectives for pocket money might be sufficient. On a shorter round, it may not realistically be achievable at all.
/:cl:
