### PR TITLE
Holographic bees die after stinging someone

### DIFF
--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -116,6 +116,7 @@
 		/mob/living/simple_animal/hostile/bee/queen,
 		/mob/living/simple_animal/hostile/bee/short,
 		/mob/living/simple_animal/hostile/bee/toxin,
+		/mob/living/simple_animal/hostile/bee/toxin/holo,
 		/mob/living/simple_animal/hostile/big_legion,
 		/mob/living/simple_animal/hostile/blob,
 		/mob/living/simple_animal/hostile/blob/blobbernaut,

--- a/orbstation/code/mob/npc/bees.dm
+++ b/orbstation/code/mob/npc/bees.dm
@@ -1,0 +1,11 @@
+// Variant of the poisonous bees summoned by the "Anthophillia" holodeck simulation, which die after stinging once.
+/mob/living/simple_animal/hostile/bee/toxin/holo
+	name = "holographic bee"
+	desc = "Someone should probably turn that simulation off, huh?"
+
+/mob/living/simple_animal/hostile/bee/toxin/holo/AttackingTarget()
+	..()
+	death(gibbed = FALSE)
+
+/obj/effect/holodeck_effect/mobspawner/bee
+	mobtype = /mob/living/simple_animal/hostile/bee/toxin/holo

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5235,6 +5235,7 @@
 #include "orbstation\code\mob\death_memory.dm"
 #include "orbstation\code\mob\eye_closing.dm"
 #include "orbstation\code\mob\npc\amoung.dm"
+#include "orbstation\code\mob\npc\bees.dm"
 #include "orbstation\code\mob\npc\magicarp.dm"
 #include "orbstation\code\mob\npc\regalrat.dm"
 #include "orbstation\code\mob\orb_species\ratfolk\cheesiness.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The title says it all, basically. I also named the holographic bees "holographic bees" so players know they're not "real" bees.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The bee holodeck simulation is silly, but extremely powerful, spawning an enormous swarm of tiny bees full of deadly poisons which can sting you repeatedly. Considering how easy and risk-free it is to activate this holodeck simulation, and how obnoxious bees are to fight against without bee protection, it makes sense to have the bees at least be more temporary. They're still extremely deadly, but at least they won't become a lasting threat on the station.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Poisonous bees summoned by the "Anthophilia" emagged holodeck simulation now die after stinging once. They are now also clearly labeled "holographic bees".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
