### PR TITLE
Things we have talked about doing but never did

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -122,7 +122,7 @@
 	target.visible_message(span_danger("[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!"), \
 		span_userdanger("You cry out in pain as [user]'s punch flings you backwards!"))
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)
-	target.apply_damage(force * fist_pressure_setting, BRUTE, wound_bonus = CANT_WOUND)
+	target.apply_damage(force, BRUTE, wound_bonus = CANT_WOUND) // ORBSTATION: don't multiply the force
 	playsound(src, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
 	playsound(src, 'sound/weapons/genhit2.ogg', 50, TRUE)
 

--- a/code/modules/projectiles/guns/special/blastcannon.dm
+++ b/code/modules/projectiles/guns/special/blastcannon.dm
@@ -116,14 +116,22 @@
 	if((!bomb && bombcheck) || !target || (get_dist(get_turf(target), get_turf(user)) <= 2))
 		return ..()
 
+	user.visible_message(
+		span_danger("[user] points [src] at [target]!"),
+		span_danger("You point [src] at [target]!")
+	)
+
 	cached_target = WEAKREF(target)
 	cached_modifiers = params
 	if(bomb?.valve_open)
-		user.visible_message(
-			span_danger("[user] points [src] at [target]!"),
-			span_danger("You point [src] at [target]!")
-		)
 		return
+
+	// ORBSTATION: Fire after a delay
+	playsound(src, 'sound/machines/boltsup.ogg', 50, TRUE)
+	if(!do_after(user, 2 SECONDS, src))
+		balloon_alert(user, "interrupted!")
+		return
+	// ORBSTATION end
 
 	cached_firer = WEAKREF(user)
 	if(!bomb)

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -34,8 +34,8 @@
 		mob_exit(M, silent)
 		return TRUE
 	to_chat(user, span_notice("You push against the back of \the [src]'s trunk to try and get out."))
-	if(!do_after(user, escape_time, target = src))
-		return FALSE
+	if(!do_after(user, escape_time, target = src, timed_action_flags = IGNORE_TARGET_LOC_CHANGE))
+		return FALSE  // ORBSTATION: Doesn't require vehicle to stay still
 	to_chat(user,span_danger("[user] gets out of [src]."))
 	mob_exit(M, silent)
 	return TRUE

--- a/orbstation/code/antagonists/traitor/items/rebalancing.dm
+++ b/orbstation/code/antagonists/traitor/items/rebalancing.dm
@@ -7,6 +7,10 @@
 /obj/vehicle/sealed/car/clowncar
 	escape_time = 15 SECONDS // Actually longer, but we removed the requirement to stay still
 
+/obj/vehicle/sealed/car/clowncar/Initialize(mapload)
+	. = ..()
+	emag_act() // Always use emag behaviour, it's silly for this item to upgrade something anyway
+
 /datum/armor/mod_theme_infiltrator // More similar to nuke op, still a bit better
 	melee = 20
 	bullet = 30

--- a/orbstation/code/antagonists/traitor/items/rebalancing.dm
+++ b/orbstation/code/antagonists/traitor/items/rebalancing.dm
@@ -1,0 +1,18 @@
+/obj/item/melee/powerfist
+	force = 15 // Little bit less, mostly we want the knockback and not the damage
+
+/datum/uplink_item/dangerous/doublesword
+	purchasable_from = UPLINK_NUKE_OPS
+
+/obj/vehicle/sealed/car/clowncar
+	escape_time = 15 SECONDS // Actually longer, but we removed the requirement to stay still
+
+/datum/armor/mod_theme_infiltrator // More similar to nuke op, still a bit better
+	melee = 20
+	bullet = 30
+	laser = 20
+	energy = 20
+	bomb = 40
+	fire = 50
+	acid = 90
+	wound = 25

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5156,6 +5156,7 @@
 #include "orbstation\code\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\code\antagonists\traitor\items\cheese_implant.dm"
 #include "orbstation\code\antagonists\traitor\items\cursed_tome.dm"
+#include "orbstation\code\antagonists\traitor\items\rebalancing.dm"
 #include "orbstation\code\antagonists\traitor\objectives\kidnapping.dm"
 #include "orbstation\code\antagonists\traitor\objectives\final_objective\lowpop_battlecruiser.dm"
 #include "orbstation\code\antagonists\traitor\objectives\final_objective\malware_injection.dm"


### PR DESCRIPTION
## About The Pull Request

This is a list of traitor gear changes that at various points we have proposed and never actually done.

- The infiltrator suit has slightly less armour, closer to nuclear operatives but still a little better.
- The Power Fist does 15 damage no matter what setting it is on.
- The Blast Cannon now has a two second delay before firing, it still gibs but people have time to get out of the way.
- Trapped players can escape from the clown car after 15 seconds, even if in motion. In exchange, it always has access to the extra buttons from an emag.
- Traitors can no longer buy a dual esword.

## Why It's Good For The Game

These are largely items that are problematic in some way. This hopefully makes them less so.

## Changelog

:cl:
balance: Reduced armour of infiltrator suit.
balance: Blast Cannon takes two seconds between clicking and firing.
balance: Adjusting the power fist pressure only increases its knockback power, not damage.
balance: Players picked up by a clown car can break free after 15 seconds, clown cars start out with their extra emag abilities.
balance: Traitors can't buy dual eswords any more, and have to make do with normal ones.
/:cl:
