### PR TITLE
Departmental Voluntary Security

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -36722,7 +36722,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "iWq" = (
@@ -48579,7 +48579,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48587,6 +48586,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Medbay"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/med,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical/medsci)
 "lKC" = (
@@ -52694,7 +52694,6 @@
 /area/station/hallway/primary/central/aft)
 "mLP" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52703,6 +52702,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Science"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical/medsci)
 "mLV" = (
@@ -70127,7 +70127,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "rgA" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -9438,7 +9438,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/full,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/med,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "cMS" = (
@@ -38487,7 +38487,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "lNH" = (
@@ -40524,7 +40524,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "myE" = (
@@ -70913,7 +70913,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron/white,
 /area/station/security/checkpoint/science)
 "vUi" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3881,7 +3881,7 @@
 	name = "Research Security Post"
 	},
 /obj/effect/turf_decal/siding/red/corner,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "bhB" = (
@@ -9888,7 +9888,7 @@
 	name = "Research Security Post"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "cYG" = (
@@ -35377,7 +35377,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Engineering Security Post"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "jYe" = (
@@ -35828,7 +35828,7 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "kex" = (
@@ -40814,8 +40814,8 @@
 	name = "Medbay Security Post"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/med,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "lAA" = (
@@ -48016,7 +48016,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "nIh" = (
@@ -51378,7 +51378,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Engineering Security Post"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "oIU" = (
@@ -57820,7 +57820,7 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "qAo" = (
@@ -59902,7 +59902,7 @@
 	name = "Cargo Security Post"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "rfM" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14860,7 +14860,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "fAI" = (
@@ -18573,7 +18573,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "gTt" = (
@@ -28817,7 +28817,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "knU" = (
@@ -30162,7 +30162,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/med,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "kOp" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -26843,10 +26843,10 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "iiw" = (
@@ -37651,9 +37651,9 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "meO" = (
@@ -56090,10 +56090,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/engine,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "sXX" = (
@@ -61586,10 +61586,10 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Outpost - Medical"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/security/med,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "vbn" = (
@@ -64829,7 +64829,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "wkR" = (

--- a/orbstation/_globalvars/traits.dm
+++ b/orbstation/_globalvars/traits.dm
@@ -1,2 +1,4 @@
 /// This mob is able to hear despite being deaf. Provided by hearing aids.
 #define TRAIT_DEAF_HEARING "deaf_hearing"
+/// This mob is an authorised security deputy
+#define TRAIT_DEPUTISED "trait_deputised"

--- a/orbstation/jobs/department_security.dm
+++ b/orbstation/jobs/department_security.dm
@@ -1,0 +1,136 @@
+// This disabler works with mind shields or a security armband
+/obj/item/gun/energy/disabler/departmental
+	name = "deputy disabler"
+	desc = "A self-defence weapon which weakens organic targets. Only functions in conjunction with an NT official armband."
+	pin = /obj/item/firing_pin/implant/mindshield_deputy
+
+/obj/item/firing_pin/implant/mindshield_deputy
+	name = "deputy firing pin"
+	desc = "This Security firing pin authorizes the weapon for mindshield-implanted users, or those wearing a less permanent armband."
+
+/obj/item/firing_pin/implant/pin_auth(mob/living/user)
+	if (HAS_TRAIT(user, TRAIT_DEPUTISED))
+		return TRUE
+	return ..()
+
+// Adds a trait to armbands
+/obj/item/clothing/accessory/armband/on_uniform_equip(obj/item/clothing/under/U, mob/living/user)
+	ADD_TRAIT(user, TRAIT_DEPUTISED, REF(src))
+
+/obj/item/clothing/accessory/armband/on_uniform_dropped(obj/item/clothing/under/U, mob/living/user)
+	REMOVE_TRAIT(user, TRAIT_DEPUTISED, REF(src))
+
+// Departmental sec belt doesn't have a baton or grenade in it
+/obj/item/storage/belt/security/departmental
+
+/obj/item/storage/belt/security/departmental/PopulateContents()
+	new /obj/item/reagent_containers/spray/pepper(src)
+	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/restraints/handcuffs(src)
+	new /obj/item/restraints/handcuffs(src)
+	update_appearance()
+
+// Adds capability of closet to talk on radio when unlocked
+/obj/structure/closet/secure_closet/security
+	var/radio_channel
+	var/dept_name
+
+/obj/structure/closet/secure_closet/security/after_open(mob/living/user, force)
+	. = ..()
+	if (!user || force || !radio_channel || !dept_name)
+		return
+
+
+	var/obj/item/card/id/used_id = user.get_idcard(TRUE)
+	var/opener_name = used_id ? used_id.registered_name : user.name
+
+	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
+	announcer.announce_locker_access(opener_name, dept_name, radio_channel)
+
+/// Announces a department's security locker has been opened
+/obj/machinery/announcement_system/proc/announce_locker_access(name, dept_name, channel)
+	if (!is_operational)
+		return
+	broadcast("[dept_name] Security Resources have been requisitioned by [name].", list(channel, RADIO_CHANNEL_SECURITY))
+
+// Change the contents of dep sec lockers
+/obj/structure/closet/secure_closet/security/cargo
+	req_access = list()
+	req_one_access = list(ACCESS_SECURITY, ACCESS_CARGO)
+	radio_channel = RADIO_CHANNEL_SUPPLY
+	dept_name = "Cargo"
+
+/obj/structure/closet/secure_closet/security/cargo/PopulateContents()
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/gun/energy/disabler/departmental(src)
+	new /obj/item/storage/belt/security/departmental(src)
+	new /obj/item/clothing/accessory/armband/cargo(src)
+	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/encryptionkey/headset_cargo(src)
+
+/obj/structure/closet/secure_closet/security/engine
+	req_access = list()
+	req_one_access = list(ACCESS_SECURITY, ACCESS_ENGINEERING)
+	radio_channel = RADIO_CHANNEL_ENGINEERING
+	dept_name = "Engineering"
+
+/obj/structure/closet/secure_closet/security/engine/PopulateContents()
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/gun/energy/disabler/departmental(src)
+	new /obj/item/storage/belt/security/departmental(src)
+	new /obj/item/clothing/accessory/armband/engine(src)
+	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/encryptionkey/headset_eng(src)
+
+/obj/structure/closet/secure_closet/security/science
+	req_access = list()
+	req_one_access = list(ACCESS_SECURITY, ACCESS_SCIENCE)
+	radio_channel = RADIO_CHANNEL_SCIENCE
+	dept_name = "Research"
+
+/obj/structure/closet/secure_closet/security/science/PopulateContents()
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/gun/energy/disabler/departmental(src)
+	new /obj/item/storage/belt/security/departmental(src)
+	new /obj/item/clothing/accessory/armband/science(src)
+	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/encryptionkey/headset_sci(src)
+
+/obj/structure/closet/secure_closet/security/med
+	req_access = list()
+	req_one_access = list(ACCESS_SECURITY, ACCESS_MEDICAL)
+	radio_channel = RADIO_CHANNEL_MEDICAL
+	dept_name = "Medical"
+
+/obj/structure/closet/secure_closet/security/med/PopulateContents()
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/gun/energy/disabler/departmental(src)
+	new /obj/item/storage/belt/security/departmental(src)
+	new /obj/item/clothing/accessory/armband/medblue(src)
+	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/encryptionkey/headset_med(src)
+
+// Mapping access helpers
+/obj/effect/mapping_helpers/airlock/access/any/security/cargo/get_access()
+	var/list/access_list = ..()
+	access_list += list(ACCESS_SECURITY, ACCESS_CARGO)
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/any/security/engine/get_access()
+	var/list/access_list = ..()
+	access_list += list(ACCESS_SECURITY, ACCESS_ENGINEERING)
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/any/security/science/get_access()
+	var/list/access_list = ..()
+	access_list += list(ACCESS_SECURITY, ACCESS_SCIENCE)
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/any/security/med/get_access()
+	var/list/access_list = ..()
+	access_list += list(ACCESS_SECURITY, ACCESS_MEDICAL)
+	return access_list

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5146,6 +5146,7 @@
 #include "orbstation\events\scrubber_clog.dm"
 #include "orbstation\hydroponics\grown.dm"
 #include "orbstation\jobs\ass_depts.dm"
+#include "orbstation\jobs\department_security.dm"
 #include "orbstation\medical\brain_trauma.dm"
 #include "orbstation\medical\dismemberment.dm"
 #include "orbstation\medical\surgery\height_manipulation.dm"


### PR DESCRIPTION
## About The Pull Request

Departmental security offices and their lockers are now accessible by anyone who has general access to that department.
Opening a departmental security locker will announce the name of the mob opening it on the departmental radio channel _and_ the security channel, but will prioritise the name on their ID card if they have one (and prioritise one in their hands over one on their uniform).

The lockers within contain:
- A security belt, itself containing a Flash, Pepper Spray, and two pairs of Handcuffs.
- A Deputy Disabler.
- A seclite torch.
- A pair of security armbands (one security coloured, one coloured for your department).
- Security HUDGlasses.
- A departmental radio chip for if you are _actually_ a security officer.

The Deputy Disabler contains a Deputy Firing Pin. 
Guns with this pin can only be fired if you either have a loyalty implant, or are wearing one of the armbands you can acquire from the locker or the Head of Security.

The brig areas of these offices (on maps which have them... which actually isn't most of them) still require brig access, partially this is just because they're accessed via windoors which don't have convenient access helpers.

This change necessitated replacing a bunch of the door access helpers on every map, which may prove to be a fragile change for the future. We'll have to see how smart it is about map merges.

## Why It's Good For The Game

There is a general reticence to play as a security officer, but an unquestionable fact that having an equipped opposition to traitors is useful to the game. This system may mean that we have more people equipped simply to defend their own workplace and coworkers, rather than needing one person to stretch their aegis over the whole station.
These are ideas we discussed and thought might do something to address the problem. At the very least they might turn the problem into a different problem, or help move towards a better solution.

## Changelog

:cl:
add: Departmental Security offices and lockers are now accessible by anyone in that department.
add: Departmental Security lockers now contain a belt of supplies, and a "deputy" disabler which can be fired only by people who are either Loyalty Implanted or wearing a deputising armband (also contained in the locker, colour coded per department).
add: Opening a departmental security locker will report your name (or the name of your ID) on the departmental and security radio channels.
/:cl: