### PR TITLE
Heads of staff have guns in their lockers on every map.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -80497,7 +80497,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "wNf" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2531,7 +2531,6 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aIl" = (
@@ -27858,7 +27857,6 @@
 "hTb" = (
 /obj/structure/closet/secure_closet/research_director,
 /obj/effect/turf_decal/delivery,
-/obj/item/gun/energy/e_gun/mini,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Research Director's Office";
@@ -60120,7 +60118,6 @@
 "rja" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/delivery,
-/obj/item/gun/energy/e_gun/mini,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{

--- a/orbstation/objects/items/storage.dm
+++ b/orbstation/objects/items/storage.dm
@@ -7,3 +7,21 @@
 /obj/item/storage/box/hug/survival/PopulateContents()
 	..()
 	new /obj/item/crowbar(src)
+
+// Head of staff lockers
+
+/obj/structure/closet/secure_closet/chief_medical/PopulateContents()
+	..()
+	new /obj/item/gun/energy/e_gun/mini(src)
+
+/obj/structure/closet/secure_closet/research_director/PopulateContents()
+	..()
+	new /obj/item/gun/energy/e_gun/mini(src)
+
+/obj/structure/closet/secure_closet/engineering_chief/PopulateContents()
+	..()
+	new /obj/item/gun/energy/e_gun/mini(src)
+
+/obj/structure/closet/secure_closet/quartermaster/PopulateContents()
+	..()
+	new /obj/item/gun/energy/e_gun/mini(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All head of staff lockers that did not already contain a gun will now have a single miniature energy gun in them. This was already the case on Kilostation, and is now true on _all_ maps. This is to say, a gun has been given to the Chief Medical Officer, Chief Engineer, Quartermaster, and Research Director.

Accordingly, the excess miniature e-gun has been _removed_ from relevant lockers on Kilo. While this is a map edit, this aspect of Kilo hasn't changed to my knowledge in the entire time Orbstation has existed, so I doubt we'll suddenly get a bunch of conflicts from this. Worst case, we have to make sure the guns don't reappear?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've always felt it was strange that heads only get to be armed on Kilo and not other maps - it's not as though Kilo is a more hostile environment unless you decide to wander through maint. I _also_ think that, especially at a lower population, it's good to have heads who are more capable of defending themselves. The miniature e-gun is a nice little weapon that is by no means overpowered - it only gets 12 shots compared to the full e-gun's 20 - but it could mean the difference between life and death in a tense moment. When we often lack security, I think it's good to let the heads step up a little more in a role of defending the station. Or at least themselves.

Also, if a head of staff is an antag, it's a nice little bonus for doing crimes that shouldn't really swing things _majorly_ compared to things antags can already do. I guess it's really nice for blood brothers?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heads of Staff can have little a gun, as a treat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
