### PR TITLE
Fixes orb cargo

### DIFF
--- a/_maps/shuttles/cargo_biodome.dmm
+++ b/_maps/shuttles/cargo_biodome.dmm
@@ -15,7 +15,7 @@
 /area/shuttle/supply)
 "j" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "l" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27,7 +27,7 @@
 	id = "QMLoad2";
 	name = "on ramp"
 	},
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "o" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst/left,
@@ -39,7 +39,7 @@
 	},
 /area/shuttle/supply)
 "r" = (
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "w" = (
 /obj/machinery/door/airlock/shuttle{
@@ -51,7 +51,7 @@
 "x" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "A" = (
 /obj/machinery/door/poddoor{
@@ -86,14 +86,14 @@
 	pixel_y = -8
 	},
 /obj/machinery/light/floor,
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "E" = (
 /turf/template_noop,
 /area/template_noop)
 "F" = (
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "H" = (
 /turf/closed/wall/mineral/titanium,
@@ -121,7 +121,7 @@
 /area/shuttle/supply)
 "W" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 "X" = (
 /turf/open/floor/iron/recharge_floor/asteroid,
@@ -131,7 +131,7 @@
 	dir = 8;
 	id = "QMLoad"
 	},
-/turf/open/misc/ironsand,
+/turf/open/floor/fake_iron_sand,
 /area/shuttle/supply)
 
 (1,1,1) = {"

--- a/orbstation/code/map/biodome/turfs.dm
+++ b/orbstation/code/map/biodome/turfs.dm
@@ -20,3 +20,22 @@
 /turf/open/floor/fake_snow/safe
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 	slowdown = 0
+
+/turf/open/floor/fake_iron_sand
+	desc = "Wait a minute. This martian soil is just painted on!"
+	icon_state = "ironsand1"
+	base_icon_state = "ironsand1"
+	footstep = FOOTSTEP_SAND
+	barefootstep = FOOTSTEP_SAND
+	clawfootstep = FOOTSTEP_SAND
+	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+
+/turf/open/floor/fake_iron_sand/Initialize(mapload)
+	. = ..()
+	icon_state = "ironsand[rand(1,15)]"
+
+/turf/open/floor/fake_iron_sand/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	return
+
+/turf/open/floor/fake_iron_sand/crowbar_act(mob/living/user, obj/item/I)
+	return


### PR DESCRIPTION
The cargo shuttle only interacted with floor tiles. Iron sand is Misc tile. So I have made "Fake iron sand". This allows cargo to actually arrive anywhere on the shuttle, and event stuff can spawn.