### PR TITLE
Adds antagonist roll weighting system

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -248,7 +248,10 @@
 			candidates -= player // We don't autotator people with roles already
 
 /datum/dynamic_ruleset/midround/from_living/autotraitor/execute()
-	var/mob/M = pick(candidates)
+	/// ORB: change to weighted pick
+	var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+	var/mob/M = pick_weight(weighted_candidates)
+	/// ORB: end
 	assigned += M
 	candidates -= M
 	var/datum/antagonist/traitor/newTraitor = new
@@ -477,7 +480,11 @@
 /datum/dynamic_ruleset/midround/from_living/blob_infection/execute()
 	if(!candidates || !candidates.len)
 		return FALSE
-	var/mob/living/carbon/human/blob_antag = pick_n_take(candidates)
+	/// ORB: change to weighted pick
+	var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+	var/mob/blob_antag = pick_weight(weighted_candidates)
+	candidates -= blob_antag
+	/// ORB: end
 	assigned += blob_antag.mind
 	blob_antag.mind.special_role = antag_flag
 	return ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -36,7 +36,11 @@
 	for (var/i = 1 to num_traitors)
 		if(candidates.len <= 0)
 			break
-		var/mob/M = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/M = pick_weight(weighted_candidates)
+		candidates -= M
+		/// ORB: end
 		assigned += M.mind
 		M.mind.special_role = ROLE_TRAITOR
 		M.mind.restricted_roles = restricted_roles
@@ -81,7 +85,11 @@
 	for (var/i in 1 to num_malf)
 		if(candidates.len <= 0)
 			break
-		var/mob/new_malf = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/new_malf = pick_weight(weighted_candidates)
+		candidates -= new_malf
+		/// ORB: end
 		assigned += new_malf.mind
 		new_malf.mind.special_role = ROLE_MALF
 		GLOB.pre_setup_antags += new_malf.mind
@@ -129,7 +137,11 @@
 		var/datum/team/brother_team/team = new
 		var/team_size = prob(10) ? min(3, candidates.len) : 2
 		for(var/k = 1 to team_size)
-			var/mob/bro = pick_n_take(candidates)
+			/// ORB: change to weighted pick
+			var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+			var/mob/bro = pick_weight(weighted_candidates)
+			candidates -= bro
+			/// ORB: end
 			assigned += bro.mind
 			team.add_member(bro.mind)
 			bro.mind.special_role = "brother"
@@ -183,7 +195,11 @@
 	for (var/i = 1 to num_changelings)
 		if(candidates.len <= 0)
 			break
-		var/mob/M = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/M = pick_weight(weighted_candidates)
+		candidates -= M
+		/// ORB: end
 		assigned += M.mind
 		M.mind.restricted_roles = restricted_roles
 		M.mind.special_role = ROLE_CHANGELING
@@ -234,7 +250,11 @@
 	for (var/i = 1 to num_ecult)
 		if(candidates.len <= 0)
 			break
-		var/mob/picked_candidate = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/picked_candidate = pick_weight(weighted_candidates)
+		candidates -= picked_candidate
+		/// ORB: end
 		assigned += picked_candidate.mind
 		picked_candidate.mind.restricted_roles = restricted_roles
 		picked_candidate.mind.special_role = ROLE_HERETIC
@@ -301,7 +321,11 @@
 	. = ..()
 	if(GLOB.wizardstart.len == 0)
 		return FALSE
-	var/mob/M = pick_n_take(candidates)
+	/// ORB: change to weighted pick
+	var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+	var/mob/M = pick_weight(weighted_candidates)
+	candidates -= M
+	/// ORB: end
 	if (M)
 		assigned += M.mind
 		M.mind.set_assigned_role(SSjob.GetJobType(/datum/job/space_wizard))
@@ -356,7 +380,11 @@
 	for(var/cultists_number = 1 to cultists)
 		if(candidates.len <= 0)
 			break
-		var/mob/M = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/M = pick_weight(weighted_candidates)
+		candidates -= M
+		/// ORB: end
 		assigned += M.mind
 		M.mind.special_role = ROLE_CULTIST
 		M.mind.restricted_roles = restricted_roles
@@ -432,7 +460,11 @@
 	for(var/operatives_number = 1 to operatives)
 		if(candidates.len <= 0)
 			break
-		var/mob/M = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/M = pick_weight(weighted_candidates)
+		candidates -= M
+		/// ORB: end
 		assigned += M.mind
 		M.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 		M.mind.special_role = ROLE_NUCLEAR_OPERATIVE
@@ -532,7 +564,11 @@
 	for(var/i = 1 to max_candidates)
 		if(candidates.len <= 0)
 			break
-		var/mob/M = pick_n_take(candidates)
+		/// ORB: change to weighted pick
+		var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+		var/mob/M = pick_weight(weighted_candidates)
+		candidates -= M
+		/// ORB: end
 		assigned += M.mind
 		M.mind.restricted_roles = restricted_roles
 		M.mind.special_role = antag_flag

--- a/orbstation/antagonists/rulesets_midround.dm
+++ b/orbstation/antagonists/rulesets_midround.dm
@@ -123,9 +123,10 @@
 			candidates -= player
 
 /datum/dynamic_ruleset/midround/from_living/waking_heretic/execute()
-	var/mob/picked_mob = pick(candidates)
-	assigned += picked_mob
+	var/list/weighted_candidates = generate_weighted_candidate_list(candidates)
+	var/mob/picked_mob = pick_weight(weighted_candidates)
 	candidates -= picked_mob
+	assigned += picked_mob
 	var/datum/antagonist/heretic/new_heretic = picked_mob.mind.add_antag_datum(antag_datum)
 	message_admins("[ADMIN_LOOKUPFLW(picked_mob)] was selected by the [name] ruleset and has been made into a midround heretic.")
 	log_game("DYNAMIC: [key_name(picked_mob)] was selected by the [name] ruleset and has been made into a midround heretic.")

--- a/orbstation/antagonists/weighting.dm
+++ b/orbstation/antagonists/weighting.dm
@@ -41,7 +41,7 @@
 		if (ckey in rounds_since_ckey_was_antagonist)
 			new_rounds_since_antagonist_count[ckey] = min(8, rounds_since_ckey_was_antagonist[ckey] + 1)
 			continue
-		new_rounds_since_antagonist_count[ckey] = 1 // Start new players low
+		new_rounds_since_antagonist_count[ckey] = 2 // They just finished their first one
 
 	for (var/ckey in rounds_since_ckey_was_antagonist) // Don't forget people who weren't here
 		if (ckey in new_rounds_since_antagonist_count)

--- a/orbstation/antagonists/weighting.dm
+++ b/orbstation/antagonists/weighting.dm
@@ -64,7 +64,7 @@
 		weighted_candidates[candidate] = ROUND_UP(rounds_since_last / ROUNDS_PER_WEIGHT) // Increase weight by 1 every 2 rounds
 	return weighted_candidates
 
-#define TIME_UNTIL_SURE 20 MINUTES
+#define TIME_UNTIL_SURE 25 MINUTES
 
 // Mark some antagonists as being things we care about for weight calculation
 /datum/antagonist

--- a/orbstation/antagonists/weighting.dm
+++ b/orbstation/antagonists/weighting.dm
@@ -64,6 +64,8 @@
 		weighted_candidates[candidate] = ROUND_UP(rounds_since_last / ROUNDS_PER_WEIGHT) // Increase weight by 1 every 2 rounds
 	return weighted_candidates
 
+#define TIME_UNTIL_SURE 20 MINUTES
+
 // Mark some antagonists as being things we care about for weight calculation
 /datum/antagonist
 	/// If true then having this datum assigned will reset your weight at the end of a round
@@ -73,7 +75,15 @@
 	. = ..()
 	if(!owner || !owner.current || !weighted_antagonist)
 		return
+	addtimer(CALLBACK(src, PROC_REF(record_antagonist_ckey)), TIME_UNTIL_SURE, TIMER_DELETE_ME)
+
+/// Adds someone to our list of "people who need their rounds since they were evil" count reset
+/datum/antagonist/proc/record_antagonist_ckey()
+	if(!owner || !owner.current)
+		return
 	SSpersistence.current_round_weighted_antagonists |= owner.current.ckey
+
+#undef TIME_UNTIL_SURE
 
 /datum/antagonist/traitor
 	weighted_antagonist = TRUE

--- a/orbstation/antagonists/weighting.dm
+++ b/orbstation/antagonists/weighting.dm
@@ -1,0 +1,106 @@
+/// The number of rounds at which we stop counting
+#define MAX_WEIGHTED_ROUND_COUNT 8
+/// Increase weight by one every X rounds
+#define ROUNDS_PER_WEIGHT 2
+
+// System changes to spread antagonist weight out somewhat between rounds
+/datum/controller/subsystem/persistence
+	/// Associative list of ckey to how likely they should be to get an antagonist role
+	var/list/rounds_since_ckey_was_antagonist = list()
+	/// List of ckeys who were given weighted antagonist roles in this round
+	var/list/current_round_weighted_antagonists = list()
+
+/datum/controller/subsystem/persistence/Initialize()
+	. = ..()
+	load_antag_weights()
+
+/datum/controller/subsystem/persistence/collect_data()
+	. = ..()
+	update_antag_weights()
+
+#define ANTAG_WEIGHTS_PATH "data/antag_weighting.json"
+
+/// Load our saved list of ckeys to "time since they were an antagonist" from a file
+/datum/controller/subsystem/persistence/proc/load_antag_weights()
+	var/file = file(ANTAG_WEIGHTS_PATH)
+	if(!fexists(file))
+		return
+	var/weight_json = file2text(file)
+	rounds_since_ckey_was_antagonist = json_decode(weight_json)
+
+/// Save a new round end count of ckeys to "time since they were an antagonist" to a file
+/datum/controller/subsystem/persistence/proc/update_antag_weights()
+	var/file = file(ANTAG_WEIGHTS_PATH)
+	fdel(file)
+
+	var/list/new_rounds_since_antagonist_count = list()
+	for (var/ckey in GLOB.joined_player_list)
+		if (ckey in SSpersistence.current_round_weighted_antagonists)
+			new_rounds_since_antagonist_count[ckey] = 1
+			continue
+		if (ckey in rounds_since_ckey_was_antagonist)
+			new_rounds_since_antagonist_count[ckey] = min(8, rounds_since_ckey_was_antagonist[ckey] + 1)
+			continue
+		new_rounds_since_antagonist_count[ckey] = 1 // Start new players low
+
+	for (var/ckey in rounds_since_ckey_was_antagonist) // Don't forget people who weren't here
+		if (ckey in new_rounds_since_antagonist_count)
+			continue
+		new_rounds_since_antagonist_count[ckey] = rounds_since_ckey_was_antagonist[ckey]
+
+	WRITE_FILE(file, json_encode(new_rounds_since_antagonist_count))
+
+#undef ANTAG_WEIGHTS_PATH
+
+/// Takes a list of candidates, returns a weighted list of candidates.
+/datum/dynamic_ruleset/proc/generate_weighted_candidate_list()
+	var/list/weighted_candidates = list()
+	for (var/mob/candidate as anything in candidates)
+		var/key = candidate.ckey
+		if (!(key in SSpersistence.rounds_since_ckey_was_antagonist))
+			weighted_candidates[candidate] = 1
+			continue
+		var/rounds_since_last = SSpersistence.rounds_since_ckey_was_antagonist[key]
+		weighted_candidates[candidate] = ROUND_UP(rounds_since_last / ROUNDS_PER_WEIGHT) // Increase weight by 1 every 2 rounds
+	return weighted_candidates
+
+// Mark some antagonists as being things we care about for weight calculation
+/datum/antagonist
+	/// If true then having this datum assigned will reset your weight at the end of a round
+	var/weighted_antagonist = FALSE
+
+/datum/antagonist/on_gain()
+	. = ..()
+	if(!owner || !owner.current || !weighted_antagonist)
+		return
+	SSpersistence.current_round_weighted_antagonists |= owner.current.ckey
+
+/datum/antagonist/traitor
+	weighted_antagonist = TRUE
+
+/datum/antagonist/brother
+	weighted_antagonist = TRUE
+
+/datum/antagonist/changeling
+	weighted_antagonist = TRUE
+
+/datum/antagonist/changeling/infiltrator
+	weighted_antagonist = FALSE // We don't count ghost roles
+
+/datum/antagonist/heretic
+	weighted_antagonist = TRUE
+
+/datum/antagonist/malf_ai
+	weighted_antagonist = TRUE
+
+/datum/antagonist/blob/infection
+	weighted_antagonist = TRUE // lol just for consistency
+
+/datum/antagonist/rev
+	weighted_antagonist = TRUE
+
+/datum/antagonist/cult
+	weighted_antagonist = TRUE
+
+#undef MAX_WEIGHTED_ROUND_COUNT
+#undef ROUNDS_PER_WEIGHT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5113,6 +5113,7 @@
 #include "orbstation\antagonists\rulesets_midround.dm"
 #include "orbstation\antagonists\steal_owned_items.dm"
 #include "orbstation\antagonists\transform_gland.dm"
+#include "orbstation\antagonists\weighting.dm"
 #include "orbstation\antagonists\zetan_pirates.dm"
 #include "orbstation\antagonists\changeling_infiltrator\changeling_infiltrator.dm"
 #include "orbstation\antagonists\heretic\heretic_items.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a system which weights Roundstart and Midround antagonist rolls which draw from living players based on how recently you received one of those roles.
This system does not effect how likely you are to become a latejoin antagonist because that is chosen before any particular candidate becomes available (admins can actually check in advance if an incoming player is going to be given an antagonist role).
This system also does not get involved in ghost role selection, partly because it would be awkward to intercept and partly because I think it would lead to odd behaviour around which ghost roles people do and do not sign up for.

The way the system works is that every account has a tracked count of "rounds since you were last an antagonist". 
At the end of the round, if you were not previously recorded in this file then your count is reset to 2. You are also counted as having a count of 1 for the pre-end duration of any round where you are a new player and not yet recorded in the list.
If at any point during the round you received a certain antagonist role (generally, those that are selected from living players at roundstart or midround) **and kept it for at least 25 minutes** then at the end of the round your count will be reset to 1.
Everyone else's count is increased by 1, up to a cap of 8 rounds.

The exceptions are nuke ops and wizard, generally because it's impossible for me to separate which ones were selected at round start from living players and which were midround from ghosts. They happen pretty rarely at round start anyway, so that's probably fine.

The 25 minute timer is there for two reasons:
A- So I don't need to teach admins how to remove people from two places when they take off an acting captain's antagonist datum or someone says they don't want to be an antagonist they just received.
B- So that people who roll traitor while the shuttle is incoming don't immediately ahelp to get it removed.

When a roundstart or midround antagonist which draws from living players is rolled, it now weights the candidate it picks based on that count.
The weighting is pretty simply "the number of rounds since you last had an antagonist role" divided by two, rounded up.

So if Fish was an antagonist one round ago, Chip was one three rounds ago, and Kas-Kas was one eight+ rounds ago, the weighting for who would be more likely to become a roundstart traitor if all had it enabled would be:
Fish = 1
Chip = 2
Kas-Kas = 4

This means that it's not impossible that Fish will be picked, but there's only a 1/7 chance compared to Kas-Kas's 4/7 chance.

I have tested this as far as I can with my limited ability of being one person and the code works. Will we **actually notice** this system taking effect? I have no idea.

## Why It's Good For The Game

Should hopefully break up occasions where the same person is an antagonist on every round of the evening, which can be tiring both for them and other players.
Should hopefully combat some of the situations where X character seems to virtually always be an antagonist.

## Changelog

:cl:
balance: You are now more likely to be a round start or mid round antagonist which draws from living players if you have not been one recently. This system does not effect and is not effected by ghost roles.
/:cl:
