### PR TITLE
Tweaks carp event chance

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -1,10 +1,9 @@
 /datum/round_event_control/carp_migration
 	name = "Carp Migration"
 	typepath = /datum/round_event/carp_migration
-	weight = 15
 	min_players = 12
-	earliest_start = 10 MINUTES
-	max_occurrences = 6
+	earliest_start = 20 MINUTES
+	max_occurrences = 2
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Summons a school of space carp."
 


### PR DESCRIPTION
## About The Pull Request

Reduced weight of carp migration event to the default weight, decreased maximum times it can occur (though I don't remember seeing more than one), and increased minimum round time to occur.

## Why It's Good For The Game

People are getting tired of getting bitten by fish every round.

## Changelog

:cl:
balance: Nanotrasen have augmented the hulls of every station with a new mineral we purchased guaranteed by the supplier to have effective carp repellent properties, which should mean you see carp at least slightly less often.
/:cl:
