### PR TITLE
Deadchat Control Brain Trauma Adjustment & Deadchat Control Smite

### DIFF
--- a/orbstation/admin/deachatsmite.dm
+++ b/orbstation/admin/deachatsmite.dm
@@ -1,5 +1,15 @@
+/datum/smite/deadchatpossession
+	name = "Ghost Control"
 
-	owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
+/datum/smite/deadchatpossession/effect
+	target.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
 		"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
 		"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
+		"fall" = CALLBACK(owner, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
+		"drop" = CALLBACK(owner, TYPE_PROC_REF(/mob, drop_all_held_items)),
+		"throw" = CALLBACK(owner, ),
+		"shove" = CALLBACK(owner, ),
 		), 7 SECONDS)
+
+	to_chat(target, span_warning("You are now being possesed by ghosts!"))
+

--- a/orbstation/admin/deachatsmite.dm
+++ b/orbstation/admin/deachatsmite.dm
@@ -1,0 +1,5 @@
+
+	owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
+		"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
+		"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
+		), 7 SECONDS)

--- a/orbstation/admin/deachatsmite.dm
+++ b/orbstation/admin/deachatsmite.dm
@@ -1,15 +1,51 @@
 /datum/smite/deadchatpossession
 	name = "Ghost Control"
 
-/datum/smite/deadchatpossession/effect
+/datum/smite/deadchatpossession/effect(client/user, mob/living/target)
 	target.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
-		"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
-		"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
-		"fall" = CALLBACK(owner, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
-		"drop" = CALLBACK(owner, TYPE_PROC_REF(/mob, drop_all_held_items)),
-		"throw" = CALLBACK(owner, ),
-		"shove" = CALLBACK(owner, ),
+		"spin" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "spin"),
+		"flip" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "flip"),
+		"cry" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "cry"),
+		"laugh" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "laugh"),
+		"scream" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "scream"),
+		"swear" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "swear"),
+		"clap" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "clap"),
+		"fall" = CALLBACK(target, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
+		"drop" = CALLBACK(target, TYPE_PROC_REF(/mob, drop_all_held_items)),
+		"throw" = CALLBACK(target, TYPE_PROC_REF(/mob, throw_item), get_edge_target_turf(target, pick(GLOB.alldirs))),
+		"shove" = CALLBACK(src, PROC_REF(ghost_shove), target),
+		"sit" = CALLBACK(src, PROC_REF(ghost_sit), target),
+		"stand" = CALLBACK(target, TYPE_PROC_REF(/mob/living, resist_buckle)),
+		"walk" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_WALK),
+		"run" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_RUN),
 		), 7 SECONDS)
 
-	to_chat(target, span_warning("You are now being possesed by ghosts!"))
+	to_chat(target, span_revenwarning("You feel a ghastly presence!!!"))
 
+
+/datum/smite/deadchatpossession/proc/ghost_shove(mob/living/carbon/target)
+	if(!istype(target) || target.get_active_held_item())
+		return
+	var/list/shoveables = list()
+	for(var/mob/living/victim in orange(1, target))
+		shoveables += victim
+	if(!length(shoveables))
+		return
+	var/mob/living/shove_me = pick(shoveables)
+	target.attack_hand_secondary(shove_me)
+
+/datum/smite/deadchatpossession/proc/ghost_sit(mob/living/target)
+	if(HAS_TRAIT(target, TRAIT_IMMOBILIZED))
+		return
+	var/list/chairs = list()
+	for(var/obj/structure/chair/possible_chair in range(1, target))
+		chairs += possible_chair
+	if(!length(chairs))
+		return
+	var/obj/structure/chair/sitting_chair = pick(chairs)
+	sitting_chair.buckle_mob(target, check_loc = FALSE)
+
+/datum/smite/deadchatpossession/proc/ghost_speed(mob/living/target, new_speed)
+	if(target.m_intent == new_speed)
+		return
+	target.toggle_move_intent()

--- a/orbstation/admin/deachatsmite.dm
+++ b/orbstation/admin/deachatsmite.dm
@@ -3,21 +3,21 @@
 
 /datum/smite/deadchatpossession/effect(client/user, mob/living/target)
 	target.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
-		"spin" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "spin"),
-		"flip" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "flip"),
+		"clap" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "clap"),
 		"cry" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "cry"),
+		"flip" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "flip"),
 		"laugh" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "laugh"),
 		"scream" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "scream"),
+		"spin" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "spin"),
 		"swear" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "swear"),
-		"clap" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "clap"),
-		"fall" = CALLBACK(target, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
 		"drop" = CALLBACK(target, TYPE_PROC_REF(/mob, drop_all_held_items)),
+		"fall" = CALLBACK(target, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
+		"stand" = CALLBACK(target, TYPE_PROC_REF(/mob/living, resist_buckle)),
 		"throw" = CALLBACK(target, TYPE_PROC_REF(/mob, throw_item), get_edge_target_turf(target, pick(GLOB.alldirs))),
 		"shove" = CALLBACK(src, PROC_REF(ghost_shove), target),
 		"sit" = CALLBACK(src, PROC_REF(ghost_sit), target),
-		"stand" = CALLBACK(target, TYPE_PROC_REF(/mob/living, resist_buckle)),
-		"walk" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_WALK),
 		"run" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_RUN),
+		"walk" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_WALK),
 		), 7 SECONDS)
 
 	to_chat(target, span_revenwarning("You feel a ghastly presence!!!"))

--- a/orbstation/medical/brain_trauma.dm
+++ b/orbstation/medical/brain_trauma.dm
@@ -39,7 +39,12 @@ GLOBAL_LIST_INIT(orb_mysterious_brain_traumas, list(
 		owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
 			"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
 			"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
-			), 7 SECONDS)
+			"cry" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "cry"),
+			"clap" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "clap"),
+			"laugh" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "laugh"),
+			"scream" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "scream"),
+			"swear" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "swear"),
+			), 10 SECONDS)
 
 /datum/brain_trauma/severe/split_personality/proc/on_stat_change(mob/living/owner, new_stat, old_stat)
 	SIGNAL_HANDLER

--- a/orbstation/medical/brain_trauma.dm
+++ b/orbstation/medical/brain_trauma.dm
@@ -34,13 +34,29 @@ GLOBAL_LIST_INIT(orb_mysterious_brain_traumas, list(
 
 /// if someone wants to juice this up more than this thats fine but just moving all around is probably decent enough
 /datum/brain_trauma/severe/split_personality/on_gain()
-	owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
-		"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
-		"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
-		), 7 SECONDS)
+	RegisterSignal(owner, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
+	if(owner.stat != DEAD)
+		owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
+			"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
+			"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
+			), 7 SECONDS)
+
+/datum/brain_trauma/severe/split_personality/proc/on_stat_change(mob/living/owner, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(new_stat == old_stat)
+		return
+	if(new_stat == DEAD)
+		qdel(owner.GetComponent(/datum/component/deadchat_control/cardinal_movement))
+		return
+	if(old_stat == DEAD)
+		owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
+			"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
+			"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
+			), 7 SECONDS)
 
 /datum/brain_trauma/severe/split_personality/on_lose()
 	qdel(owner.GetComponent(/datum/component/deadchat_control/cardinal_movement))
+	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 
 /// have to override this bc split personality has its own on this
 /datum/brain_trauma/severe/split_personality/on_life(delta_time, times_fired)

--- a/orbstation/medical/brain_trauma.dm
+++ b/orbstation/medical/brain_trauma.dm
@@ -37,12 +37,12 @@ GLOBAL_LIST_INIT(orb_mysterious_brain_traumas, list(
 	RegisterSignal(owner, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 	if(owner.stat != DEAD)
 		owner.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
-			"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
-			"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
-			"cry" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "cry"),
 			"clap" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "clap"),
+			"cry" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "cry"),
+			"flip" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "flip"),
 			"laugh" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "laugh"),
 			"scream" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "scream"),
+			"spin" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "spin"),
 			"swear" = CALLBACK(owner, TYPE_PROC_REF(/mob, emote), "swear"),
 			), 10 SECONDS)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5106,6 +5106,7 @@
 #include "orbstation\_globalvars\pod_bloodtypes.dm"
 #include "orbstation\_globalvars\traits.dm"
 #include "orbstation\_globalvars\wizard_journeyman.dm"
+#include "orbstation\admin\deachatsmite.dm"
 #include "orbstation\antagonists\acting_captain_check.dm"
 #include "orbstation\antagonists\dynamic.dm"
 #include "orbstation\antagonists\grand_ritual.dm"


### PR DESCRIPTION
## About The Pull Request
The Possession brain trauma no longer applies to dead people, if you die when it is applied it will turn off and when you come back to life it will turn on again. Additionally, other than spinning and flipping, you can be made to laugh, cry, scream, swear, and clap on command by ghosts. This is good because it is longer time that they are not moving you. The cooldown is also increased between commands to 10.

I have also added a new option in the smite menu that shares some stuff from the brain trauma.
![dreamseeker_MEwSKVsb3g](https://user-images.githubusercontent.com/116288367/219878222-6a186f8e-e7bb-4a2e-8035-e9aa483cb99d.png)

Ghost Control is a new smite option that is similar to the brain trauma, but is unremovable and has the 7 second cooldown applied. There are also some more, nastier options in this version, such as throwing or dropping your held item, falling to the floor, buckling yourself to the nearest chair, shoving a random person near you, and changing your movement intent.
![dreamseeker_PSA3RII1fc](https://user-images.githubusercontent.com/116288367/219878224-c9888dcc-82bd-4086-a4c9-ca90f2f51516.png)

It also has the emotes from the brain trauma.

## Why It's Good For The Game

while it was cute to take that skeleton to medbay its probably bad for random rotting corpses no where near the station to notify deadchat that you can control them. also more emotes is more fun and means that nasty ghosts will not just be moving you up and down. the 10 seconds is bc while no player has had to have it i think its fine to be a little nicer.

the smite is good for the game so that we can punish glup shizzo when she renames the station "glup house 13"

## Changelog

:cl:
add: possession's deadchat control has new emotes added to it
balance: possession's deadchat control cooldown is 10 seconds instead of 7
admin: ghost control is a new smite that lets you give someone the deadchat control component
/:cl: