### PR TITLE
EMPing cyberlimbs does stamina damage instead of paralysis and emits sparks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -503,14 +503,16 @@
 		if(!IS_ORGANIC_LIMB(L))
 			if(!informed)
 				to_chat(src, span_userdanger("You feel a sharp pain as your robotic limbs overload."))
+				do_sparks(5, 0, src) // ORBSTATION
 				informed = TRUE
 			switch(severity)
 				if(1)
 					L.receive_damage(0,10)
-					Paralyze(200)
+					adjustStaminaLoss(20) // ORBSTATION
 				if(2)
 					L.receive_damage(0,5)
-					Paralyze(100)
+					adjustStaminaLoss(10) // ORBSTATION
+
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This removes the _**10 or 20 second hardstun**_ that EMPs do to people who have cybernetic limbs and replaces it with stamina damage per limb. Also, the person will now emit sparks when EMPed, which can, of course, light nearby plasma on fire.

This change isn't modular due to the way the original proc is coded; attempting to make it modular just made the old effect happen in addition to the new one, which isn't what I wanted. But at least this is only three lines of code.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Most of the hardstuns were smartly removed from this game ages ago, so it's bizarre that these are still here. Getting punished with a 10 or 20 second stun just for having one cybernetic limb is ridiculous and turns the ion rifle into a binary hard counter against people with any of the cybernetic quirks. Changing it to stamina damage makes it much more fair to deal with, and also means that people with only one cybernetic limb will be less impacted than people with four.

I added the sparks because I thought it would be funny.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
- EMP no longer hardstuns people with cybernetic limbs, instead dealing stamina damage per each limb.
- People with cybernetic limbs now emit sparks when EMPed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
