### PR TITLE
SandboxVend extra belts, traitor uplinks, and quality of life.

### DIFF
--- a/orbstation/code/objects/items/debug_items.dm
+++ b/orbstation/code/objects/items/debug_items.dm
@@ -101,3 +101,35 @@
 		/obj/item/stack/sheet/pizza/fifty=1,
 		)
 	generate_items_inside(items_inside,src)
+
+/obj/item/storage/belt/medical/abductor
+	name = "\improper Zetan medical belt"
+	desc = "A belt used by extremely strong doctors."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "belt"
+	inhand_icon_state = "security"
+	worn_icon_state = "security"
+	content_overlays = TRUE
+
+/obj/item/storage/belt/medical/abductor/PopulateContents()
+	new /obj/item/scalpel/alien(src)
+	new /obj/item/retractor/alien(src)
+	new /obj/item/hemostat/alien(src)
+	new /obj/item/circular_saw/alien(src)
+	new /obj/item/cautery/alien(src)
+	new /obj/item/surgicaldrill/alien(src)
+	new /obj/item/surgical_drapes(src)
+
+//Giving subtypes to some items so they have clearer names in the sandbox vendor
+/obj/item/storage/belt/military/abductor/full/zetan
+	name = "\improper Zetan toolbelt"
+	desc = "A belt used by extremely strong engineers."
+
+/obj/item/storage/belt/medical/ert/debug
+	name = "advanced medical belt"
+
+/obj/item/storage/belt/utility/full/powertools/debug
+	name = "advanced toolbelt"
+
+/obj/item/uplink/sandbox //This is NOT the debug uplink, which has unlimited TC, because I don't think we should give those out.
+	name = "traitor uplink"

--- a/orbstation/code/objects/vending/sandboxvendor.dm
+++ b/orbstation/code/objects/vending/sandboxvendor.dm
@@ -59,8 +59,10 @@
 			"products" = list(
 				/obj/item/clothing/glasses/debug = 999,
 				/obj/item/clothing/gloves/chief_engineer = 999,
-				/obj/item/storage/belt/medical/ert = 999,
-				/obj/item/storage/belt/utility/full/powertools = 999,
+				/obj/item/storage/belt/medical/ert/debug = 999,
+				/obj/item/storage/belt/medical/abductor = 999,
+				/obj/item/storage/belt/utility/full/powertools/debug = 999,
+				/obj/item/storage/belt/military/abductor/full/zetan = 999,
 				/obj/item/clothing/shoes/magboots/advance = 999,
 				/obj/item/radio/headset/headset_cent/commander = 999,
 				/obj/item/storage/belt/military = 999,
@@ -153,6 +155,7 @@
 		/obj/item/stack/sheet/hauntium/fifty = 99,
 		/obj/item/suspiciousphone = 99,
 		/obj/item/guardiancreator/tech/choose/traitor = 99,
+		/obj/item/uplink/sandbox = 99, // Yes, infinite traitor uplinks might destroy the station, but it's for sandbox.
 	)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	refill_canister = /obj/item/vending_refill/clothing // wont populate categories without this


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new belts to the SandboxVend - the "Zetan medical belt" and the "Zetan toolbelt". The former is a belt containing all of the alien medical tools, while the latter is the existing abductor agent toolbelt, but renamed. Additionally, the medical belt and toolbelt already in the SandboxVend have been renamed and are now designated as "advanced", just to clarify what's in them.

Finally, the contraband section now contains 99 traitor uplinks, each preloaded with 20 TC.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've thought for a while that it might be nice to just spawn in the alien tools if you want to mess around with them. The renaming is simply for clarity, because some things in the SandboxVend aren't very clear from the item name alone.

As for the traitor uplinks, I'm not _100%_ convinced it's a good idea to give out unlimited traitor tools, but it's been requested a few times by now. We'll just have to trust people to behave, just like always. It's not the _worst_ thing if the sandbox station explodes, anyway, as long as it's not disruptive to other players.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added two new belts and a traitor uplink to the SandboxVend.
qol: Made some SandboxVend item names more clear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
