### PR TITLE
Cleaned up Orbstation sprite datums and made colored snouts work again.

### DIFF
--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -95,7 +95,15 @@
 		if(ORGAN_COLOR_OVERRIDE)
 			draw_color = override_color(ownerlimb.draw_color)
 		if(ORGAN_COLOR_INHERIT)
-			draw_color = ownerlimb.draw_color
+			//BEGIN ORBSTATION EDIT
+			if(sprite_datum.color_src == FACEHAIR) //Re-enabling colored snouts, mostly
+				if(!ishuman(ownerlimb.owner))
+					return
+				var/mob/living/carbon/human/human_owner = ownerlimb.owner
+				draw_color = human_owner.facial_hair_color
+			else
+				draw_color = ownerlimb.draw_color
+			//END ORBSTATION EDIT
 		if(ORGAN_COLOR_HAIR)
 			if(!ishuman(ownerlimb.owner))
 				return

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1739,24 +1739,6 @@
 	icon_state = "lbelly"
 	gender_specific = 1
 
-/datum/sprite_accessory/body_markings/ltigercolor
-	name = "Light Tiger Body (Colored)"
-	icon_state = "ltiger"
-	gender_specific = 1
-	color_src = FACEHAIR
-
-/datum/sprite_accessory/body_markings/dtigercolor
-	name = "Dark Tiger Body (Colored)"
-	icon_state = "dtiger"
-	gender_specific = 1
-	color_src = FACEHAIR
-
-/datum/sprite_accessory/body_markings/lbellycolor
-	name = "Light Belly (Colored)"
-	icon_state = "lbelly"
-	gender_specific = 1
-	color_src = FACEHAIR
-
 /datum/sprite_accessory/tails
 	em_block = TRUE
 
@@ -1854,16 +1836,6 @@
 /datum/sprite_accessory/snouts/roundlight
 	name = "Round + Light"
 	icon_state = "roundlight"
-
-/datum/sprite_accessory/snouts/sharpcolored
-	name = "Sharp + Colored"
-	icon_state = "sharplight"
-	color_src = FACEHAIR
-
-/datum/sprite_accessory/snouts/roundcolored
-	name = "Round + Colored"
-	icon_state = "roundlight"
-	color_src = FACEHAIR
 
 /datum/sprite_accessory/horns
 	icon = 'icons/mob/species/lizard/lizard_misc.dmi'

--- a/orbstation/species/lizardpeople.dm
+++ b/orbstation/species/lizardpeople.dm
@@ -37,3 +37,32 @@
 	..()
 	var/mob/living/carbon/human/was_silverscale = C
 	was_silverscale.facial_hair_color = old_facehair_color
+
+//Orb specific sprite accessories
+/datum/sprite_accessory/body_markings/ltigercolor
+	name = "Light Tiger Body (Colored)"
+	icon_state = "ltiger"
+	gender_specific = 1
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/body_markings/dtigercolor
+	name = "Dark Tiger Body (Colored)"
+	icon_state = "dtiger"
+	gender_specific = 1
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/body_markings/lbellycolor
+	name = "Light Belly (Colored)"
+	icon_state = "lbelly"
+	gender_specific = 1
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/snouts/sharpcolored
+	name = "Sharp + Colored"
+	icon_state = "sharplight"
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/snouts/roundcolored
+	name = "Round + Colored"
+	icon_state = "roundlight"
+	color_src = FACEHAIR


### PR DESCRIPTION
Moved the Orbstation sprite datums for colored snouts and body markings to the Orbstation folder. Made colored snouts display the proper color by making a modification to the new bodypart overlay system. This will likely need further changes in the future, but it should be fine for now.