### PR TITLE
Further biodome fixes

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -3855,6 +3855,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
+"bzZ" = (
+/turf/open/space/basic,
+/area/station/maintenance/department/science)
 "bAd" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -7550,21 +7553,6 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/hydroponics)
-"dag" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/button/elevator/directional/north{
-	id = "biodome_science_lift"
-	},
-/obj/machinery/lift_indicator/directional/north{
-	linked_elevator_id = "biodome_science_lift"
-	},
-/turf/open/floor/iron,
-/area/station/science/research)
 "dah" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -9914,6 +9902,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"dVr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/structure/ladder,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dVt" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -16252,6 +16248,12 @@
 /area/station/science/xenobiology)
 "gAf" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
+/obj/machinery/button/elevator/directional/south{
+	id = "biodome_medbay_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "biodome_medbay_lift"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gAv" = (
@@ -16583,12 +16585,13 @@
 /turf/closed/wall,
 /area/station/security/execution/education)
 "gHY" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
 /area/station/science/research)
 "gIa" = (
@@ -20252,6 +20255,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research)
 "inm" = (
@@ -20559,14 +20563,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ius" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron,
 /area/station/science/research)
 "iuu" = (
 /obj/structure/disposalpipe/segment,
@@ -25168,6 +25168,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/biodome/aft)
+"koX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "kpb" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -29890,11 +29901,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/button/elevator/directional/south{
-	id = "biodome_medbay_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "biodome_medbay_lift"
+/obj/machinery/button/door/directional/south{
+	name = "Chemistry Access Shutters";
+	id = "chemistry_access_shutters";
+	req_access = list("medical")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -33702,10 +33712,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Under Junction";
-	network = list("ss13","rd")
-	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "nJq" = (
@@ -41674,10 +41680,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "qVh" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/stairs/left{
+	dir = 8
+	},
 /area/station/science/research)
 "qVs" = (
 /turf/closed/wall/mineral/wood,
@@ -45640,6 +45645,10 @@
 /obj/machinery/lift_indicator/directional/west{
 	linked_elevator_id = "biodome_science_lift"
 	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "sCK" = (
@@ -46528,6 +46537,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/research)
+"sVn" = (
+/obj/machinery/light/cold/directional/east,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/station/asteroid)
 "sVp" = (
 /obj/effect/turf_decal/tile/dark_green/full,
 /obj/machinery/door/airlock/wood,
@@ -47898,6 +47911,16 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"tyh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tyi" = (
 /obj/effect/supplypod_rubble,
 /turf/open/misc/asteroid,
@@ -49649,15 +49672,11 @@
 /turf/open/floor/grass,
 /area/station/biodome/aft)
 "unD" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
 /obj/structure/mirror/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/stairs/east,
+/turf/open/floor/iron/stairs/left{
 	dir = 8
 	},
-/turf/open/floor/iron/freezer,
 /area/station/science/research)
 "unN" = (
 /obj/machinery/camera/directional/south{
@@ -53052,6 +53071,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"vLT" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/ladder,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/xeno_spawn,
@@ -55302,6 +55328,9 @@
 /obj/machinery/button/elevator/directional/south{
 	id = "biodome_medbay_lift"
 	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "biodome_medbay_lift"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wEB" = (
@@ -56822,13 +56851,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xkG" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Under Junction";
+	network = list("ss13","rd")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron,
 /area/station/science/research)
 "xkP" = (
 /obj/structure/disposalpipe/segment{
@@ -57069,11 +57096,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "xqc" = (
-/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/station/science/research)
 "xqB" = (
 /obj/machinery/firealarm/directional/west,
@@ -83296,8 +83322,8 @@ noi
 lHf
 mfK
 ufA
-iAA
-aqD
+vLT
+tyh
 gYt
 dMC
 nvT
@@ -84843,7 +84869,7 @@ qPQ
 oAe
 jqF
 bqj
-hNy
+sVn
 hNy
 cCZ
 vtU
@@ -91452,8 +91478,8 @@ jpl
 jpl
 dJN
 xkG
-czJ
-dag
+dCg
+ifC
 lUf
 fMc
 qhx
@@ -91966,7 +91992,7 @@ vXN
 xRE
 dJN
 unD
-czJ
+ius
 nJl
 vLE
 hpD
@@ -148832,7 +148858,7 @@ gxh
 oLd
 mXw
 tBE
-oSg
+dVr
 cqp
 giE
 oSg
@@ -155704,7 +155730,7 @@ cLA
 dJN
 dJN
 dJN
-dJN
+bzZ
 dJN
 pLp
 jXN
@@ -157245,7 +157271,7 @@ aqd
 aqd
 dJN
 xqc
-umb
+koX
 dCg
 dCg
 ina
@@ -157501,8 +157527,8 @@ dJN
 aqd
 aqd
 dJN
-qCr
-umb
+vUU
+koX
 dCg
 gcX
 gcX

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1325,6 +1325,9 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ayJ" = (
@@ -7403,6 +7406,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "cWi" = (
+/obj/structure/railing,
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cWD" = (
@@ -46385,7 +46389,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "AI Minisat - Chamber Starboard"
 	},
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "sQE" = (
 /obj/structure/table,
@@ -49084,6 +49088,9 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tVA" = (
@@ -49555,6 +49562,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uhS" = (
@@ -52036,6 +52044,9 @@
 /area/station/maintenance/department/electrical)
 "vni" = (
 /obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vnl" = (
@@ -53964,12 +53975,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"wed" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "wei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -54611,7 +54616,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Minisat - Chamber Port"
 	},
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "woh" = (
 /obj/structure/rack,
@@ -56623,12 +56628,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/research)
-"xdd" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "xdw" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
@@ -144766,8 +144765,8 @@ xuo
 wLQ
 jWY
 jWY
-cWi
-cWi
+jWY
+jWY
 wof
 jWY
 jWY
@@ -145022,11 +145021,11 @@ xuo
 xuo
 jWY
 jWY
-cWi
-cWi
-cWi
-cWi
-cWi
+loe
+eyj
+eyj
+eyj
+lyX
 jWY
 jWY
 xuo
@@ -145277,14 +145276,14 @@ xuo
 xuo
 xuo
 xuo
-wed
-cWi
+jWY
+loe
 vni
 gdV
 gdV
 gdV
 ayG
-cWi
+lyX
 jWY
 xuo
 xuo
@@ -145534,15 +145533,15 @@ xuo
 xuo
 xuo
 hFj
+jWY
 bsp
-gdV
 jCg
 qtq
 jME
 pMf
 xKr
 cWi
-cWi
+jWY
 xuo
 xuo
 wfW
@@ -145799,7 +145798,7 @@ xMJ
 lWa
 xKr
 cWi
-cWi
+jWY
 xuo
 xuo
 naC
@@ -146048,15 +146047,15 @@ xuo
 xuo
 xuo
 hFj
+jWY
 loe
-eyj
 lyX
 hFj
 kIy
 hFj
 xKr
 cWi
-cWi
+jWY
 xuo
 xuo
 wfW
@@ -146305,14 +146304,14 @@ xuo
 xuo
 xuo
 xuo
-xdd
-cWi
+jWY
+bsp
 tVn
 eyj
 eyj
 eyj
 uhL
-cWi
+jCg
 jWY
 xuo
 xuo
@@ -146564,11 +146563,11 @@ xuo
 xuo
 jWY
 jWY
-cWi
-cWi
-cWi
-cWi
-cWi
+bsp
+gdV
+gdV
+gdV
+jCg
 jWY
 jWY
 xuo
@@ -146822,8 +146821,8 @@ xuo
 wLQ
 jWY
 jWY
-cWi
-cWi
+jWY
+jWY
 sQx
 jWY
 jWY

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -8856,10 +8856,8 @@
 /area/station/command/heads_quarters/hos)
 "dBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/multilayer/multiz{
-	cable_layer = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/multilayer/multiz/cable_2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dBn" = (
@@ -25008,9 +25006,7 @@
 	},
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable/multilayer/multiz{
-	cable_layer = 1
-	},
+/obj/structure/cable/multilayer/multiz/cable_1,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "klJ" = (
@@ -25824,7 +25820,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kBF" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable/multilayer/multiz/cable_2,
 /turf/open/floor/plating/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kBL" = (
@@ -32103,11 +32099,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "naC" = (
-/obj/structure/cable/multilayer/multiz,
 /obj/machinery/camera/directional/north{
 	c_tag = "AI Minisat - AI Solars";
 	network = list("ss13","minisat")
 	},
+/obj/structure/cable/multilayer/multiz/cable_2,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "naK" = (
@@ -32515,7 +32511,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nhR" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable/multilayer/multiz/cable_2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nhT" = (
@@ -40324,9 +40320,7 @@
 	},
 /area/station/ai_monitored/command/nuke_storage)
 "qtq" = (
-/obj/structure/cable/multilayer/multiz{
-	cable_layer = 1
-	},
+/obj/structure/cable/multilayer/multiz/cable_1,
 /turf/open/floor/plating/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "qtw" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1875,6 +1875,11 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"aJU" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "aKd" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/office)
@@ -2278,13 +2283,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"aQM" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "aRh" = (
 /obj/structure/chair{
 	dir = 4
@@ -5230,6 +5228,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cfm" = (
@@ -5670,14 +5669,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
-"cpC" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
 "cpN" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /turf/open/misc/beach/coastline_b,
@@ -6185,6 +6176,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/glass,
 /area/station/hallway/secondary/service)
+"cxT" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -6208,6 +6206,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"cyo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cyq" = (
 /turf/open/floor/eighties/red,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -7118,7 +7121,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cPG" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -8850,7 +8852,9 @@
 /area/station/command/heads_quarters/hos)
 "dBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable/multilayer/multiz{
+	cable_layer = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -10053,6 +10057,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dYX" = (
@@ -14496,13 +14502,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"fPC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
 "fPM" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -16067,6 +16066,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gww" = (
@@ -20293,7 +20293,6 @@
 /area/station/science/research)
 "inm" = (
 /mob/living/simple_animal/bot/cleanbot,
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "inr" = (
@@ -20390,8 +20389,8 @@
 /turf/open/floor/glass/reinforced,
 /area/station/commons/dorms)
 "ipf" = (
-/obj/structure/cable,
 /obj/machinery/light/floor,
+/obj/structure/cable/layer1,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ipq" = (
@@ -21773,6 +21772,7 @@
 "iWM" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "iWT" = (
@@ -23088,6 +23088,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jyN" = (
@@ -23747,6 +23748,10 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"jME" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/plating/reinforced,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "jMG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -24999,7 +25004,9 @@
 	},
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable/multilayer/multiz{
+	cable_layer = 1
+	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "klJ" = (
@@ -25015,6 +25022,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "klK" = (
@@ -25811,6 +25819,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kBF" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating/reinforced,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "kBL" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/cable,
@@ -27593,6 +27605,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"llE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "llF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 1
@@ -29597,10 +29615,10 @@
 	network = list("ss13","minisat");
 	c_tag = "AI Minisat - Foyer"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "lZb" = (
@@ -29891,7 +29909,7 @@
 	id = "AI";
 	pixel_x = 20
 	},
-/obj/structure/cable,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mdD" = (
@@ -30928,9 +30946,6 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "mAi" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
@@ -31193,6 +31208,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "mHg" = (
@@ -31387,11 +31403,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"mKZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "mLm" = (
 /turf/closed/wall,
 /area/station/hallway/primary/port)
@@ -32499,6 +32510,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nhR" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "nhT" = (
 /obj/machinery/door/window/right/directional/north{
 	dir = 8;
@@ -33835,8 +33850,7 @@
 	name = "AI Antechamber turret control";
 	pixel_y = 25
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "nKM" = (
@@ -34859,6 +34873,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "oeZ" = (
@@ -34977,6 +34992,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ogs" = (
@@ -38732,10 +38748,15 @@
 "pMd" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"pMf" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/plating/reinforced,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "pMw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -40299,8 +40320,9 @@
 	},
 /area/station/ai_monitored/command/nuke_storage)
 "qtq" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable/multilayer/multiz{
+	cable_layer = 1
+	},
 /turf/open/floor/plating/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "qtw" = (
@@ -45208,6 +45230,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"srU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "srW" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Genpop Lockers"
@@ -49403,6 +49431,8 @@
 	c_tag = "AI Minisat - Chargebay";
 	network = list("ss13","minisat")
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ufj" = (
@@ -51785,8 +51815,10 @@
 /turf/open/floor/wood,
 /area/station/security/brig)
 "vjl" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -52013,6 +52045,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vnE" = (
@@ -52427,6 +52460,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"vxn" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "vxs" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -52742,6 +52782,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"vEm" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "vEr" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/landmark/start/hangover,
@@ -54489,6 +54533,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"wnj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "wno" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot_white,
@@ -54948,6 +54997,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wxc" = (
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "wxd" = (
@@ -55627,6 +55677,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/funeral)
+"wKo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "wKx" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -55913,7 +55968,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/structure/cable,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "wPK" = (
@@ -56376,6 +56431,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
+"wZi" = (
+/obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "wZn" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/plating,
@@ -56765,6 +56827,10 @@
 "xhE" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "xhF" = (
@@ -58287,8 +58353,8 @@
 /turf/open/floor/plating,
 /area/station/biodome/aft)
 "xMJ" = (
-/obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/power/terminal,
 /turf/open/floor/plating/reinforced,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "xMM" = (
@@ -79419,12 +79485,12 @@ cCZ
 xuo
 xuo
 kVI
-xWn
+xrX
 gwv
-wxc
-mqX
-wxc
-wxc
+iWo
+hJk
+iWo
+iWo
 xWn
 xWn
 xuo
@@ -79676,11 +79742,11 @@ xuo
 xuo
 xuo
 heN
-xWn
-tFm
-mKZ
+xrX
+wnj
+pKm
 cPG
-mKZ
+pKm
 tFm
 inm
 xWn
@@ -79932,14 +79998,14 @@ xuo
 xuo
 xuo
 lXb
-xWn
-xWn
 xrX
+xrX
+xWn
 klF
 xuo
 xuo
-pKm
-xrX
+cyo
+xWn
 aut
 xuo
 mMq
@@ -80188,10 +80254,10 @@ fNk
 xuo
 xuo
 kuz
-iWo
 bJr
-hJk
-iWo
+nhR
+mqX
+wxc
 mdC
 rhL
 xuo
@@ -80447,12 +80513,12 @@ xuo
 xuo
 kgl
 xWn
-xWn
-xWn
+vEm
+vEm
 iPj
 xuo
 xuo
-bNk
+wKo
 xWn
 eYm
 xuo
@@ -80704,12 +80770,12 @@ xuo
 xuo
 xuo
 sJf
-xWn
+vEm
 faC
 bNk
 oRw
 bNk
-faC
+llE
 uqt
 xWn
 xuo
@@ -80961,10 +81027,10 @@ cCZ
 xuo
 xuo
 dTN
-xWn
+vEm
 oeX
 wxc
-mqX
+cxT
 wxc
 wxc
 xWn
@@ -94695,7 +94761,7 @@ huh
 iXQ
 lXp
 roy
-rVG
+srU
 xhE
 jZC
 gfn
@@ -94952,7 +95018,7 @@ qmt
 vaW
 ljW
 mGW
-fPC
+srU
 vjl
 jZC
 fhc
@@ -95209,8 +95275,8 @@ vUj
 yiJ
 lXp
 kIR
-cpC
 qXA
+aJU
 jZC
 rQm
 lEp
@@ -95467,7 +95533,7 @@ uGG
 lXp
 ogp
 mAi
-iWM
+vxn
 jZC
 dTP
 dTP
@@ -96758,7 +96824,7 @@ sgC
 uOi
 cgJ
 qZF
-ylF
+wZi
 pMd
 dTP
 itE
@@ -97016,7 +97082,7 @@ jpp
 jpp
 dTP
 ceK
-aQM
+dTP
 jpp
 jpp
 jpp
@@ -145472,8 +145538,8 @@ bsp
 gdV
 jCg
 qtq
-kIy
-hFj
+jME
+pMf
 xKr
 cWi
 cWi
@@ -145724,10 +145790,10 @@ jUo
 xuo
 xuo
 hyY
-kIy
 lHJ
-kIy
-kIy
+kBF
+sSm
+sSm
 sSm
 xMJ
 lWa

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -102666,7 +102666,7 @@ tUo
 tUo
 ykP
 wfX
-wfX
+leE
 wfX
 wfX
 wfX
@@ -102927,7 +102927,7 @@ hzh
 kTX
 oBj
 hzh
-leE
+wfX
 ajG
 wLu
 fgi

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2336,6 +2336,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/masks,
+/obj/structure/window/spawner/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aSu" = (
@@ -3383,6 +3384,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
+"bpV" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/science/research)
 "bpW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer4{
 	dir = 1
@@ -6555,10 +6561,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"cEJ" = (
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/space/openspace,
-/area/space)
 "cEV" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security)
@@ -6647,6 +6649,19 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
+"cGO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/button/elevator/directional/south{
+	id = "biodome_medbay_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "biodome_medbay_lift"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cGX" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -7223,6 +7238,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"cSA" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cSL" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -14860,6 +14881,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"fWD" = (
+/obj/machinery/power/floodlight,
+/turf/open/floor/grass,
+/area/station/biodome/aft)
 "fWF" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/navigate_destination/bar,
@@ -16227,12 +16252,6 @@
 /area/station/science/xenobiology)
 "gAf" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "biodome_medbay_lift"
-	},
-/obj/machinery/button/elevator/directional/south{
-	id = "biodome_medbay_lift"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gAv" = (
@@ -19227,6 +19246,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"hRr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "hRM" = (
 /obj/machinery/light/cold/directional/east,
 /obj/item/radio/intercom/directional/east,
@@ -21873,6 +21903,18 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"iZK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "iZR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -22334,6 +22376,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/bodybags,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jjo" = (
@@ -22465,6 +22508,11 @@
 	},
 /obj/structure/flora/bush/stalky/style_random,
 /turf/open/floor/grass,
+/area/station/science/research)
+"jnh" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
 /area/station/science/research)
 "jni" = (
 /obj/structure/table/glass,
@@ -22975,6 +23023,13 @@
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"jyB" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/science/research)
 "jyC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage"
@@ -29832,10 +29887,14 @@
 /area/station/engineering/atmos/hfr_room)
 "mep" = (
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/button/door/directional/south{
-	name = "Chemistry Access Shutters";
-	id = "chemistry_access_shutters";
-	req_access = list("medical")
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/button/elevator/directional/south{
+	id = "biodome_medbay_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "biodome_medbay_lift"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -30558,6 +30617,11 @@
 "muJ" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/button/door/directional/south{
+	name = "Chemistry Access Shutters";
+	id = "chemistry_access_shutters";
+	req_access = list("medical")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "muL" = (
@@ -35764,6 +35828,11 @@
 "oAe" = (
 /turf/closed/wall,
 /area/station/maintenance/central/greater)
+"oAj" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "oAm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38720,24 +38789,26 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pPs" = (
-/obj/item/storage/box/syringes{
-	pixel_y = 4
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 4
-	},
-/obj/item/gun/syringe,
-/obj/item/gun/syringe,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/left/directional/west{
 	name = "Secure Medical Storage";
 	req_access = list("medical")
 	},
+/obj/item/mod/module/plasma_stabilizer,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/storage/box/syringes{
+	pixel_y = 4
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 4
+	},
+/obj/item/gun/syringe,
+/obj/item/gun/syringe,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "pPI" = (
@@ -39326,6 +39397,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research)
 "qdG" = (
@@ -42706,6 +42778,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"rrw" = (
+/obj/machinery/power/floodlight,
+/turf/open/floor/grass,
+/area/station/biodome/fore)
 "rrD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43713,6 +43789,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/commissary)
+"rNm" = (
+/obj/machinery/power/floodlight,
+/turf/open/floor/grass,
+/area/station/biodome)
 "rOt" = (
 /obj/structure/railing{
 	dir = 1
@@ -47477,6 +47557,7 @@
 /area/station/security/prison)
 "tqQ" = (
 /obj/machinery/photocopier,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tqV" = (
@@ -51635,6 +51716,7 @@
 "vjl" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "vjn" = (
@@ -55216,9 +55298,6 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "biodome_medbay_lift"
 	},
 /obj/machinery/button/elevator/directional/south{
 	id = "biodome_medbay_lift"
@@ -82452,7 +82531,7 @@ pov
 lnK
 pov
 iQm
-oso
+cGO
 jHc
 oAe
 oAe
@@ -86799,7 +86878,7 @@ dGd
 asD
 asD
 ryw
-asD
+rNm
 dhk
 qMk
 asD
@@ -88328,7 +88407,7 @@ ikE
 erU
 eBC
 eBC
-eBC
+rrw
 iMD
 iMD
 iMD
@@ -93204,7 +93283,7 @@ eBC
 eBC
 eBC
 eBC
-eBC
+rrw
 rnX
 aki
 aLk
@@ -96066,7 +96145,7 @@ ota
 ota
 hbx
 ota
-ota
+fWD
 vEf
 ota
 fPs
@@ -143785,7 +143864,7 @@ hHc
 hHc
 hHc
 hHc
-cEJ
+hHc
 hHc
 hHc
 hHc
@@ -147986,8 +148065,8 @@ kLh
 xlt
 sZX
 aSh
-kKJ
-woD
+iZK
+cSA
 mep
 jHc
 wat
@@ -160513,9 +160592,9 @@ czJ
 czJ
 czJ
 czJ
-qCr
-bTC
-kAO
+jyB
+hRr
+bpV
 qfx
 qfx
 qfx
@@ -160772,7 +160851,7 @@ ivJ
 kFW
 eKq
 bTC
-kAO
+jnh
 qfx
 kmV
 qAT
@@ -172861,7 +172940,7 @@ mFe
 vrU
 kGT
 mNx
-gaE
+oAj
 tYp
 mLG
 qtE
@@ -173118,7 +173197,7 @@ cop
 vrU
 vIi
 mNx
-gaE
+oAj
 tYp
 mLG
 reE

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2495,7 +2495,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "aVA" = (
-/obj/structure/tank_holder/extinguisher,
+/obj/structure/toilet,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/science/research)
 "aVD" = (
@@ -3855,9 +3856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
-"bzZ" = (
-/turf/open/space/basic,
-/area/station/maintenance/department/science)
 "bAd" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -5745,12 +5743,8 @@
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cqp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
 /obj/structure/sign/departments/exam_room/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/station/medical/medbay/central)
 "cqs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6383,6 +6377,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
+"cBk" = (
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cBv" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9355,6 +9357,16 @@
 /obj/structure/sign/warning/no_smoking/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dKV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dMg" = (
 /obj/structure/closet/crate/silvercrate,
 /turf/open/misc/beach/coastline_t{
@@ -9365,6 +9377,12 @@
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -9903,11 +9921,11 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "dVr" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
-/obj/structure/ladder,
+/obj/machinery/light/cold/directional/west,
+/obj/structure/railing,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dVt" = (
@@ -12506,6 +12524,9 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eZP" = (
@@ -12802,6 +12823,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/lab)
+"fft" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ffO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -13877,6 +13909,13 @@
 "fDn" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"fDy" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "fDK" = (
 /obj/structure/chair/sofa/bamboo,
 /turf/open/floor/grass,
@@ -15383,13 +15422,8 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
 "giE" = (
-/obj/machinery/light/cold/directional/west,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
 /obj/machinery/vending/wallmed/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/station/medical/medbay/central)
 "giG" = (
 /obj/item/stack/rods/twentyfive,
@@ -17300,12 +17334,10 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
 "gYt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/structure/stairs/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gYA" = (
@@ -18081,6 +18113,7 @@
 "hpD" = (
 /obj/structure/sign/warning/test_chamber/directional/south,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "hpP" = (
@@ -20752,6 +20785,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"ixh" = (
+/obj/structure/stairs/west{
+	dir = 1
+	},
+/turf/closed/wall/mineral/wood,
+/area/station/service/hydroponics)
 "ixB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -21534,6 +21573,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iRf" = (
@@ -24037,11 +24077,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	name = "sorting disposal pipe (CMO)"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jUE" = (
@@ -30780,6 +30818,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"myr" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "myB" = (
 /obj/structure/railing{
 	dir = 1
@@ -36675,13 +36722,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/plating,
 /area/station/science/breakroom)
-"oSg" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "oTe" = (
 /turf/open/openspace,
 /area/station/ai_monitored/security/armory)
@@ -37601,6 +37641,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"plG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "plH" = (
 /obj/effect/spawner/random/food_or_drink,
 /turf/open/water/jungle/biodome,
@@ -38025,6 +38075,16 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"pxl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "pxn" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/line{
@@ -39266,14 +39326,16 @@
 /turf/closed/wall,
 /area/station/cargo/miningdock)
 "qaW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	name = "sorting disposal pipe (CMO)"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -41712,6 +41774,9 @@
 	name = "Hydroponics Requests Console";
 	pixel_y = -30;
 	supplies_requestable = 1
+	},
+/obj/structure/stairs/west{
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
@@ -45962,7 +46027,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -47912,14 +47977,7 @@
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "tyh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/stairs/medium,
 /area/station/medical/medbay/central)
 "tyi" = (
 /obj/effect/supplypod_rubble,
@@ -48072,15 +48130,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
-"tBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "tBY" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B"
@@ -48901,6 +48950,9 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot_red,
 /obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tSK" = (
@@ -51681,11 +51733,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -53071,13 +53123,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"vLT" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/ladder,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "vMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/xeno_spawn,
@@ -57095,12 +57140,6 @@
 /obj/item/toy/plush/space_lizard_plushie,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"xqc" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/science/research)
 "xqB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57597,11 +57636,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -57615,6 +57654,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"xCm" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/science/research)
 "xCp" = (
 /obj/structure/table/reinforced,
 /obj/item/crowbar,
@@ -82811,7 +82857,7 @@ oLd
 oLd
 gLk
 oLd
-oLd
+myr
 oLd
 wrB
 oso
@@ -83067,7 +83113,7 @@ tOS
 tPM
 wSI
 eZH
-wSI
+fft
 tSJ
 uuc
 kob
@@ -83322,7 +83368,7 @@ noi
 lHf
 mfK
 ufA
-vLT
+rgo
 tyh
 gYt
 dMC
@@ -89199,7 +89245,7 @@ aZw
 mnM
 cHu
 qVW
-kFI
+ixh
 wlT
 dit
 eBC
@@ -91992,7 +92038,7 @@ vXN
 xRE
 dJN
 unD
-ius
+xCm
 nJl
 vLE
 hpD
@@ -148857,11 +148903,11 @@ aZD
 gxh
 oLd
 mXw
-tBE
+oLd
 dVr
 cqp
 giE
-oSg
+oLd
 xBr
 woD
 wEA
@@ -149115,9 +149161,9 @@ kUH
 cSL
 ejP
 jUz
-hbg
-hbg
-hbg
+pxl
+dKV
+dKV
 hbg
 sJE
 woD
@@ -149372,10 +149418,10 @@ waq
 vSV
 waq
 qaW
-iAA
+cBk
 iQS
-hvF
-aqD
+fDy
+plG
 vhi
 woD
 nUx
@@ -155730,7 +155776,7 @@ cLA
 dJN
 dJN
 dJN
-bzZ
+dJN
 dJN
 pLp
 jXN
@@ -157270,7 +157316,7 @@ dJN
 aqd
 aqd
 dJN
-xqc
+vUU
 koX
 dCg
 dCg

--- a/orbstation/code/map/biodome/power.dm
+++ b/orbstation/code/map/biodome/power.dm
@@ -1,0 +1,8 @@
+/obj/structure/cable/multilayer/multiz/cable_1
+	cable_layer = CABLE_LAYER_1
+
+/obj/structure/cable/multilayer/multiz/cable_2
+	cable_layer = CABLE_LAYER_2
+
+/obj/structure/cable/multilayer/multiz/cable_3
+	cable_layer = CABLE_LAYER_2

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5230,6 +5230,7 @@
 #include "orbstation\code\map\shuttles.dm"
 #include "orbstation\code\map\biodome\area.dm"
 #include "orbstation\code\map\biodome\decoration.dm"
+#include "orbstation\code\map\biodome\power.dm"
 #include "orbstation\code\map\biodome\shuttles.dm"
 #include "orbstation\code\map\biodome\turfs.dm"
 #include "orbstation\code\mob\death_memory.dm"


### PR DESCRIPTION
- removes stray posters from outside the AI core wall
- added a few turned off floodlights around the biodome, you can drag them to places that need it, wire and wrench them to turn them on
- added two o2 closets to departures
- added the thermal and plasma modsuit modules to medbay storage
- aft medbay and the corridor by the science servers has firelocks, and firealarms on both sides
- added stairs to the main corridors of medbay and science
- actually solves AI, Telecomms and GravGen power issues
- added a circular overlook to the upper floor of the AI core, with railings, to make it harder to just jump down to the lower floor
- moves a maint room's door