### PR TITLE
Journeyman Wizard Artifact: Rod of Blasting

### DIFF
--- a/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
+++ b/orbstation/antagonists/wizard_journeyman/diploma/spell_offensive.dm
@@ -126,3 +126,11 @@
 	spell_type = /datum/action/cooldown/spell/touch/animate_limb
 	category = DIPLOMA_SPELL_OFFENSIVE
 	weight = DIPLOMA_SPELL_RARE
+
+/datum/diploma_spell/item/blasting_rod
+	name = "Rod of Blasting"
+	desc = "A wand so modern that most full wizard refuse to countenance its use. \
+		Accelerates conjured chunks of metal at high speeds towards your target, filling them with magical wounds."
+	item_path = /obj/item/gun/blasting_rod
+	category = DIPLOMA_SPELL_OFFENSIVE
+	weight = DIPLOMA_SPELL_RARE

--- a/orbstation/spells/wands/blasting_rod.dm
+++ b/orbstation/spells/wands/blasting_rod.dm
@@ -1,0 +1,36 @@
+/// A revolver with infinite ammo, pretending to be a wand.
+/obj/item/gun/blasting_rod
+	name = "Rod of Blasting"
+	desc = "A wand at the cutting edge of magical research. Conjures holes in targets with startling speed and accuracy by aetherically accelerating small pieces of metal."
+	icon_state = "c38"
+	fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
+	fire_delay = 1 SECONDS
+	obj_flags = NONE
+	unique_reskin = list(
+		"Default" = "c38",
+		"Fitz Special" = "c38_fitz",
+		"Police Positive Special" = "c38_police",
+		"Blued Steel" = "c38_blued",
+		"Stainless Steel" = "c38_stainless",
+		"Gold Trim" = "c38_trim",
+		"Golden" = "c38_gold",
+		"The Peacemaker" = "c38_peacemaker",
+		"Black Panther" = "c38_panther"
+	)
+
+/obj/item/gun/blasting_rod/Initialize(mapload)
+	. = ..()
+	chambered = new /obj/item/ammo_casing/blasting(src)
+
+/obj/item/gun/blasting_rod/handle_chamber(empty_chamber, from_firing, chamber_next_round)
+	chambered.newshot()
+
+/obj/item/ammo_casing/blasting
+	name = "enchanted casing"
+	desc = "A lump of runed metal."
+	projectile_type = /obj/projectile/bullet/blasting
+
+/obj/projectile/bullet/blasting
+	name = "bolt of blasting"
+	damage = 20
+	embedding = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5278,6 +5278,7 @@
 #include "orbstation\spells\robed_robeless_spells.dm"
 #include "orbstation\spells\spellbook.dm"
 #include "orbstation\spells\tentacle_burst.dm"
+#include "orbstation\spells\wands\blasting_rod.dm"
 #include "orbstation\spells\wands\discount_wands.dm"
 #include "orbstation\spells\wands\wand_animate.dm"
 #include "orbstation\spells\wands\wand_babel.dm"


### PR DESCRIPTION
## About The Pull Request

Journeyman Wizards will occasionally be offered the opportunity to purchase the "rod of blasting".
This is a new "wand" which is essentially a worse version of the spell "Arcane Barrage" (in that it fires slower and can be disarmed).

## Why It's Good For The Game

Honestly it's mostly just funny.

## Changelog

:cl:
add: Adds a new offensive wand for Journeyman Wizards which launches fast-moving chunks of metal.
/:cl:
