### PR TITLE
Teleporter accidents no longer immediately fly you.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -78,7 +78,24 @@
 			use_power(active_power_usage)
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
-					var/mob/living/carbon/human/human = M
+					//ORBSTATION ADDITION: Give people fly organs on a teleporter accident.
+					var/list/fly_organs = list(
+						/obj/item/organ/internal/eyes/fly,
+						/obj/item/organ/internal/tongue/fly,
+						/obj/item/organ/internal/heart/fly,
+						/obj/item/organ/internal/lungs/fly,
+						/obj/item/organ/internal/liver/fly,
+						/obj/item/organ/internal/stomach/fly,
+						/obj/item/organ/internal/appendix/fly,
+					)
+					var/obj/item/organ/new_organ = pick(fly_organs)
+					if(new_organ)
+						new_organ = new new_organ()
+						to_chat(M, span_hear("You hear a buzzing in your ears."))
+						new_organ.Insert(M, special = TRUE, drop_if_replaced = FALSE)
+					//END ORBSTATION ADDITION
+					//ORBSTATION REMOVAL: Don't turn people into flies.
+					/*var/mob/living/carbon/human/human = M
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						var/datum/species/species_to_transform = /datum/species/fly
 						if(check_holidays(MOTH_WEEK))
@@ -86,7 +103,8 @@
 						if(human.dna && human.dna.species.id != initial(species_to_transform.id))
 							to_chat(M, span_hear("You hear a buzzing in your ears."))
 							human.set_species(species_to_transform)
-							human.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)
+							human.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)*/
+					//END ORBSTATION REMOVAL
 			calibrated = FALSE
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says, teleporter accidents no longer instantly turn you into a flyperson. Instead, they will give you a random flyperson organ, as the DNA infuser does when loaded with an invalid mob. If you obtain four of these organs, you permanently transform into a flyperson.

This is just one possible solution, so if anyone has a better one in mind, I'm fine with that. I figure the flyperson organs mostly suck enough to be punishment for your hubris anyway - except they can be removed by doctors.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was requested. A number of people, myself included, are uncomfortable with an unlisted feature that permanently transforms your character into a joke species. I figure that this, taking advantage of the relatively new DNA infusion system, still punishes you without ruining your character. And if you _want_ to become a fly... just run through the teleporter several times.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Spinward Sector Megafly has gone extinct. Remaining fly species are only big enough to transform one of your organs if there's a terrible mishap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
