### PR TITLE
Biodome Science Fix

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -25368,6 +25368,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "kDp" = (


### PR DESCRIPTION
Research division APC had a wire missing, making the science hallway have no power. This fixes that, urgently.