### PR TITLE
Biodome: Boats and Windows and Such

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -467,19 +467,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/biodome/aft)
-"ajv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_half,
-/area/station/security/brig)
 "ajw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11249,6 +11236,9 @@
 /obj/machinery/computer/warrant{
 	dir = 1
 	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	pixel_y = -30
+	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "eAT" = (
@@ -16378,11 +16368,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "gBb" = (
@@ -24991,13 +24979,6 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/station/service/hydroponics/garden)
-"kkD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/security/brig)
 "kkE" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/botanist,
@@ -28277,11 +28258,11 @@
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_x = 30
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark/smooth_half,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "lxZ" = (
 /obj/machinery/camera/directional/west{
@@ -40396,10 +40377,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "qrF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "qrH" = (
@@ -40550,12 +40529,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"qvf" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/smooth_half,
-/area/station/security/brig)
 "qvg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57050,9 +57023,6 @@
 /obj/item/clothing/suit/hazardvest,
 /turf/open/floor/plating,
 /area/station/construction)
-"xhZ" = (
-/turf/closed/wall,
-/area/station/security/brig)
 "xib" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -167726,8 +167696,8 @@ iwf
 iwf
 iwf
 rWr
-ajv
-dUY
+fpE
+ePm
 qrF
 egm
 fht
@@ -167984,8 +167954,8 @@ cue
 cEF
 xbr
 gAM
-xhZ
-kkD
+ePm
+oKs
 egm
 hUJ
 vTi
@@ -168240,8 +168210,8 @@ dUY
 dUY
 taA
 dUY
-qvf
-xhZ
+dUY
+dUY
 lxV
 uox
 hmh

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1459,10 +1459,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/cargo)
-"aBr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "aBy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -10466,6 +10462,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"eiO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ejf" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -14354,12 +14357,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"fNe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "fNg" = (
 /obj/machinery/duct,
 /turf/open/floor/bamboo/tatami/black{
@@ -14731,6 +14728,10 @@
 	dir = 8
 	},
 /area/station/service/chapel)
+"fSW" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "fTb" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/computer/apc_control{
@@ -15336,6 +15337,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/white,
 /area/station/medical/medbay/lobby)
+"gfL" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_half,
+/area/station/security/brig)
 "gfQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -15837,6 +15847,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"grw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/office)
 "grI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16086,6 +16100,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"gwq" = (
+/obj/machinery/vending/cola/red,
+/turf/open/floor/carpet/black,
+/area/station/security/prison)
 "gws" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -16364,6 +16382,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "gBb" = (
@@ -18534,9 +18553,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
-"hyu" = (
-/turf/closed/wall,
-/area/space)
 "hyx" = (
 /obj/item/shovel/spade,
 /turf/open/misc/asteroid/dug,
@@ -20039,6 +20055,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"igj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "ign" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20850,12 +20870,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"ixh" = (
-/obj/structure/stairs/west{
-	dir = 1
-	},
-/turf/closed/wall/mineral/wood,
-/area/station/service/hydroponics)
 "ixB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -21031,7 +21045,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -25791,6 +25804,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"kzz" = (
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "kzF" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -28107,6 +28127,13 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"lvd" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lvu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -29038,6 +29065,7 @@
 /obj/machinery/photocopier{
 	pixel_y = 3
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "lMU" = (
@@ -30307,6 +30335,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"mjF" = (
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mjR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30870,6 +30903,7 @@
 /area/station/security/prison)
 "mww" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mwz" = (
@@ -35052,6 +35086,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
 "ofF" = (
@@ -36698,7 +36733,7 @@
 	name = "Engineering Requests Console";
 	anon_tips_receiver = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oPo" = (
@@ -40565,7 +40600,7 @@
 "qvR" = (
 /obj/structure/girder,
 /obj/machinery/button/tram{
-	id = "aft_boat_dock";
+	id = "central_boat_dock";
 	lift_id = "tram_boat"
 	},
 /turf/open/water/jungle/biodome,
@@ -41129,6 +41164,13 @@
 "qHj" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/station/engineering/atmos/project)
+"qHm" = (
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qHA" = (
 /obj/structure/flora/bush/jungle/a/style_random,
 /obj/machinery/firealarm/directional/north,
@@ -41908,9 +41950,6 @@
 	name = "Hydroponics Requests Console";
 	pixel_y = -30;
 	supplies_requestable = 1
-	},
-/obj/structure/stairs/west{
-	dir = 1
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
@@ -44395,6 +44434,11 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"rVH" = (
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rVI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/duct,
@@ -44477,6 +44521,7 @@
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "rXb" = (
@@ -44938,6 +44983,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Engine Entrance"
 	},
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "shZ" = (
@@ -46340,6 +46386,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"sMH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sNs" = (
 /obj/effect/landmark/start/lawyer,
 /obj/structure/chair/office{
@@ -50971,7 +51024,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/light/directional/south,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "uNk" = (
@@ -53840,7 +53893,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "vXf" = (
@@ -89472,7 +89524,7 @@ aZw
 mnM
 cHu
 qVW
-ixh
+kFI
 wlT
 dit
 eBC
@@ -92381,8 +92433,8 @@ ecV
 ecV
 ecV
 ecV
+ecV
 eQy
-cCZ
 cCZ
 cCZ
 nLN
@@ -92630,6 +92682,7 @@ lOH
 avA
 ajK
 lOH
+lOH
 mSg
 mSg
 mSg
@@ -92639,7 +92692,6 @@ mSg
 mSg
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -92886,6 +92938,7 @@ qCC
 ttj
 mww
 gGu
+fSW
 ttj
 mSg
 lEN
@@ -92896,7 +92949,6 @@ dUq
 lhu
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -93141,8 +93193,9 @@ iqP
 osb
 alG
 alG
-alG
+rVH
 gGu
+avb
 xFy
 mSg
 lEN
@@ -93153,7 +93206,6 @@ sGU
 lhu
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -93400,6 +93452,7 @@ rKd
 ukO
 rKd
 rKd
+avb
 mzv
 mSg
 iEq
@@ -93412,7 +93465,6 @@ mSg
 eRd
 gsG
 eQy
-cCZ
 cCZ
 cCZ
 cCZ
@@ -93655,8 +93707,9 @@ vzP
 alG
 rZl
 idm
-alG
+avb
 rKd
+avb
 lfG
 mSg
 mSg
@@ -93669,7 +93722,6 @@ mSg
 mSg
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -93914,6 +93966,7 @@ gMZ
 gMZ
 oPb
 rKd
+avb
 lfG
 mSg
 lrN
@@ -93926,7 +93979,6 @@ spc
 ikH
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -94169,8 +94221,9 @@ uYT
 qeg
 rQl
 gMZ
-alG
+mww
 rKd
+alG
 ttj
 mSg
 drK
@@ -94183,7 +94236,6 @@ guf
 wEe
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -94426,8 +94478,9 @@ uax
 bKT
 asX
 gMZ
-mww
+avb
 rKd
+avb
 gvg
 wew
 nmk
@@ -94440,7 +94493,6 @@ uuR
 qtH
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -94686,6 +94738,7 @@ gMZ
 shL
 rKd
 rKd
+rKd
 msz
 mPn
 vHm
@@ -94697,7 +94750,6 @@ xUV
 aCz
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -94940,8 +94992,9 @@ lvA
 eZx
 fTb
 aQb
-aBr
+avb
 rKd
+qHm
 mYz
 wew
 jrK
@@ -94954,7 +95007,6 @@ xUV
 aCz
 mSg
 tQT
-cCZ
 cCZ
 cCZ
 cCZ
@@ -95197,8 +95249,9 @@ oBb
 gJD
 fdy
 aQb
-alG
+avb
 rKd
+mjF
 mYz
 wew
 jMz
@@ -95210,9 +95263,8 @@ oCD
 fVT
 aCz
 mSg
-tQT
-cCZ
-cCZ
+sMH
+eQy
 nLN
 cCZ
 cCZ
@@ -95454,8 +95506,9 @@ gMZ
 gMZ
 gMZ
 gMZ
-ttj
+lvd
 cMI
+ttj
 ttj
 mSg
 mSg
@@ -95467,9 +95520,8 @@ gif
 mSg
 mSg
 mSg
-fNe
 siV
-cCZ
+tQT
 cCZ
 cCZ
 cCZ
@@ -95724,9 +95776,9 @@ eNj
 gvA
 gXp
 lCl
-fxi
-siV
-cCZ
+kzz
+igj
+eiO
 cCZ
 cCZ
 cCZ
@@ -103424,7 +103476,7 @@ rzh
 cUO
 mHB
 usE
-usE
+gwq
 pZn
 fPm
 aYJ
@@ -157914,7 +157966,7 @@ hHc
 hHc
 hNy
 hNy
-hNy
+rRv
 hHc
 hHc
 hHc
@@ -158171,10 +158223,10 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hNy
-hHc
+rRv
+rRv
+rRv
+rRv
 hHc
 hHc
 hHc
@@ -158429,9 +158481,9 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hHc
+rRv
+rRv
+rRv
 hHc
 hHc
 hHc
@@ -158686,9 +158738,9 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hHc
+rRv
+rRv
+rRv
 hHc
 hHc
 hHc
@@ -158942,10 +158994,10 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hNy
-hHc
+rRv
+rRv
+rRv
+rRv
 hHc
 hHc
 hHc
@@ -159201,10 +159253,10 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hNy
-hHc
+rRv
+rRv
+rRv
+rRv
 hHc
 byv
 hHc
@@ -159461,7 +159513,7 @@ tFt
 tFt
 tFt
 tFt
-hyu
+tFt
 hHc
 hHc
 hHc
@@ -162793,7 +162845,7 @@ eSi
 cue
 bHr
 uNd
-rRy
+hTo
 vWM
 rRq
 rRq
@@ -163307,7 +163359,7 @@ mvG
 iJB
 mvG
 vJT
-rRy
+hTo
 tfY
 oPI
 loD
@@ -163820,7 +163872,7 @@ ePm
 hIV
 ePm
 mvG
-jKG
+gfL
 rRy
 rRy
 rRy
@@ -166390,7 +166442,7 @@ jhI
 vMM
 tgi
 uQE
-egm
+grw
 iCj
 gXF
 gyj
@@ -167161,7 +167213,7 @@ lla
 lhq
 jep
 jrI
-egm
+grw
 bXK
 xTR
 dhN

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -36312,7 +36312,6 @@
 /obj/structure/curtain/cloth/fancy,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "oGj" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -13571,6 +13571,9 @@
 "fuQ" = (
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"fuT" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/aft)
 "fvb" = (
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 35;
@@ -28255,9 +28258,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "lxV" = (
-/obj/machinery/computer/security/telescreen/interrogation{
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
@@ -92910,8 +92910,8 @@ qCC
 ttj
 mww
 gGu
+avb
 fSW
-ttj
 mSg
 lEN
 lEN
@@ -159732,11 +159732,11 @@ pOn
 nTy
 pGQ
 jAa
-tFt
-tFt
-tFt
-tFt
-tFt
+jAa
+jAa
+jAa
+jAa
+jAa
 kcg
 kcg
 kcg
@@ -160762,9 +160762,9 @@ loB
 loB
 loB
 jps
-qgt
-qgt
-qgt
+fuT
+fuT
+fuT
 kcg
 kcg
 kcg

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -20202,6 +20202,10 @@
 	},
 /turf/closed/wall,
 /area/station/commons/fitness)
+"iiR" = (
+/obj/structure/plaque/static_plaque/golden/commission/biodome,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iji" = (
 /obj/structure/ladder,
 /turf/open/floor/iron/dark/telecomms,
@@ -144490,7 +144494,7 @@ cNt
 sCM
 txv
 fmZ
-txv
+iiR
 jpO
 riL
 nMm

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -36312,6 +36312,7 @@
 /obj/structure/curtain/cloth/fancy,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "oGj" = (
@@ -50508,7 +50509,9 @@
 /area/station/biodome/fore)
 "uAA" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "uBu" = (
@@ -150742,14 +150745,14 @@ xIR
 ple
 iLi
 vxC
-fJC
+pAg
 oFR
-fJC
-fJC
-fJC
+pAg
+pAg
+pAg
 uAA
-pAg
-pAg
+fJC
+fJC
 vxC
 hNy
 rRv
@@ -150999,14 +151002,14 @@ vxC
 vxC
 vxC
 vxC
-fJC
+pAg
 ceO
 fJC
 jur
 ixS
 iuZ
 qLe
-pAg
+fJC
 vxC
 rRv
 rRv
@@ -151255,8 +151258,8 @@ gpd
 beC
 bDR
 mqk
-fJC
-fJC
+pAg
+pAg
 geA
 geA
 geA

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -11939,11 +11939,6 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/cmo)
-"eNj" = (
-/obj/structure/cable/layer3,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "eNs" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -35799,6 +35794,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"owj" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "owk" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -95748,8 +95749,8 @@ nlO
 nlO
 nlO
 nlO
-eNj
-gvA
+nlO
+owj
 gXp
 lCl
 kzz

--- a/orbstation/code/map/biodome/decoration.dm
+++ b/orbstation/code/map/biodome/decoration.dm
@@ -3,3 +3,6 @@
 	max_integrity = 150
 	icon = 'orbstation/icons/effects/holo_leaves.dmi'
 	icon_state = "holo_leaves"
+
+/obj/structure/plaque/static_plaque/golden/commission/biodome
+	desc = "Spinward Sector Station SS-13\n'Biodome' Class Outpost \nCommissioned 18/02/2563\n'Walk In The Park'"


### PR DESCRIPTION
- adds more internal windows to security (labour shuttle dock and security office)
- gives back the soda vendor to perma, turns out its not an issue
- removed random stairs from botany
- expanded engineering room by one row of tiles
- central boat caller no longer sends the boat to the aft
- abandoned theater's vent is now hooked up to the air supply
- removed the tiny interrogation monitor room, to make space for walking around the stairs, monitor moved to the small security station inside the brig
- adds commission plaque