### PR TITLE
Decouples traitor limit from threat level

### DIFF
--- a/orbstation/code/antagonists/traitor_limit.dm
+++ b/orbstation/code/antagonists/traitor_limit.dm
@@ -2,11 +2,9 @@
 GLOBAL_VAR_INIT(traitor_limit_antag_count, 0)
 
 /datum/game_mode/dynamic
-	/// Theoretical percentage of crew that can become traitors at 100 threat.
-	/// Used to calculate maximum traitor count for current population and threat level.
-	/// Remember that threat level generally falls somewhere around 50.
+	/// The number of alive players is multitplied by this percentage to determine the traitor limit.
 	/// Configurable in dynamic.json.
-	var/max_threat_traitor_percent = 0.5
+	var/traitor_limit_scaling_percentage = 0.25
 	/// Minimum amount of threat allowed to generate.
 	var/min_threat_level = 30
 	/// Chance that the roundstart threat report will be wrong about the threat level.
@@ -19,7 +17,7 @@ GLOBAL_VAR_INIT(traitor_limit_antag_count, 0)
 /// Calculates the limit for midround/latejoin traitor spawns based on current population and threat level.
 /// Returns TRUE or FALSE depending on if more traitors can spawn or not.
 /datum/game_mode/dynamic/proc/calculate_traitor_limit()
-	var/traitor_limit = round(((threat_level / 100) * max_threat_traitor_percent) * GLOB.alive_player_list.len, 1)
+	var/traitor_limit = round(traitor_limit_scaling_percentage * GLOB.alive_player_list.len, 1)
 	if(GLOB.traitor_limit_antag_count >= traitor_limit)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This changes the way the traitor limit is calculated so that threat level is no longer factored into the formula. The scaling percentage has been set to a fixed value of 25%, meaning 25% of the living crew (rounded up) can be traitors/blood brothers at a given time. This is the value it previously had at 50 threat, which seems like a decent baseline. The number can be adjusted in dynamic.json if needed in the future.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

When I originally coded the traitor limit, I had intended for it to be tied to threat level thinking that this would work well with the general intent of some rounds being more or less threatening than others. However, in hindsight, this is redundant, as the threat level already decides how many midround rolls there are as well as the amount of threat there is to spend on rulesets, so in practice this just ended up making the amount of traitors _too_ swingy. At low threat levels there are often too few traitors, and at high threat levels there are often too many. So, I'm removing this part of the formula, which should hopefully stabilize things and make the amount of traitors hit that sweet spot more often (although obviously _who_ the traitors are still influences things a lot.)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

- Threat level no longer influences the traitor limit formula, which should hopefully make the amount of traitors less inconsistent.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
