### PR TITLE
Kills valentines day

### DIFF
--- a/orbstation/cleanup/valentines.dm
+++ b/orbstation/cleanup/valentines.dm
@@ -8,6 +8,7 @@
 	max_occurrences = 0
 
 /datum/round_event_control/valentines/can_spawn_event(players_amt)
+	. = ..()
 	return FALSE
 
 // Don't do anything if we somehow run this event

--- a/orbstation/cleanup/valentines.dm
+++ b/orbstation/cleanup/valentines.dm
@@ -1,0 +1,15 @@
+// Prevents valentines antagonist from being assigned to anyone
+/datum/antagonist/valentine/can_be_owned(datum/mind/new_owner)
+	return FALSE
+
+// Disable the event
+/datum/round_event_control/valentines
+	weight = 0
+	max_occurrences = 0
+
+/datum/round_event_control/valentines/can_spawn_event(players_amt)
+	return FALSE
+
+// Don't do anything if we somehow run this event
+/datum/round_event/valentines/start()
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5129,6 +5129,7 @@
 #include "orbstation\cleanup\mobs.dm"
 #include "orbstation\cleanup\moodlets.dm"
 #include "orbstation\cleanup\recipes.dm"
+#include "orbstation\cleanup\valentines.dm"
 #include "orbstation\clothing\hats.dm"
 #include "orbstation\clothing\hawaiian.dm"
 #include "orbstation\clothing\hud.dm"


### PR DESCRIPTION
## About The Pull Request

This PR disables the valentines day event, and makes it impossible to assign the valentines antagonist to anyone.

## Why It's Good For The Game

This seemed to cause a bunch of problems.

## Changelog

:cl:
del: Corporate valentines day has been cancelled after an urgent series of emails about the inappropriate nature and inherently power misbalances of workplace relationships.
/:cl:
