### PR TITLE
Journeyman Wizard: Remedial Studies

### DIFF
--- a/orbstation/_globalvars/wizard_journeyman.dm
+++ b/orbstation/_globalvars/wizard_journeyman.dm
@@ -7,3 +7,6 @@
 #define DIPLOMA_SPELL_OFFENSIVE "offensive"
 #define DIPLOMA_SPELL_DEFENSIVE "defensive"
 #define DIPLOMA_SPELL_OTHER "other"
+
+/// Signal sent when you draw a rune, passed the rune
+#define GRAND_RITUAL_RUNE_DRAWN "grand_ritual_rune_drawn"

--- a/orbstation/antagonists/grand_ritual.dm
+++ b/orbstation/antagonists/grand_ritual.dm
@@ -47,3 +47,15 @@
 
 /datum/grand_finale/armageddon/death_yell(mob/living/carbon/human/invoker)
 	priority_announce(pick(possible_last_words + orb_last_words), null, 'sound/magic/voidblink.ogg', sender_override = "[invoker.real_name]")
+
+#define RITUAL_EXTRA_TIME 3 MINUTES
+
+// Extend active shuttle timers
+/obj/effect/grand_rune/on_invocation_complete(mob/living/user)
+	if (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED))
+		SSshuttle.emergency.setTimer(SSshuttle.emergency.timeLeft(1) + RITUAL_EXTRA_TIME)
+		var/time_left = SSshuttle.emergency.timeLeft()
+		priority_announce("Unexpected interference with shuttle routing calculations. [SSshuttle.emergency.mode == SHUTTLE_CALL ? "arrival" : "departure"] will now occur in an estimated [(time_left / 60) % 60]:[add_leading(num2text(time_left % 60), 2, "0")] minutes.", sound = ANNOUNCER_SPANOMALIES)
+	return ..()
+
+#undef RITUAL_EXTRA_TIME

--- a/orbstation/antagonists/wizard_journeyman/diploma/journeyman_diploma.dm
+++ b/orbstation/antagonists/wizard_journeyman/diploma/journeyman_diploma.dm
@@ -13,7 +13,7 @@
 	resistance_flags = FLAMMABLE
 
 	/// The number of spells you can pick remaining
-	var/picks_remaining = 3
+	var/picks_remaining = 4
 	/// The mind that first used this. Automatically assigned when a wizard spawns.
 	var/datum/mind/owner
 	/// A list of all purchased options
@@ -51,7 +51,7 @@
 			if (DIPLOMA_SPELL_OTHER)
 				spells_other[type] = possible_entry.weight
 
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 4)
 		entries += random_spell_from(spells_offensive)
 		entries += random_spell_from(spells_defensive)
 		entries += random_spell_from(spells_other)

--- a/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
+++ b/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
@@ -129,6 +129,6 @@
 
 /datum/diploma_spell/sanguine_strike
 	name = "Sanguine Strike"
-	desc = "Enchants an item you are holding to deal more damage on its next strike, as well as healing you!"
+	desc = "Enchants an item you are holding to deal more damage on its next strike, as well as healing you and restoring your blood!"
 	spell_type = /datum/action/cooldown/spell/sanguine_strike
 	category = DIPLOMA_SPELL_OFFENSIVE

--- a/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
+++ b/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
@@ -126,3 +126,9 @@
 	spell_type = /datum/action/cooldown/spell/touch/animate_limb
 	category = DIPLOMA_SPELL_OFFENSIVE
 	weight = DIPLOMA_SPELL_RARE
+
+/datum/diploma_spell/sanguine_strike
+	name = "Sanguine Strike"
+	desc = "Enchants an item you are holding to deal more damage on its next strike, as well as healing you!"
+	spell_type = /datum/action/cooldown/spell/sanguine_strike
+	category = DIPLOMA_SPELL_OFFENSIVE

--- a/orbstation/antagonists/wizard_journeyman/diploma/spell_other.dm
+++ b/orbstation/antagonists/wizard_journeyman/diploma/spell_other.dm
@@ -125,3 +125,10 @@
 	item_path = /obj/item/antag_spawner/contract
 	category = DIPLOMA_SPELL_OTHER
 	weight = DIPLOMA_SPELL_RARE
+
+/datum/diploma_spell/vampirism
+	name = "Marrabo's Splattercasting"
+	desc = "Empower yourself with blood magic, gaining vampiric qualities. Your spells cast much more rapidly but drain your blood as fuel. (Warning: Becoming a vampire will make you appear as a pale human)"
+	spell_type = /datum/action/cooldown/spell/splattercasting
+	category = DIPLOMA_SPELL_OTHER
+	weight = DIPLOMA_SPELL_RARE

--- a/tgui/packages/tgui/interfaces/AntagInfoWizardJourneyman.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoWizardJourneyman.tsx
@@ -85,8 +85,8 @@ export const AntagInfoWizardJourneyman = (props, context) => {
               <Stack vertical fill>
                 <Stack.Item>
                   Your magical diploma will remind you what spells you majored
-                  in during your studies. You get three choices from three
-                  categories, each of which will present you with three options.
+                  in during your studies. You get four choices from three
+                  categories, each of which will present you with four options.
                   <br />
                   <span style={destructionstyle}>
                     The first category will present you with spells or artifacts

--- a/tgui/packages/tgui/interfaces/SpellDiploma.tsx
+++ b/tgui/packages/tgui/interfaces/SpellDiploma.tsx
@@ -21,7 +21,7 @@ type Info = {
 export const SpellDiploma = (props, context) => {
   const { act, data } = useBackend<Info>(context);
   return (
-    <Window width={720} height={820} theme="wizard">
+    <Window width={940} height={820} theme="wizard">
       <Window.Content>
         <Stack vertical>
           <Stack.Item>
@@ -50,7 +50,7 @@ export const SpellDiploma = (props, context) => {
           <Stack.Item>
             <Section title="Major Selection">
               <Stack.Item>
-                Please select three of the nine options presented below.
+                Please select four of the twelve options presented below.
               </Stack.Item>
               <Stack.Item>You have {data.picks} choices remaining.</Stack.Item>
               <Stack.Item>


### PR DESCRIPTION
## About The Pull Request

Journeyman Wizards are much loved but also not usually very threatening, they tend to have to take a semi-friendly approach just because they're very easy to kill and not actually that dangerous.

I came up with three ideas to fix this and then added _all_ of them.
These are as follows:
- You can pick four spells instead of three.
- You pick from 12 spell options instead of nine.
- Every time you complete a ritual a random spell levels up.

What the latter essentially means is its cooldown gets reduced, up to a cap. If you have more artifacts (and thus fewer spells) you have more control over which ones get a reduced cooldown. Also true if you're a real daredevil and choose to leave one or two spell choices unselected on your diploma, risky!

As a bonus, this means the UI is now landscape in a similar manner to the graphic for the diploma.
![image](https://user-images.githubusercontent.com/7483112/219771426-a94aaf1e-59e5-4050-9353-46a89f86f65f.png)

Oh ALSO I removed the maroon objective from the Journeyman objective generation because while funny, they don't really have any ability to do it. And nobody does those anyway, everyone wants to draw circles.

Finally as a bonus they can also pick the new spell "Sanguine Strike" and the slightly older spell "Splattercasting", for some vampire flavour.
Is it good? I don't know. Kind of a long cooldown!

***Additional Feature*** by popular request.
Completing a ritual will delay an incoming or departing shuttle by 3 minutes. It has no effect on a shuttle which has already left.

## Why It's Good For The Game

Allows wizards to be more versatile and slightly more confident.
Creates less chance that you'll only be offered spells which don't match your intended plan at all.
Creates more incentive to do rituals (as if we needed any) which create antagonism with the crew.

## Changelog

:cl:
balance: Journeyman Wizards can now select four spells from a list of twelve, instead of three from a list of nine.
add: Every time a Journeyman Wizard completes a Grand Ritual, one of their spells at random has its cooldown permanently reduced. This can be done as many times as you perform rituals.
add: A new vampiric curriculum for Journeyman Wizards. Exchange your blood for power, use that power to acquire more blood.
add: Completing a Grand Ritual will delay the arrival or departure of the emergency shuttle. Don't let those wizards hold you up!
/:cl:
