### PR TITLE
Moves from appending update_descs to examine

### DIFF
--- a/orbstation/modules/mining/megafauna.dm
+++ b/orbstation/modules/mining/megafauna.dm
@@ -34,8 +34,7 @@
 	damage_coeff = original_damage_coeff.Copy()
 	FindTarget(list(future_corpse))
 
-/mob/living/simple_animal/hostile/megafauna/update_desc(updates)
+/mob/living/simple_animal/hostile/megafauna/examine(mob/user)
 	. = ..()
-	if (!dormant)
-		return
-	desc += "<BR>[span_warning("It seems to be dormant, but could be awakened by clicking on it.")]"
+	if (dormant)
+		. += span_warning("It seems to be dormant, but could be awakened by clicking on it.")

--- a/orbstation/objects/items/hearing_aid.dm
+++ b/orbstation/objects/items/hearing_aid.dm
@@ -61,11 +61,10 @@
 	if (user.sound_environment_override == SOUND_ENVIRONMENT_SEWER_PIPE)
 		user.sound_environment_override = SOUND_ENVIRONMENT_NONE
 
-/obj/item/radio/headset/update_desc(updates)
+/obj/item/radio/headset/examine(mob/user)
 	. = ..()
-	if (!hearing_aid)
-		return
-	desc += "<br>It has a hearing aid attached."
+	if (hearing_aid)
+		. += "It has a hearing aid attached."
 
 /mob/living/carbon/can_hear()
 	. = ..()

--- a/orbstation/objects/items/radio_gloves.dm
+++ b/orbstation/objects/items/radio_gloves.dm
@@ -45,11 +45,10 @@
 		return
 	. += mutable_appearance('orbstation/icons/obj/accessibility.dmi', "glove_wires")
 
-/obj/item/clothing/gloves/update_desc(updates)
+/obj/item/clothing/gloves/examine(mob/user)
 	. = ..()
-	if (!clothing_traits || !(TRAIT_CAN_SIGN_ON_COMMS in clothing_traits))
-		return
-	desc += "<br>They have a sign language interpreting assembly attached."
+	if (clothing_traits && (TRAIT_CAN_SIGN_ON_COMMS in clothing_traits))
+		. += "<br>They have a sign language interpreting assembly attached."
 
 // Replace the existing crafting recipe because it's redundant
 /datum/crafting_recipe/radiogloves


### PR DESCRIPTION
Update_desc keeps on appending the same text to the description, it should only be used if the description is completely reset. I have replaced them with the use of the examine proc. This prevents the same description being appended possibly infinitely.