### PR TITLE
Biodome Emergency Fix 1, part 2

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -8048,7 +8048,7 @@
 /area/station/security/prison)
 "diT" = (
 /obj/effect/spawner/random/structure/crate,
-/turf/open/floor/glass/reinforced/airless,
+/turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "djt" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -15276,7 +15276,7 @@
 /turf/open/floor/plating,
 /area/station/asteroid)
 "gdP" = (
-/turf/open/floor/glass/reinforced/airless,
+/turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "gdU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27974,7 +27974,7 @@
 /area/station/maintenance/port/lesser)
 "lqe" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/glass/reinforced/airless,
+/turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "lqj" = (
 /turf/open/floor/fakebasalt,
@@ -43940,7 +43940,7 @@
 /area/station/hallway/primary/fore)
 "rIM" = (
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/glass/reinforced/airless,
+/turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "rIP" = (
 /obj/structure/chair{
@@ -44985,7 +44985,7 @@
 /area/station/service/theater)
 "sfB" = (
 /obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/glass/reinforced/airless,
+/turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "sfD" = (
 /obj/machinery/door/airlock/maintenance,
@@ -106703,7 +106703,7 @@ oCW
 wYk
 tuE
 dpm
-tju
+mBf
 mBf
 cCZ
 cCZ
@@ -106961,12 +106961,12 @@ dwu
 xoS
 dpm
 hNy
+dMJ
 vtU
 vtU
 vtU
 vtU
-vtU
-vtU
+dMJ
 vtU
 vtU
 vtU
@@ -108246,12 +108246,12 @@ hNy
 hNy
 hNy
 hNy
+dMJ
 vtU
 vtU
 vtU
 vtU
-vtU
-vtU
+dMJ
 vtU
 vtU
 vtU
@@ -168897,7 +168897,7 @@ jvo
 kcg
 jvo
 kcg
-kPb
+eZB
 eZB
 eZB
 avN
@@ -169154,7 +169154,7 @@ nzQ
 kPb
 nzQ
 kPb
-kPb
+eZB
 diT
 gdP
 gdP
@@ -169411,7 +169411,7 @@ nUl
 nUl
 nUl
 nUl
-kPb
+eZB
 lqe
 gdP
 gdP
@@ -169668,7 +169668,7 @@ nUl
 nUl
 nUl
 nUl
-kPb
+eZB
 eZB
 eZB
 avN
@@ -171727,7 +171727,7 @@ wkW
 wLS
 wLS
 wLS
-wLS
+eZB
 rsW
 avN
 avN
@@ -171984,7 +171984,7 @@ nMG
 rSB
 nKr
 nvv
-wLS
+eZB
 ihI
 avN
 avN
@@ -172241,7 +172241,7 @@ vTb
 wLS
 fwe
 qcV
-wLS
+eZB
 jgZ
 qzY
 avN
@@ -172498,7 +172498,7 @@ cRc
 wLS
 lyD
 npX
-wLS
+eZB
 ulQ
 qzY
 avN
@@ -172753,9 +172753,9 @@ ovq
 xaf
 hkN
 wLS
-wLS
-wLS
-wLS
+eZB
+eZB
+eZB
 ePj
 avN
 avN
@@ -173009,7 +173009,7 @@ hor
 bHf
 kru
 jDc
-wLS
+eZB
 aXd
 aXd
 avN
@@ -173260,13 +173260,13 @@ wyn
 eZB
 nbP
 eZB
-wLS
-wLS
-wLS
-wLS
-wLS
-wLS
-wLS
+eZB
+eZB
+eZB
+eZB
+eZB
+eZB
+eZB
 ePj
 wCf
 avN


### PR DESCRIPTION
- airless glass tiles replaced with aired glass tiles.
- made walls touching maint be maint areas

In addition a fix of mine: one tile wasn't airwall in the "detective maint access".

And also minor addition: changed some lattices to walls to act as "support beams" under the new maintenance.