### PR TITLE
Permitless guns for heads

### DIFF
--- a/orbstation/code/objects/items/guns.dm
+++ b/orbstation/code/objects/items/guns.dm
@@ -1,0 +1,4 @@
+/obj/item/gun/energy/e_gun/mini/permitless
+	name = "emergency miniature energy gun"
+	desc = "A small, pistol-sized energy gun with a built-in flashlight. It has two settings: disable and kill. A warning label says that securitrons are programed to ignore these."
+	item_flags = NONE

--- a/orbstation/code/objects/items/storage.dm
+++ b/orbstation/code/objects/items/storage.dm
@@ -12,16 +12,16 @@
 
 /obj/structure/closet/secure_closet/chief_medical/PopulateContents()
 	..()
-	new /obj/item/gun/energy/e_gun/mini(src)
+	new /obj/item/gun/energy/e_gun/mini/permitless(src)
 
 /obj/structure/closet/secure_closet/research_director/PopulateContents()
 	..()
-	new /obj/item/gun/energy/e_gun/mini(src)
+	new /obj/item/gun/energy/e_gun/mini/permitless(src)
 
 /obj/structure/closet/secure_closet/engineering_chief/PopulateContents()
 	..()
-	new /obj/item/gun/energy/e_gun/mini(src)
+	new /obj/item/gun/energy/e_gun/mini/permitless(src)
 
 /obj/structure/closet/secure_closet/quartermaster/PopulateContents()
 	..()
-	new /obj/item/gun/energy/e_gun/mini(src)
+	new /obj/item/gun/energy/e_gun/mini/permitless(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5293,6 +5293,7 @@
 #include "orbstation\code\objects\items\debug_items.dm"
 #include "orbstation\code\objects\items\elance.dm"
 #include "orbstation\code\objects\items\hearing_aid.dm"
+#include "orbstation\code\objects\items\guns.dm"
 #include "orbstation\code\objects\items\magazines.dm"
 #include "orbstation\code\objects\items\orb.dm"
 #include "orbstation\code\objects\items\radio_keys.dm"


### PR DESCRIPTION


## About The Pull Request

Adds a new subtype of the pistol that has no item_flags (to my knowledge all flags the guns had was NEEDS_PERMIT), and replaces the ones in the head's lockers with this version.

## Why It's Good For The Game

Heads can not use these guns outside their departments without getting bopped by Beepsky. Rather then giving them Weapon Permits, which would be its own can of worms, I removed the permit from the gun.

This also means the QM, the RD, the CMO and CE should still need to dramatically RP getting weapon permits if they want bigger weapons, without skewing the balance of them waltzing around with revolvers and armblades.

This also makes the guns a desirable target to take, increasing the head's responsibility for getting the gun, which is a pretty low powered prize anyways.

The new version might require new sprites, please put this in draft mode if that is decided upon.

## Changelog

:cl:
fix: the e-pistol the heads get is now ignored by beepsky. Keep _them_ safe to keep **them** safe!
/:cl:

