### PR TITLE
Replaces maint slime console with computer frame

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -53054,7 +53054,8 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "vhZ" = (
-/obj/machinery/computer/camera_advanced/xenobio{
+/obj/structure/frame/computer{
+	anchored = 1;
 	dir = 8
 	},
 /turf/open/floor/plating/reinforced,


### PR DESCRIPTION
The slime console lets you move the camera around in an area, and see through every cameras on your screen. Maintenance is long, and could let you see through many places... This PR fixes that.