### PR TITLE
Tizirans no longer have a cold vulnerability.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -55,7 +55,7 @@
 
 /// Lizards are cold blooded and do not stabilize body temperature naturally
 /datum/species/lizard/body_temperature_core(mob/living/carbon/human/humi, delta_time, times_fired)
-	return
+	..() //ORBSTATION - lizards can stabilize body temperature now
 
 /datum/species/lizard/random_name(gender,unique,lastname)
 	if(unique)
@@ -109,14 +109,14 @@
 /datum/species/lizard/create_pref_temperature_perks()
 	var/list/to_add = list()
 
-	to_add += list(list(
+	/*to_add += list(list(
 		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
 		SPECIES_PERK_ICON = "thermometer-empty",
 		SPECIES_PERK_NAME = "Cold-blooded",
 		SPECIES_PERK_DESC = "Lizardpeople have higher tolerance for hot temperatures, but lower \
 			tolerance for cold temperatures. Additionally, they cannot self-regulate their body temperature - \
 			they are as cold or as warm as the environment around them is. Stay warm!",
-	))
+	))*/ //ORBSTATION REMOVAL: this perk no longer applies
 
 	return to_add
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -109,13 +109,13 @@
 /datum/species/lizard/create_pref_temperature_perks()
 	var/list/to_add = list()
 
-	/*to_add += list(list(
+	to_add += list(list(
 		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 		SPECIES_PERK_ICON = "thermometer-empty",
 		SPECIES_PERK_NAME = "Temperature Tolerance",
 		SPECIES_PERK_DESC = "Tizirans are resilient to hotter temperatures. In addition, they are \
 		comfortable in a wider range of temperature than most species.",
-	))*/ //ORBSTATION REMOVAL - this perk no longer exists
+	))
 
 	return to_add
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -109,13 +109,13 @@
 /datum/species/lizard/create_pref_temperature_perks()
 	var/list/to_add = list()
 
-	to_add += list(list(
+	/*to_add += list(list(
 		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 		SPECIES_PERK_ICON = "thermometer-empty",
 		SPECIES_PERK_NAME = "Temperature Tolerance",
 		SPECIES_PERK_DESC = "Tizirans are resilient to hotter temperatures. In addition, they are \
 		comfortable in a wider range of temperature than most species.",
-	)) //ORBSTATION - perk edited to reflect changes
+	))*/ //ORBSTATION REMOVAL - this perk no longer exists
 
 	return to_add
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -110,11 +110,12 @@
 	var/list/to_add = list()
 
 	to_add += list(list(
-		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
 		SPECIES_PERK_ICON = "thermometer-empty",
-		SPECIES_PERK_NAME = "Temperature Tolerance",
-		SPECIES_PERK_DESC = "Tizirans are resilient to hotter temperatures. In addition, they are \
-		comfortable in a wider range of temperature than most species.",
+		SPECIES_PERK_NAME = "Cold-blooded",
+		SPECIES_PERK_DESC = "Lizardpeople have higher tolerance for hot temperatures, but lower \
+			tolerance for cold temperatures. Additionally, they cannot self-regulate their body temperature - \
+			they are as cold or as warm as the environment around them is. Stay warm!",
 	))
 
 	return to_add

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -109,14 +109,13 @@
 /datum/species/lizard/create_pref_temperature_perks()
 	var/list/to_add = list()
 
-	/*to_add += list(list(
-		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 		SPECIES_PERK_ICON = "thermometer-empty",
-		SPECIES_PERK_NAME = "Cold-blooded",
-		SPECIES_PERK_DESC = "Lizardpeople have higher tolerance for hot temperatures, but lower \
-			tolerance for cold temperatures. Additionally, they cannot self-regulate their body temperature - \
-			they are as cold or as warm as the environment around them is. Stay warm!",
-	))*/ //ORBSTATION REMOVAL: this perk no longer applies
+		SPECIES_PERK_NAME = "Temperature Tolerance",
+		SPECIES_PERK_DESC = "Tizirans are resilient to hotter temperatures. In addition, they are \
+		comfortable in a wider range of temperature than most species.",
+	)) //ORBSTATION - perk edited to reflect changes
 
 	return to_add
 

--- a/orbstation/species/lizardpeople.dm
+++ b/orbstation/species/lizardpeople.dm
@@ -15,6 +15,9 @@
 	human_mob.hairstyle = "Bald"
 	human_mob.facial_hair_color = "#F0E0C0" // for the colored snout option
 
+/datum/species/lizard/create_pref_temperature_perks()
+	return list()
+
 /datum/species/lizard/ashwalker
 	heatmod = 0.5
 	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT + 50)

--- a/orbstation/species/lizardpeople.dm
+++ b/orbstation/species/lizardpeople.dm
@@ -6,11 +6,19 @@
 		HAIR
 	)
 	coldmod = 1 //no more increased cold damage
+	heatmod = 1 //no more heat resistance either, sorry
+	bodytemp_heat_damage_limit = BODYTEMP_HEAT_DAMAGE_LIMIT
+	bodytemp_cold_damage_limit = BODYTEMP_COLD_DAMAGE_LIMIT
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	..()
 	human_mob.hairstyle = "Bald"
 	human_mob.facial_hair_color = "#F0E0C0" // for the colored snout option
+
+/datum/species/lizard/ashwalker
+	heatmod = 0.5
+	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT + 50)
+	bodytemp_cold_damage_limit = (BODYTEMP_COLD_DAMAGE_LIMIT - 10)
 
 /datum/species/lizard/silverscale
 	/// Stored facial hair color for when the species is removed.

--- a/orbstation/species/lizardpeople.dm
+++ b/orbstation/species/lizardpeople.dm
@@ -5,6 +5,7 @@
 		LIPS,
 		HAIR
 	)
+	coldmod = 1 //no more increased cold damage
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Strips off Tizirans' vulnerability to cold temperatures, and lets them self-regulate their body temperature like humans do. Also removed their resistance to heat and their tolerance for a wider range of temperatures. They just don't have temperature mechanics anymore.

Gave ashwalkers a greater resistance to heat than before, however, with a heatmod of 0.5 and an extremely high maximum temperature. As tizirans mutated by the horrible lava planet, I think it makes sense that they aren't bothered by extreme heat. They could take a bath in boiling water if that was a mechanic this game had.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For months now, it's been clear that Tizirans' cold weakness is bad and makes them much, much weaker than humans for no real reason other than some bizarre need to have lizards be worse than humans. Removing it should alleviate the badness of having one species worse than others for no reason.

Incidentally, this makes cryosting a notably weaker choice for changelings - which is fine. Changelings having a power that amounts to "mildly inconvenience humans and literally murder tizirans" sucks anyway.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Gave Ashwalkers a much greater resistance to heat.
del: Removed unique temperature-based mechanics from tizirans entirely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
