### PR TITLE
Removes forced speech from brain trauma

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -712,14 +712,14 @@
 		if(isElectrified() && shock(user, 100))
 			return
 
-	if(ishuman(user) && prob(5) && density)
+	if(ishuman(user) && prob(5) && density) // ORBSTATION: adjusted probability
 		var/mob/living/carbon/human/H = user
 		if((HAS_TRAIT(H, TRAIT_DUMB)) && Adjacent(user))
 			playsound(src, 'sound/effects/bang.ogg', 25, TRUE)
 			if(!istype(H.head, /obj/item/clothing/head/helmet))
 				H.visible_message(span_danger("[user] headbutts the airlock."), \
 									span_userdanger("You headbutt the airlock!"))
-				H.Paralyze(0.5 SECONDS)
+				H.Paralyze(0.5 SECONDS) // ORBSTATION: adjusted duration
 				H.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
 			else
 				visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -712,14 +712,14 @@
 		if(isElectrified() && shock(user, 100))
 			return
 
-	if(ishuman(user) && prob(40) && density)
+	if(ishuman(user) && prob(5) && density)
 		var/mob/living/carbon/human/H = user
 		if((HAS_TRAIT(H, TRAIT_DUMB)) && Adjacent(user))
 			playsound(src, 'sound/effects/bang.ogg', 25, TRUE)
 			if(!istype(H.head, /obj/item/clothing/head/helmet))
 				H.visible_message(span_danger("[user] headbutts the airlock."), \
 									span_userdanger("You headbutt the airlock!"))
-				H.Paralyze(100)
+				H.Paralyze(0.5 SECONDS)
 				H.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
 			else
 				visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))

--- a/orbstation/code/jobs/medical/brain_trauma.dm
+++ b/orbstation/code/jobs/medical/brain_trauma.dm
@@ -78,6 +78,9 @@ GLOBAL_LIST_INIT(orb_mysterious_brain_traumas, list(
 	gain_text = span_warning("You can't seem to concentrate.")
 	lose_text = span_notice("You feel focused.")
 
+/datum/brain_trauma/mild/dumbness/on_life(delta_time, times_fired)
+	return // This was just forced speech which we do not want
+
 /datum/brain_trauma/special/psychotic_brawling
 	name = "Chaotic Brawler"
 	desc = "Patient fights in unpredictable ways, ranging from helping his target to hitting them with brutal strength."


### PR DESCRIPTION
## About The Pull Request

This brain trauma already was reflavoured to be less offensive but it still had forced speech attached, and we deleted the relevant file because we didn't want it.

Here's the full override:
```
/datum/brain_trauma/mild/dumbness
	name = "Distractible"
	desc = "Patient has difficulty focusing, and may walk into objects."
	scan_desc = "easily distracted"
	gain_text = span_warning("You can't seem to concentrate.")
	lose_text = span_notice("You feel focused.")

/datum/brain_trauma/mild/dumbness/on_life(delta_time, times_fired)
	return // This was just forced speech which we do not want
```

What it does with forced speech removed is:
- Increases your mood (this is a positive effect)
- You occasionally bump into airlocks instead of opening them
- You can always be hypnotised
- Some effects which overlap with a clown's clumsiness trait

## Why It's Good For The Game

This effect is gross and demeaning and also conveniently easy to remove.

## Changelog

:cl:
del: The brain trauma "distractible" doesn't make you emote or talk.
/:cl:
