### PR TITLE
new mystery boxes & temporary mystery box variable

### DIFF
--- a/orbstation/objects/items/mysterybox.dm
+++ b/orbstation/objects/items/mysterybox.dm
@@ -103,6 +103,7 @@ GLOBAL_LIST_INIT(mystery_box_shoes, list(
 ))
 
 /obj/structure/mystery_box
+	/// By default will make mystery boxes permanent, but when set to true will add the temporary atom element the next time it is opened and closed.
 	var/temporary_box = FALSE
 
 /obj/structure/mystery_box/close_box()

--- a/orbstation/objects/items/mysterybox.dm
+++ b/orbstation/objects/items/mysterybox.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(mystery_box_shoes, list(
 ))
 
 /obj/structure/mystery_box
-	/// By default will make mystery boxes permanent, but when set to true will add the temporary atom element the next time it is opened and closed.
+	/// By default mystery boxes are permanent, but when this is set to true will add the temporary atom element the next time it is opened and closed.
 	var/temporary_box = FALSE
 
 /obj/structure/mystery_box/close_box()

--- a/orbstation/objects/items/mysterybox.dm
+++ b/orbstation/objects/items/mysterybox.dm
@@ -21,26 +21,31 @@ GLOBAL_LIST_INIT(mystery_box_cheese, list(
 ))
 
 GLOBAL_LIST_INIT(mystery_box_clown, list(
+	/obj/item/assembly/mousetrap,
 	/obj/item/bikehorn,
 	/obj/item/bikehorn/golden,
 	/obj/item/book/mimery,
-	/obj/item/clothing/head/frenchberet,
 	/obj/item/clothing/glasses/salesman,
 	/obj/item/extendohand,
 	/obj/item/firing_pin/clown/,
 	/obj/item/food/baguette,
 	/obj/item/food/grown/banana,
 	/obj/item/food/pie/cream,
+	/obj/item/grown/bananapeel,
 	/obj/item/implant/sad_trombone,
 	/obj/item/pneumatic_cannon/pie/,
 	/obj/item/reagent_containers/cup/glass/bottle/bottleofnothing,
 	/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
 	/obj/item/reagent_containers/spray/waterflower/lube,
-	/obj/item/shield/energy/bananium,
 	/obj/item/stack/sheet/mineral/bananium/five,
+	/obj/item/stack/tile/fakeice/loaded,
+	/obj/item/stack/tile/fakepit/loaded,
+	/obj/item/stack/tile/fakespace/loaded,
 	/obj/item/stamp/clown,
 	/obj/item/stamp/mime,
 	/obj/item/toy/balloon,
+	/obj/item/toy/crayon/spraycan/lubecan,
+	/obj/item/toy/dummy,
 	/obj/item/toy/figure/clown,
 	/obj/item/toy/figure/mime,
 	/obj/item/toy/mecha/darkhonk,
@@ -74,7 +79,7 @@ GLOBAL_LIST_INIT(mystery_box_clownevil, list(
 GLOBAL_LIST_INIT(mystery_box_shoes, list(
 	/obj/item/clothing/shoes/bhop,
 	/obj/item/clothing/shoes/bhop/rocket,
-	/obj/item/clothing/shoes/chameleon/noslip
+	/obj/item/clothing/shoes/chameleon/noslip,
 	/obj/item/clothing/shoes/clown_shoes/banana_shoes,
 	/obj/item/clothing/shoes/clown_shoes/ducky_shoes,
 	/obj/item/clothing/shoes/clown_shoes/jester,
@@ -97,27 +102,34 @@ GLOBAL_LIST_INIT(mystery_box_shoes, list(
 	/obj/item/clothing/shoes/winterboots/ice_boots/eva,
 ))
 
+/obj/structure/mystery_box
+	var/temporary_box = FALSE
+
+/obj/structure/mystery_box/close_box()
+	. = ..()
+	if(temporary_box)
+		AddElement(/datum/element/temporary_atom, 7 SECONDS, 5 SECONDS)
+
 /obj/structure/mystery_box/cheese
 	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of different items. This one seems focused on cheese."
 
-/obj/structure/mystery_box/guns/generate_valid_types()
-	valid_types = GLOB.summoned_cheese
+/obj/structure/mystery_box/cheese/generate_valid_types()
+	valid_types = GLOB.mystery_box_cheese
 
 /obj/structure/mystery_box/clown
 	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of funny items."
 
-/obj/structure/mystery_box/guns/generate_valid_types()
-	valid_types = GLOB.summoned_clown
+/obj/structure/mystery_box/clown/generate_valid_types()
+	valid_types = GLOB.mystery_box_clown
 
 /obj/structure/mystery_box/clownevil
 	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of funny items."
 
-/obj/structure/mystery_box/guns/generate_valid_types()
-	valid_types = GLOB.summoned_clown + GLOB.summoned_clownevil
-
+/obj/structure/mystery_box/clownevil/generate_valid_types()
+	valid_types = GLOB.mystery_box_clown + GLOB.mystery_box_clownevil
 
 /obj/structure/mystery_box/shoes
 	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of different items. This one seems focused on exclusive footwear."
 
-/obj/structure/mystery_box/guns/generate_valid_types()
-	valid_types = GLOB.summoned_shoes
+/obj/structure/mystery_box/shoes/generate_valid_types()
+	valid_types = GLOB.mystery_box_shoes

--- a/orbstation/objects/items/mysterybox.dm
+++ b/orbstation/objects/items/mysterybox.dm
@@ -1,0 +1,123 @@
+GLOBAL_LIST_INIT(mystery_box_cheese, list(
+	/obj/item/food/baked_cheese_platter,
+	/obj/item/food/cheese/curd_cheese,
+	/obj/item/food/cheese/cheese_curds,
+	/obj/item/food/cheese/firm_cheese,
+	/obj/item/food/cheese/firm_cheese_slice,
+	/obj/item/food/cheese/mozzarella,
+	/obj/item/food/cheese/royal,
+	/obj/item/food/cheese/wedge,
+	/obj/item/food/cheese/wheel,
+	/obj/item/food/crispy_headcheese,
+	/obj/item/food/grilled_cheese,
+	/obj/item/food/herby_cheese,
+	/obj/item/food/loaded_curds,
+	/obj/item/food/pizza/mothic_five_cheese,
+	/obj/item/food/raw_headcheese,
+	/obj/item/food/mac_balls,
+	/obj/item/food/mozzarella_sticks,
+	/obj/item/food/soup/moth_cheese_soup,
+	/obj/item/food/sustenance_bar/cheese,
+))
+
+GLOBAL_LIST_INIT(mystery_box_clown, list(
+	/obj/item/bikehorn,
+	/obj/item/bikehorn/golden,
+	/obj/item/book/mimery,
+	/obj/item/clothing/head/frenchberet,
+	/obj/item/clothing/glasses/salesman,
+	/obj/item/extendohand,
+	/obj/item/firing_pin/clown/,
+	/obj/item/food/baguette,
+	/obj/item/food/grown/banana,
+	/obj/item/food/pie/cream,
+	/obj/item/implant/sad_trombone,
+	/obj/item/pneumatic_cannon/pie/,
+	/obj/item/reagent_containers/cup/glass/bottle/bottleofnothing,
+	/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
+	/obj/item/reagent_containers/spray/waterflower/lube,
+	/obj/item/shield/energy/bananium,
+	/obj/item/stack/sheet/mineral/bananium/five,
+	/obj/item/stamp/clown,
+	/obj/item/stamp/mime,
+	/obj/item/toy/balloon,
+	/obj/item/toy/figure/clown,
+	/obj/item/toy/figure/mime,
+	/obj/item/toy/mecha/darkhonk,
+	/obj/item/toy/mecha/honk,
+	/obj/item/toy/mecha/reticence,
+	/obj/item/toy/snappop,
+	/obj/item/toy/waterballoon,
+))
+
+GLOBAL_LIST_INIT(mystery_box_clownevil, list(
+	/obj/item/bikehorn/airhorn,
+	/obj/item/clothing/shoes/clown_shoes/banana_shoes,
+	/obj/item/clothing/shoes/clown_shoes/combat,
+	/obj/item/dnainjector/clumsymut,
+	/obj/item/firing_pin/clown/ultra,
+	/obj/item/firing_pin/clown/ultra/selfdestruct,
+	/obj/item/food/baguette/combat,
+	/obj/item/food/croissant/throwing,
+	/obj/item/food/grown/banana/bombanana,
+	/obj/item/grenade/chem_grenade/teargas/moustache,
+	/obj/item/hot_potato/syndicate,
+	/obj/item/melee/energy/sword/bananium,
+	/obj/item/pneumatic_cannon/pie/selfcharge,
+	/obj/item/reagent_containers/spray/waterflower/superlube,
+	/obj/item/reverse_bear_trap,
+	/obj/item/sbeacondrop/clownbomb,
+	/obj/item/shield/energy/bananium,
+	/obj/item/sord,
+))
+
+GLOBAL_LIST_INIT(mystery_box_shoes, list(
+	/obj/item/clothing/shoes/bhop,
+	/obj/item/clothing/shoes/bhop/rocket,
+	/obj/item/clothing/shoes/chameleon/noslip
+	/obj/item/clothing/shoes/clown_shoes/banana_shoes,
+	/obj/item/clothing/shoes/clown_shoes/ducky_shoes,
+	/obj/item/clothing/shoes/clown_shoes/jester,
+	/obj/item/clothing/shoes/clown_shoes/meown_shoes,
+	/obj/item/clothing/shoes/cowboy/fancy,
+	/obj/item/clothing/shoes/cult,
+	/obj/item/clothing/shoes/glow,
+	/obj/item/clothing/shoes/gunboots,
+	/obj/item/clothing/shoes/gunboots/disabler,
+	/obj/item/clothing/shoes/kindle_kicks,
+	/obj/item/clothing/shoes/laceup,
+	/obj/item/clothing/shoes/magboots,
+	/obj/item/clothing/shoes/russian,
+	/obj/item/clothing/shoes/sandal/magic,
+	/obj/item/clothing/shoes/sneakers/marisa,
+	/obj/item/clothing/shoes/swagshoes,
+	/obj/item/clothing/shoes/wheelys,
+	/obj/item/clothing/shoes/wheelys/rollerskates,
+	/obj/item/clothing/shoes/wheelys/skishoes,
+	/obj/item/clothing/shoes/winterboots/ice_boots/eva,
+))
+
+/obj/structure/mystery_box/cheese
+	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of different items. This one seems focused on cheese."
+
+/obj/structure/mystery_box/guns/generate_valid_types()
+	valid_types = GLOB.summoned_cheese
+
+/obj/structure/mystery_box/clown
+	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of funny items."
+
+/obj/structure/mystery_box/guns/generate_valid_types()
+	valid_types = GLOB.summoned_clown
+
+/obj/structure/mystery_box/clownevil
+	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of funny items."
+
+/obj/structure/mystery_box/guns/generate_valid_types()
+	valid_types = GLOB.summoned_clown + GLOB.summoned_clownevil
+
+
+/obj/structure/mystery_box/shoes
+	desc = "A wooden crate that seems equally magical and mysterious, capable of granting the user all kinds of different items. This one seems focused on exclusive footwear."
+
+/obj/structure/mystery_box/guns/generate_valid_types()
+	valid_types = GLOB.summoned_shoes

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5214,6 +5214,7 @@
 #include "orbstation\objects\items\debug_items.dm"
 #include "orbstation\objects\items\hearing_aid.dm"
 #include "orbstation\objects\items\magazines.dm"
+#include "orbstation\objects\items\mysterybox.dm"
 #include "orbstation\objects\items\orb.dm"
 #include "orbstation\objects\items\poster.dm"
 #include "orbstation\objects\items\prescription_lenses.dm"


### PR DESCRIPTION
## About The Pull Request

while fixing something upstream today jac found out about mystery boxes but the only two options are guns and more guns so i decided to make FOUR fun NEW mystery boxes for admins to spawn.
to facilitate spawning dangerous ones, ive also added a new variable which, after the next time the box is opened, upon closing will self apply the temporary atom element, which means that the box will soon vanish! this means that rather than a stream of bad items, its just one or two.

the new boxes are a box full of cheese food items, one full of shoes, one full of clown items, and one full of clown items and also traitor and clown ops items

## Why It's Good For The Game

more fun admin toys

## Changelog

:cl:
add: four new mystery boxes! clown, evil clown, shoes, and cheese!
admin: mystery boxes now have a variable that lets you varedit them into being temporary
/:cl:

