### PR TITLE
Only HoP is forced to be acting captain; safe code request announces who did it, notifies admins if antagonist

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -43,11 +43,6 @@ SUBSYSTEM_DEF(job)
 	var/list/chain_of_command = list(
 		JOB_CAPTAIN = 1,
 		JOB_HEAD_OF_PERSONNEL = 2,
-		JOB_RESEARCH_DIRECTOR = 3,
-		JOB_CHIEF_ENGINEER = 4,
-		JOB_CHIEF_MEDICAL_OFFICER = 5,
-		JOB_HEAD_OF_SECURITY = 6,
-		JOB_QUARTERMASTER = 7,
 	)
 
 	/// If TRUE, some player has been assigned Captaincy or Acting Captaincy at some point during the shift and has been given the spare ID safe code.

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -441,12 +441,16 @@
 				to_chat(usr, span_warning("There is no safe code to deliver to your station!"))
 				return
 
+			// ORBSTATION: Notify admins if the person requesting the safe code has an antag datum or a spsecial role
+			if(usr.mind && (usr.mind.special_role || usr.mind.antag_datums?.len > 0))
+				message_admins("[usr] requested the spare ID safe code, but may be an antagonist!")
+
 			var/turf/pod_location = get_turf(src)
 
 			SSjob.safe_code_request_loc = pod_location
 			SSjob.safe_code_requested = TRUE
-			SSjob.safe_code_timer_id = addtimer(CALLBACK(SSjob, TYPE_PROC_REF(/datum/controller/subsystem/job, send_spare_id_safe_code), pod_location), 120 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
-			minor_announce("Due to staff shortages, your station has been approved for delivery of access codes to secure the Captain's Spare ID. Delivery via drop pod at [get_area(pod_location)]. ETA 120 seconds.")
+			SSjob.safe_code_timer_id = addtimer(CALLBACK(SSjob, TYPE_PROC_REF(/datum/controller/subsystem/job, send_spare_id_safe_code), pod_location), 60 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
+			minor_announce("Due to staff shortages, your station has been approved for delivery of access codes to secure the Captain's Spare ID, as requested by [usr.name]. Delivery via drop pod at [get_area(pod_location)]. ETA 60 seconds.")
 
 /obj/machinery/computer/communications/proc/emergency_access_cooldown(mob/user)
 	if(toggle_uses == toggle_max_uses) //you have used up free uses already, do it one more time and start a cooldown


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This pull request makes the following changes to how acting captain works:

1. Only the Head of Personnel will have acting captain forced on them, as they're the second-in-command and have the ability to essentially give themselves all-access anyway.
2. In the event that there's no captain or HoP, anyone else can use the communications console to request the safe code, as usual.
3. The announcement that goes out when the safe code is requested now includes the name of the person who requested it, ensuring that there is some accountability for who did it.
4. Admins will be notified if the person who requested the safe code is an antagonist.
5. The time it takes for the safe code to be delivered to the bridge has been reduced from 2 minutes to 1 minute.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

In #state-of-orbstation, it was broadly agreed that there is currently a problem of people not playing heads of staff out of fear that they will be forced to be acting captain, especially as this means potentially losing an antagonist role at the start of the round. This set of changes was one proposal that got brought up, and several people thought it would be worth a try. I believe that there does not always need to be a captain or acting captain in every round, especially with the recent voluntary security changes. My hope is that this change will lead to more people playing heads of staff, treating the captain's spare ID more like something that can be broken out in case of emergencies or something that can be opted into without as much of an expectation to do "captainly" things, and less like an unfortunate obligation.

Undoubtedly, these changes will be controversial, at least at first, but it's clear that something needs to be done, and it's better to try things that may not work out rather than pre-emptively decide they won't. I would suggest having a two-week trial period for this in a manner similar to whitetext, after which we can discuss and decide whether we want to keep these changes or revert them.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

- Acting Captain will no longer be forced on heads of staff other than the Head of Personnel. The communications console on the Bridge can be used to request the code to the safe containing the captain's spare ID. This will announce who requested the safe code, and notify the admins if it was done by an antagonist.
- It now takes one minute to deliver the safe code to the station when requested instead of two.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
