### PR TITLE
The Fully Augmented quirk now respects digitigrade legs.

### DIFF
--- a/orbstation/quirks/augmented.dm
+++ b/orbstation/quirks/augmented.dm
@@ -9,8 +9,12 @@
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/)
 	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/)
+	if(human_holder.dna.species.bodytype & BODYTYPE_DIGITIGRADE)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/digitigrade)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/digitigrade)
+	else
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/)
 
 /datum/quirk/augmented/post_add()
 	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with cybernetic parts. They are roughly analogous to organic limbs. However, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The "Fully Augmented" quirk will now give you digitigrade cyborg legs if you're supposed to have digitigrade legs, rather than regular ones.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You probably chose digitigrade legs because you want digitigrade legs.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fully Augmented gives you digitigrade legs if you're supposed to have them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
