### PR TITLE
Orbpdate 03/03/2023

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1,0 +1,5783 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"ae" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/storage/book/bible{
+	pixel_x = 3
+	},
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_2,
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"ak" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"at" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/obj/machinery/light/dim/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"ax" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"ay" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"aB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/morphine{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/hypospray/medipen/morphine,
+/obj/item/reagent_containers/cup/bottle/morphine,
+/obj/item/reagent_containers/syringe,
+/obj/structure/sign/warning/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"aD" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"aI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"aW" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"aY" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"aZ" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"bb" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid5"
+	},
+/area/ruin/space)
+"bl" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"bu" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"bO" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"bP" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/structure/sign/poster/contraband/interdyne_gene_clinics{
+	pixel_x = 32
+	},
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/item/bedsheet/purple,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"cd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ce" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"ci" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/wallframe/camera,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"cl" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"cm" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"cp" = (
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"cv" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/stack/rods/two,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"cN" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"cW" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"db" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"df" = (
+/obj/structure/trap/eldritch/tentacle,
+/obj/structure/door_assembly/door_assembly_vault,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"dl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"dm" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/item/food/donkpocket/spicy,
+/obj/item/food/ready_donk,
+/obj/item/food/ready_donk/mac_n_cheese,
+/obj/structure/sign/poster/contraband/donk_co{
+	pixel_x = -32
+	},
+/obj/machinery/light/dim/directional/west,
+/obj/structure/closet/secure_closet/freezer/empty{
+	name = "fridge"
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"do" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid10"
+	},
+/area/ruin/space)
+"dw" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_3,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"dy" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"dC" = (
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/item/pen/screwdriver,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"dI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"dX" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"dZ" = (
+/obj/machinery/air_sensor{
+	chamber_id = "asrc_a"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"ec" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/reagent_containers/blood/b_minus,
+/obj/item/reagent_containers/blood/b_minus,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"eq" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"eu" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ey" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"eQ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/table,
+/obj/item/toy/nuke,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"eW" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/item/organ/internal/liver,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fi" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"fn" = (
+/obj/item/trash/can{
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/machinery/light/very_dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fo" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fx" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fB" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fE" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fH" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio{
+	pixel_x = -8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fJ" = (
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/sign/departments/science/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fO" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"fR" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"fT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"gl" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"go" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"gr" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"gt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/item/folder/syndicate/red,
+/obj/item/paper/fluff/ruins/dangerous_research/head_occultist_note,
+/obj/item/stamp/syndicate{
+	pixel_x = -6
+	},
+/obj/machinery/button/door/directional/east{
+	id = "asrc_supply";
+	name = "Supply Closet Access";
+	req_access = list("away_command")
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"gF" = (
+/obj/item/trash/can/food/peaches/maint,
+/obj/item/trash/sosjerky,
+/obj/item/trash/semki,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"gH" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/trash/can,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"gN" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"gR" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"gY" = (
+/obj/structure/flora/grass/brown/style_2,
+/turf/open/misc/sandy_dirt,
+/area/ruin/space/has_grav/dangerous_research)
+"he" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/flag/ssc/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"hI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/item/organ/internal/appendix,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"hL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"hS" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "Subject Pen"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"hV" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"if" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ip" = (
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/very_dim/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"iw" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/machinery/chem_heater/withbuffer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"ix" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"iD" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_1,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"iE" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"iR" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"iU" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"iZ" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"jh" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"ji" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/table,
+/obj/item/disk/tech_disk/spaceloot,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"jk" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"jm" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"jp" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"jq" = (
+/obj/structure/table,
+/obj/machinery/light/broken/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"js" = (
+/obj/structure/rack,
+/obj/item/storage/box/swab,
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"jv" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"jz" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/clothing/suit/toggle/labcoat/interdyne,
+/obj/effect/mapping_helpers/atom_injector/element_injector{
+	element_type = /datum/element/decal/blood;
+	target_type = /obj/item/clothing
+	},
+/obj/item/card/id/away/dangerous_research/head_occultist,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"jB" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/computer/terminal/dangerous_research/lab_recording,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"jC" = (
+/obj/machinery/door/airlock{
+	name = "Dorms - Researcher Smith"
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"jF" = (
+/obj/machinery/light/broken/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"jH" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"jJ" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"jL" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/electric_shock/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"jO" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid9"
+	},
+/area/ruin/space)
+"jR" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"kc" = (
+/obj/machinery/air_sensor{
+	chamber_id = "asrc_b"
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"kf" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/structure/sign/warning/biohazard/directional/north,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"kj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"kz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"kA" = (
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"kP" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"kV" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"kY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"lp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"lq" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"lX" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"lY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"mg" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/machinery/chem_mass_spec,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"mo" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"mp" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"mu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"mG" = (
+/obj/structure/table,
+/obj/item/organ/internal/heart,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/spawner/random/medical/surgery_tool_advanced,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"mK" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"mV" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"mX" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"nl" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/item/modular_computer/laptop/buildable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"nm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"nv" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"nx" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"nz" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"nB" = (
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"nF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"nS" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/sign/clock/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"nT" = (
+/obj/structure/closet/crate/trashcart/filled,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/item/trash/cheesie,
+/obj/item/trash/ready_donk,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"nY" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"nZ" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/clothing/glasses/science,
+/obj/structure/sign/warning/chem_diamond/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"oa" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"om" = (
+/obj/machinery/door/airlock/science{
+	name = "Decontamination"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"os" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"ot" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/paper/fluff/ruins/dangerous_research/manifest,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"ou" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ox" = (
+/obj/machinery/door/airlock/vault{
+	name = "ASRC Electrical"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"oF" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"oH" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/item/organ/internal/lungs,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"oJ" = (
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 4
+	},
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/suture/emergency,
+/obj/item/stack/medical/gauze/twelve,
+/obj/item/reagent_containers/hypospray/medipen/blood_loss,
+/obj/effect/spawner/random/medical/injector,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"oW" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"pa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"pb" = (
+/obj/item/chair,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"pi" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"pk" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/dangerous_research)
+"pu" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/tank_holder/extinguisher/advanced,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"pC" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/bedsheet/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"pF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"pH" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid6"
+	},
+/area/ruin/space)
+"pO" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/trap/eldritch/tentacle,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"pP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"pQ" = (
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"pR" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/gun/ballistic/revolver/c38{
+	name = "outpost revolver";
+	pin = /obj/item/firing_pin/explorer
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"qc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/command{
+	name = "Head Occultist Bedroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/command,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"qg" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/item/organ/internal/brain,
+/obj/item/skillchip/job/research_director,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ql" = (
+/obj/item/trash/cheesie,
+/obj/structure/sign/poster/ripped{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"qp" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/structure/sign/clock/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"qq" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"qs" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"qv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"qB" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/closet/crate/bin,
+/obj/item/broken_bottle,
+/obj/item/shard,
+/obj/item/trash/champagne_cork,
+/obj/item/trash/ready_donk,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"qE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"qM" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"qO" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"qR" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ra" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"rb" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/item/organ/internal/heart,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"rc" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/microscope{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -3;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"rd" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"re" = (
+/mob/living/simple_animal/hostile/heretic_summon/raw_prophet{
+	AIStatus = 1;
+	stop_automated_movement = 0
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"ri" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/pen/blue,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"rl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet{
+	anchored = 1;
+	name = "HO Locker"
+	},
+/obj/effect/spawner/random/aimodule/harmful,
+/obj/item/clothing/suit/toggle/labcoat/interdyne,
+/obj/item/gps/spaceruin,
+/obj/item/clothing/under/rank/rnd/research_director/turtleneck,
+/obj/item/clothing/under/rank/rnd/research_director/turtleneck/skirt,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"rm" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"rq" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"rA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "asrc_b";
+	dir = 8
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"rF" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"rO" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"rT" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Main Testing Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"sa" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"sh" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/corner,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"sj" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"sv" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"sG" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tb" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tf" = (
+/obj/machinery/door/airlock{
+	name = "Dorms - Researcher Armstrong"
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"ti" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/trap/eldritch/tentacle,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"tk" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/door/airlock{
+	name = "Dorms - Officer Simes"
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"tm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tp" = (
+/obj/item/shard,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"tq" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/item/toy/plush/snakeplushie{
+	pixel_x = -14;
+	pixel_y = -9
+	},
+/obj/item/switchblade/extended,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ts" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"tu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"tv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"tz" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"tD" = (
+/obj/machinery/door/airlock{
+	name = "Dorms - Doctor Greyham"
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"tE" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"tF" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/sign/warning/test_chamber/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tK" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/trap/eldritch/mad,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"tQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"tR" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/machinery/computer/terminal/dangerous_research/greyham_report{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"tX" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 6;
+	pixel_y = 18
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"uc" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"um" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"un" = (
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"us" = (
+/turf/closed/wall,
+/area/ruin/space)
+"uB" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"uG" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"uI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/purple,
+/turf/open/space/basic,
+/area/ruin/space)
+"uP" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/tank_holder/anesthetic,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"uR" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"vg" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"vv" = (
+/obj/effect/spawner/structure/window/reinforced/damaged,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"vz" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"vH" = (
+/obj/item/wallframe/camera,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"wf" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"wh" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_1,
+/obj/structure/sign/poster/contraband/tea_over_tizira{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"wi" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"wr" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/machinery/light/dim/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"wt" = (
+/obj/structure/sign/warning/directional/north,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"wv" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"wC" = (
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"wJ" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"wS" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"wV" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"xb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"xd" = (
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"xn" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"xo" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"xq" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"xB" = (
+/obj/structure/barricade/wooden,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"xD" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"xJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"xK" = (
+/turf/open/misc/asteroid{
+	icon_state = "asteroid6"
+	},
+/area/ruin/space/has_grav/dangerous_research/medical)
+"xN" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"xS" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"xW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"xZ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"yl" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"yr" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"yO" = (
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"yQ" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/shower/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"yT" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/barricade/wooden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"yZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/directional/north,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"zb" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"zc" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"zd" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"ze" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"zg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"zi" = (
+/turf/open/misc/asteroid{
+	icon_state = "asteroid8"
+	},
+/area/ruin/space/has_grav/dangerous_research/medical)
+"zj" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/light/broken/directional/south,
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"zD" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"zM" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/light/warm/directional/south,
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/effect/mapping_helpers/atom_injector/element_injector{
+	element_type = /datum/element/decal/blood;
+	target_type = /obj/item/clothing
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"zO" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"zQ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/stack/sheet/iron,
+/mob/living/simple_animal/hostile/heretic_summon/rust_spirit{
+	AIStatus = 1;
+	stop_automated_movement = 0
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"zR" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid12"
+	},
+/area/ruin/space)
+"zY" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/ruin/space)
+"zZ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Ad" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/mob/living/simple_animal/hostile/heretic_summon/raw_prophet{
+	AIStatus = 1;
+	stop_automated_movement = 0
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Ag" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/soap,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"An" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Aq" = (
+/obj/machinery/atmospherics/components/binary/valve/on/layer4{
+	dir = 4;
+	name = "Air Tank A Valve"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Av" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"AH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple,
+/obj/item/folder/white,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"AK" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"AO" = (
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard,
+/obj/item/food/pizzaslice/moldy/bacteria,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"AQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"AT" = (
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"AU" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/item/trash/ready_donk,
+/obj/structure/closet/secure_closet/freezer/empty/open,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Ba" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Bc" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Bg" = (
+/turf/closed/mineral/random,
+/area/ruin/space)
+"Bm" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Bq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research)
+"Bs" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"By" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"BE" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"BG" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"BJ" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/sign/warning/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"BN" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"BY" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Cd" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/clock/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Cf" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Cl" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Cn" = (
+/obj/item/stack/sheet/mineral/silver,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Cq" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Cs" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"CA" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"CB" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("asrc_b" = "Air Supply B");
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"CD" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"CG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"CI" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid2"
+	},
+/area/ruin/space)
+"CL" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"CR" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"CS" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"CU" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Dg" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Dk" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Ds" = (
+/obj/item/shard,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Dt" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Dw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"DA" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/dangerous_research)
+"DB" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"DL" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"DX" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/sign/poster/official/moth_piping{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"DY" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/trash/chips,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/trash/cnds,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Ei" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/vault{
+	name = "Subject Containment"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/command,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Ep" = (
+/obj/structure/lattice,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"Ey" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space)
+"EA" = (
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"EF" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/item/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"ET" = (
+/obj/structure/sink/directional/south,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/clothing/shoes/sneakers/white,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/mapping_helpers/atom_injector/element_injector{
+	element_type = /datum/element/decal/blood;
+	target_type = /obj/item/clothing
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"EU" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rd/double{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Fa" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Fi" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Fq" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"Fw" = (
+/obj/structure/door_assembly/door_assembly_vault,
+/obj/effect/turf_decal/stripes/full,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"FA" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"FG" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"FJ" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"FM" = (
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"FZ" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Gb" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/structure/fluff/paper/stack,
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Gd" = (
+/obj/machinery/door/airlock/science{
+	name = "Supply Closet"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/obj/machinery/door/poddoor/shutters{
+	id = "asrc_supply";
+	name = "Supply Closet Shutters"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Gg" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/airlock/vault{
+	name = "Decontamination"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Gh" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Gm" = (
+/obj/machinery/light/broken/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/yes_smoking/circle/directional/east,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Gn" = (
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/toy/figure/rd{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/pen/fountain{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/pen/red,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Go" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Gs" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Gz" = (
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"GZ" = (
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Hj" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Hq" = (
+/turf/open/floor/glass/reinforced,
+/area/ruin/space/has_grav/dangerous_research)
+"Hu" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Hx" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Restroom"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"HF" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"HG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"HO" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"HQ" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/door/airlock{
+	name = "Dorms - Researcher Beaches"
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"HT" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/away{
+	name = "ASRC Lobby";
+	pixel_y = -25
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Ij" = (
+/obj/structure/table/glass,
+/obj/item/pai_card,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Ik" = (
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Il" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"IC" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/item/wallframe/camera,
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/robot_debris/up,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"IZ" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Ja" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Jh" = (
+/obj/effect/spawner/structure/window/reinforced/damaged,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"JA" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/structure/sign/warning/biohazard/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"JF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"JI" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"JN" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/cable,
+/obj/machinery/power/apc/away{
+	dir = 8;
+	name = "ASRC Dorms";
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"JS" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"JW" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Ki" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Kk" = (
+/obj/machinery/light/broken/directional/west,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Kt" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/grille/broken,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"KB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"KM" = (
+/obj/structure/barricade/wooden,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"KP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/door/airlock/science/glass{
+	name = "Alternate Sciences Research Center"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"KS" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"KT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"KU" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/structure/sign/flag/tizira/directional/north,
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"La" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Lc" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"Lk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Lr" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/grille/broken,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Lz" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"LC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"LH" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"LJ" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"LL" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"LU" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head Occultist Office"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/away/command,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"LW" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"LZ" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Mr" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"MD" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"MJ" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/item/food/badrecipe/moldy/bacteria{
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"MO" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"MT" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"MU" = (
+/obj/machinery/atmospherics/components/binary/valve/layer4{
+	dir = 4;
+	name = "Air Tank B Valve"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Nc" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Alternate Sciences Research Center"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Ni" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"No" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Nq" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Nr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Ns" = (
+/obj/machinery/door/airlock/science{
+	name = "Decontamination"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Ny" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Nz" = (
+/obj/structure/flora/grass/brown/style_3,
+/turf/open/misc/sandy_dirt,
+/area/ruin/space/has_grav/dangerous_research)
+"NK" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"NN" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"NV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"NX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Oa" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Ob" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("asrc_a" = "Air Supply A")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Oc" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"On" = (
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"Oo" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Op" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/ants,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"Oy" = (
+/obj/structure/flora/rock/icy/style_random,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"OB" = (
+/obj/structure/table,
+/obj/structure/microscope,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"OC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"OK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"OL" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"OM" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"OR" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"OW" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Pb" = (
+/obj/effect/turf_decal/stripes/asteroid,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Pc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Pk" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/heretic_rune/big,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Pn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka{
+	pixel_x = 8;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/sign/poster/contraband/andromeda_bitters{
+	pixel_x = 32
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Pu" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/bedsheet/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Pv" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"PJ" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"PL" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"PM" = (
+/obj/item/stack/rods/ten,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"PO" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"PP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Qa" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Qe" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Qn" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Qo" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Qt" = (
+/obj/effect/spawner/structure/window/reinforced/damaged,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Qv" = (
+/turf/open/space/basic,
+/area/template_noop)
+"Qy" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"QA" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid1"
+	},
+/area/ruin/space)
+"QE" = (
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"QK" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/very_dim/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"QQ" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/item/chair,
+/obj/item/clothing/under/rank/medical/doctor,
+/obj/effect/mapping_helpers/atom_injector/element_injector{
+	element_type = /datum/element/decal/blood;
+	target_type = /obj/item/clothing
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Rd" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Rf" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Rj" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Rr" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Rs" = (
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Rt" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Rx" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/structure/closet{
+	name = "Greyham's Locker"
+	},
+/obj/machinery/light/small/directional/east,
+/obj/item/clothing/under/rank/medical/doctor,
+/obj/item/lighter,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"RA" = (
+/turf/open/misc/asteroid/airless{
+	icon_state = "asteroid8"
+	},
+/area/ruin/space)
+"RB" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"RD" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"RE" = (
+/obj/structure/table,
+/obj/item/storage/box/matches,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/item/match,
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"RM" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"RR" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"RW" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Si" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Sj" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Sv" = (
+/obj/effect/turf_decal/stripes/asteroid{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"SF" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"SH" = (
+/obj/machinery/door/airlock/science{
+	name = "Science Lab"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"SK" = (
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/shard,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"SS" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/petri_dish/random,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"SV" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/shower/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Tc" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Te" = (
+/obj/effect/turf_decal/tile/purple/diagonal_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"TD" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"TE" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"TH" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/syndiemoth{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"TV" = (
+/obj/machinery/light/broken/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"TW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/machinery/iv_drip/saline,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Uc" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Uk" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Um" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Uu" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"UA" = (
+/obj/machinery/door/airlock/science{
+	name = "Living Quarters"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"UD" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"UH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/computer/terminal/dangerous_research/front_desk{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"UQ" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"UT" = (
+/obj/structure/flora/grass/brown,
+/obj/machinery/light/dim/directional/west,
+/turf/open/misc/sandy_dirt,
+/area/ruin/space/has_grav/dangerous_research)
+"Va" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/structure/desk_bell{
+	pixel_x = -7
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Vd" = (
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/paper/fluff/ruins/dangerous_research/manifest,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Vf" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "ASRC Atmospherics"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/access/all/away/science,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Vj" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Vo" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"VD" = (
+/obj/structure/flora/rock/icy/style_3,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"VL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"VP" = (
+/obj/effect/turf_decal/tile/dark_red/anticorner,
+/obj/structure/closet{
+	name = "Outpost Security Locker"
+	},
+/obj/structure/window/reinforced/spawner,
+/obj/effect/spawner/random/contraband/permabrig_weapon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/ammo_box/c38,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"VQ" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/cup/glass/waterbottle/large,
+/obj/item/reagent_containers/cup/glass/waterbottle/large,
+/obj/item/reagent_containers/cup/glass/waterbottle/large,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Wm" = (
+/obj/item/stack/rods/ten,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Wn" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Wt" = (
+/obj/structure/table/optable,
+/obj/item/organ/internal/eyes,
+/obj/item/organ/internal/liver,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"WG" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"WQ" = (
+/obj/structure/toilet{
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/obj/structure/fluff{
+	desc = "Ew, I think I see a hairball.";
+	icon = 'icons/obj/lavaland/survival_pod.dmi';
+	icon_state = "fan_tiny";
+	name = "shower drain"
+	},
+/obj/machinery/shower/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Xb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "asrc_a";
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"Xh" = (
+/mob/living/simple_animal/hostile/heretic_summon/rust_spirit{
+	AIStatus = 1;
+	stop_automated_movement = 0
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Xi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"Xk" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+"Xr" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"Xy" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"XB" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	name = "Scrubbers To External"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"XI" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/away{
+	dir = 1;
+	name = "ASRC Maintenance";
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/dangerous_research/maint)
+"XO" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"XX" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Yb" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/item/hemostat,
+/obj/item/circular_saw,
+/obj/item/surgical_drapes,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/sign/departments/medbay/alt/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Yh" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Yr" = (
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/structure/cable,
+/obj/machinery/power/apc/away{
+	dir = 1;
+	name = "ASRC Laboratory";
+	pixel_y = 25
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"YA" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/dangerous_research)
+"YC" = (
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research)
+"YL" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/structure/closet{
+	name = "Smith's Locker"
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/light/small/directional/east,
+/obj/item/paper/fluff/ruins/dangerous_research/smith,
+/obj/item/clothing/suit/toggle/labcoat/chemist,
+/obj/item/reagent_containers/pill/stimulant,
+/obj/item/card/id/away/dangerous_research,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"YY" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/away{
+	dir = 4;
+	name = "ASRC Medical Facility";
+	pixel_x = 25
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"YZ" = (
+/mob/living/simple_animal/hostile/heretic_summon/rust_spirit{
+	AIStatus = 1;
+	stop_automated_movement = 0
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/dangerous_research/lab)
+"Zc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/effect/mapping_helpers/atom_injector/element_injector{
+	element_type = /datum/element/decal/blood;
+	target_type = /obj/item/clothing
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Zn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Zv" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/dangerous_research/medical)
+"Zw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/dangerous_research/dorms)
+"ZF" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/dangerous_research)
+
+(1,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(2,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+jO
+On
+On
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(3,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Tc
+Um
+Um
+Um
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Bg
+Qv
+Qv
+On
+RA
+Qv
+Qv
+Qv
+Qv
+On
+On
+Bg
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(4,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Tc
+No
+Kk
+yO
+NN
+qg
+cp
+fn
+gF
+Tc
+Bg
+On
+QA
+Bg
+Bg
+On
+Qv
+Qv
+On
+On
+pH
+Bg
+On
+On
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Qv
+Qv
+Qv
+"}
+(5,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Tc
+qv
+cv
+zQ
+mK
+pO
+qE
+sG
+ql
+Tc
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+On
+On
+On
+On
+Lc
+On
+zR
+Qv
+QA
+Bg
+Bg
+Bg
+Bg
+Qv
+Qv
+"}
+(6,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Tc
+nl
+cl
+fE
+TD
+zZ
+gH
+DY
+qp
+Tc
+Bg
+Bg
+ts
+ts
+ts
+ts
+ts
+ts
+ts
+Bg
+Bg
+bb
+Bg
+On
+On
+On
+On
+On
+On
+Bg
+Bg
+Bg
+Qv
+Qv
+"}
+(7,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Tc
+TW
+iD
+ec
+An
+jz
+iR
+SS
+rc
+Tc
+Bg
+Bg
+ts
+ae
+Sj
+ts
+tz
+pC
+ts
+ts
+ts
+ts
+ts
+ts
+ts
+On
+On
+On
+Bg
+Bg
+Bg
+Bg
+Bg
+Qv
+"}
+(8,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Tc
+Yr
+Dt
+aW
+nx
+Wn
+Qn
+UD
+rd
+jp
+ts
+ts
+ts
+Pu
+uB
+ts
+um
+YL
+ts
+WQ
+ts
+rl
+EU
+mu
+ts
+On
+On
+On
+Bg
+Bg
+Bg
+Bg
+Bg
+Qv
+"}
+(9,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+Tc
+Tc
+Tc
+BJ
+BN
+fg
+BN
+AK
+Qa
+zO
+rq
+jp
+Rd
+pi
+ts
+ts
+tf
+ts
+jC
+ts
+ts
+Oc
+ts
+NX
+Zw
+Fa
+ts
+VD
+pH
+bb
+Bg
+Bg
+Bg
+Bg
+Bg
+Qv
+"}
+(10,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+Yh
+rF
+Ei
+ay
+Dw
+UQ
+UQ
+fR
+xD
+Uk
+Il
+jp
+Rj
+jk
+tk
+Lk
+OL
+JN
+pa
+aD
+Hx
+ce
+ts
+Zw
+Pn
+gt
+ts
+On
+On
+do
+On
+Bg
+Bg
+Bg
+Qv
+Qv
+"}
+(11,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+eq
+QE
+Tc
+aB
+fo
+vH
+EA
+AK
+YZ
+QK
+rO
+jp
+ts
+ts
+ts
+OR
+OL
+Rt
+nT
+ts
+ts
+ts
+ts
+qc
+ts
+ts
+ts
+Bg
+On
+On
+On
+us
+Bg
+Bg
+Qv
+Qv
+"}
+(12,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+hS
+BY
+Tc
+Tc
+Um
+Um
+YZ
+hV
+Um
+Tc
+rT
+Qe
+jJ
+he
+tD
+hL
+bl
+Uc
+AT
+ts
+KS
+Cd
+TE
+Nr
+qB
+ts
+Bg
+CI
+On
+Qv
+RA
+Ep
+Oy
+Bg
+Qv
+Qv
+"}
+(13,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+tq
+La
+Tc
+dw
+Bs
+CL
+Ds
+if
+CL
+EA
+Xh
+Qe
+bP
+Rx
+ts
+CA
+AO
+Rt
+HF
+ts
+DX
+bu
+Ij
+Ny
+ot
+dl
+On
+On
+us
+uI
+Ey
+Ey
+Ey
+Ey
+uI
+Qv
+"}
+(14,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+fH
+nY
+Tc
+jq
+jH
+tF
+IZ
+iE
+fB
+hI
+TV
+jp
+ts
+ts
+ts
+qO
+PJ
+Rt
+zM
+ts
+Bm
+OC
+Fi
+PP
+ji
+dl
+On
+pH
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(15,1,1) = {"
+Qv
+Bg
+Bg
+Tc
+Tc
+Tc
+Tc
+OB
+Pb
+mp
+rb
+qq
+sa
+Rr
+tb
+jp
+KU
+Cs
+HQ
+OW
+nz
+Xi
+nv
+ts
+Bm
+Ny
+Gn
+xZ
+eQ
+ts
+Bg
+Bg
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(16,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Tc
+jB
+qR
+eW
+sj
+Pk
+Bc
+DB
+tb
+jp
+wh
+LW
+ts
+ts
+UA
+ts
+ts
+ts
+LU
+dl
+ts
+ts
+ts
+ts
+pk
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(17,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Tc
+fJ
+jH
+BE
+FZ
+kV
+NK
+ou
+tb
+jp
+jp
+jp
+jp
+MO
+RM
+Xr
+wr
+Av
+Av
+db
+pk
+gY
+UT
+Nz
+pk
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(18,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Tc
+ci
+Gb
+VL
+Ja
+tK
+JS
+oH
+tb
+cd
+pb
+EF
+Tc
+JW
+Hq
+Hq
+Hq
+Hq
+Hq
+RD
+pk
+PL
+ax
+Cq
+Bq
+Bq
+pk
+Ey
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(19,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+CI
+Bg
+Tc
+jF
+dI
+CD
+oW
+CS
+xq
+Nq
+tP
+Fw
+eu
+iZ
+Tc
+LZ
+Hq
+Hq
+Hq
+Hq
+Hq
+Lz
+Bq
+lp
+wJ
+MD
+zc
+CG
+Xk
+zY
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(20,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+On
+Bg
+Tc
+FG
+XX
+AH
+tm
+NV
+dy
+fi
+nm
+Tc
+tI
+wC
+Tc
+Oa
+RW
+RW
+yr
+Hq
+Hq
+RD
+Nc
+tv
+Cf
+fO
+Bq
+Bq
+pk
+Ey
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(21,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Tc
+Tc
+Tc
+Tc
+Qt
+Kt
+iU
+vv
+Tc
+fx
+Pc
+Fw
+Tc
+Rs
+ri
+ZF
+FJ
+Hq
+Hq
+Lz
+Bq
+wJ
+Ni
+tv
+Bq
+zY
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(22,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+Yb
+Sv
+QQ
+sh
+jv
+aZ
+Hj
+xd
+ti
+Rf
+os
+cW
+UH
+rm
+Hq
+Hq
+RD
+KP
+Te
+Te
+Mr
+Bq
+Bq
+pk
+Ey
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(23,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+mG
+mV
+Ad
+XO
+tp
+tR
+qM
+kP
+fm
+Rf
+RB
+sv
+Va
+FJ
+Hq
+Hq
+RD
+Bq
+wJ
+lp
+MD
+jh
+Gs
+OM
+zY
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(24,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+ip
+Wt
+Vo
+kY
+pQ
+uP
+qM
+gR
+cm
+Rf
+TH
+yl
+Vd
+FJ
+Hq
+Hq
+RD
+pk
+RE
+Gm
+dX
+Bq
+Bq
+pk
+Ey
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(25,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+ET
+Zc
+PM
+Ki
+Zn
+IC
+Jh
+wV
+kz
+Zv
+oJ
+at
+VP
+uR
+MT
+aa
+HT
+pk
+pk
+pk
+pk
+pk
+Bg
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(26,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+FM
+JF
+Wm
+wv
+ak
+PO
+pF
+Xy
+xn
+Zv
+DA
+DA
+DA
+DA
+Dk
+HG
+LJ
+ey
+dm
+AU
+pk
+Bg
+Bg
+CI
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(27,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Zv
+xd
+zi
+re
+lX
+Go
+uc
+KB
+SK
+cm
+Rf
+KM
+yQ
+YC
+DA
+yZ
+Pv
+LJ
+xN
+xN
+xN
+Bq
+pH
+On
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(28,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Zv
+GZ
+GZ
+Cn
+lY
+Si
+vg
+Hu
+CU
+zD
+Gg
+Gz
+yT
+nF
+om
+Uu
+Oo
+LJ
+YA
+mX
+lq
+Bq
+On
+On
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(29,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+nB
+nB
+GZ
+GZ
+nB
+KT
+gN
+KB
+wV
+JA
+Rf
+xo
+RR
+zj
+DA
+kf
+Oo
+SF
+wS
+MJ
+tX
+Bq
+VD
+On
+us
+uI
+Ey
+Ep
+Ep
+Ey
+uI
+Qv
+"}
+(30,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+nB
+nB
+xK
+xd
+xd
+pP
+qs
+Jh
+aI
+FA
+df
+jm
+ze
+xJ
+Ns
+Dg
+Oo
+Gh
+Op
+LL
+vz
+Bq
+zR
+On
+On
+Qv
+On
+Ep
+On
+On
+Qv
+Qv
+"}
+(31,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+nB
+nB
+Zv
+Zv
+iw
+pR
+gN
+Lr
+Xy
+cm
+Rf
+xB
+SV
+YC
+DA
+wt
+WG
+tE
+nS
+xS
+xN
+pk
+Bg
+Bg
+On
+On
+Bg
+us
+Bg
+On
+Qv
+Qv
+"}
+(32,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Bg
+Rf
+mg
+LC
+bO
+xd
+xd
+xn
+jR
+jR
+jR
+jR
+jR
+cN
+wi
+zb
+Cl
+Cl
+Cl
+Cl
+jR
+On
+On
+bb
+Bg
+Bg
+On
+Qv
+Qv
+Qv
+"}
+(33,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Rf
+mo
+Ba
+un
+Hj
+kA
+cm
+jR
+uG
+BG
+VQ
+jR
+Cl
+Vf
+Cl
+Cl
+pu
+oF
+Qy
+jR
+On
+Bg
+Bg
+On
+Lc
+On
+Qv
+Qv
+Qv
+"}
+(34,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Rf
+nZ
+tQ
+ix
+SH
+zd
+cm
+jR
+fT
+zg
+kj
+Gd
+tu
+xb
+AQ
+By
+OK
+xW
+XB
+gl
+DL
+Qv
+Qv
+Qv
+On
+Qv
+Qv
+Qv
+Qv
+"}
+(35,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+bb
+Qv
+Qv
+Bg
+Bg
+Bg
+Bg
+Rf
+oa
+YY
+aY
+qM
+jL
+Qo
+jR
+js
+Ag
+dC
+jR
+XI
+go
+Ob
+Aq
+ra
+MU
+CB
+jR
+On
+RA
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(36,1,1) = {"
+Qv
+Qv
+Qv
+Bg
+Bg
+On
+Qv
+Bg
+Bg
+Bg
+Bg
+Rf
+Rf
+jR
+jR
+jR
+jR
+ox
+jR
+jR
+jR
+jR
+jR
+jR
+jR
+Vj
+CR
+jR
+CR
+Vj
+jR
+On
+On
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(37,1,1) = {"
+Qv
+Qv
+Bg
+Bg
+Bg
+On
+On
+do
+Bg
+Bg
+Bg
+Bg
+Bg
+jR
+LH
+Ik
+HO
+wf
+jR
+Bg
+Bg
+Bg
+Bg
+Bg
+jR
+dZ
+Xb
+jR
+rA
+kc
+jR
+do
+Bg
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(38,1,1) = {"
+Qv
+Qv
+Qv
+zR
+pH
+Qv
+Qv
+Bg
+On
+On
+CI
+Bg
+Bg
+jR
+LH
+Ik
+JI
+gr
+jR
+Bg
+Bg
+On
+do
+On
+jR
+jR
+jR
+jR
+jR
+jR
+jR
+On
+Bg
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(39,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+On
+On
+zR
+Bg
+jR
+jR
+jR
+jR
+jR
+jR
+Bg
+On
+jO
+On
+Fq
+On
+RA
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+RA
+On
+QA
+Bg
+Qv
+Qv
+Qv
+Qv
+"}
+(40,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+On
+On
+Qv
+Qv
+do
+Bg
+Bg
+On
+CI
+Bg
+Bg
+Bg
+QA
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Bg
+Bg
+Qv
+zR
+On
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(41,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+bb
+On
+Bg
+Bg
+Bg
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}
+(42,1,1) = {"
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+Qv
+"}

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2174,6 +2174,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
 "mA" = (

--- a/_maps/map_files/tramstation/maintenance_modules/dormenginelower_2.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormenginelower_2.dmm
@@ -53,7 +53,6 @@
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/random/maintenance/two,
-/obj/item/stock_parts/cell/infinite,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "dp" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5205,6 +5205,9 @@
 	supplies_requestable = 1;
 	name = "Cargo Bay Requests Console"
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aAN" = (
@@ -6326,7 +6329,7 @@
 /turf/open/floor/plating,
 /area/station/science/genetics)
 "aId" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #8";
 	req_access = list("xenobiology")
 	},
@@ -6336,6 +6339,10 @@
 	name = "Xenobio Bottom Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #8";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "aIi" = (
@@ -9438,7 +9445,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Secure - AI Antechamber North";
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -9810,7 +9817,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External West";
 	dir = 6;
-	network = list("aicore")
+	network = list("minisat")
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)
@@ -10475,7 +10482,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External South";
 	dir = 9;
-	network = list("aicore")
+	network = list("minisat")
 	},
 /obj/structure/lattice,
 /turf/open/space/openspace,
@@ -11083,7 +11090,8 @@
 /area/station/cargo/lobby)
 "cbj" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
+	base_state = "right";
+	icon_state = "right";
 	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
@@ -11093,6 +11101,12 @@
 	name = "Xenobio Topleft Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cbn" = (
@@ -12694,7 +12708,6 @@
 /area/station/hallway/secondary/exit)
 "cFk" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -12704,6 +12717,10 @@
 	name = "Xenobio Top Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #4";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cFl" = (
@@ -16763,7 +16780,7 @@
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Secure - AI Minisat Teleporter";
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /obj/machinery/button/door/directional/south{
 	id = "teledoor";
@@ -17855,6 +17872,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "eCz" = (
@@ -20664,15 +20682,15 @@
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/ce{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
 	supplies_requestable = 1;
 	name = "Chief Engineer's Request Console"
+	},
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -21041,7 +21059,6 @@
 /area/station/security/processing)
 "fPi" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
 	name = "Containment Pen #2";
 	req_access = list("xenobiology")
 	},
@@ -21051,6 +21068,10 @@
 	name = "Xenobio Topleft Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #2";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fPy" = (
@@ -22456,7 +22477,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - AI Lower Ring Access"
+	c_tag = "Secure - AI Lower Ring Access";
+	network = list("ss13","minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -23802,7 +23824,7 @@
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Secure - AI Upper Ring North";
-	network = list("ss13","aicore")
+	network = list("aicore")
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -24110,7 +24132,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Minisat Entry";
 	dir = 10;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -27867,7 +27889,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Lower External East";
 	dir = 10;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -29571,7 +29593,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Lower External West";
 	dir = 6;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -29687,7 +29709,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "jmb" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #5";
@@ -29699,6 +29721,12 @@
 	name = "Xenobio Bottom Left Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "jmk" = (
@@ -34632,7 +34660,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Antechamber East";
 	dir = 10;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -36371,7 +36399,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "lIa" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #6";
 	req_access = list("xenobiology")
 	},
@@ -36381,6 +36409,10 @@
 	name = "Xenobio Bottom Left Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #6";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "lIe" = (
@@ -36659,7 +36691,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring East";
 	dir = 10;
-	network = list("ss13","aicore")
+	network = list("aicore")
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -37009,10 +37041,9 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "lSQ" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
+/obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "lSU" = (
@@ -37450,7 +37481,7 @@
 "mbe" = (
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "Secure - AI Lower External North";
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space)
@@ -38386,7 +38417,8 @@
 	name = "Private Channel"
 	},
 /obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - AI Upper Ring Access"
+	c_tag = "Secure - AI Upper Ring Access";
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -39152,7 +39184,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Antechamber West";
 	dir = 6;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -41058,7 +41090,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Antechamber South";
 	dir = 9;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -42851,7 +42883,7 @@
 "obF" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/motion/directional/west{
-	c_tag = "Secure - ai_upload"
+	c_tag = "Secure - AI Upload"
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -43763,9 +43795,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ouF" = (
@@ -48790,7 +48822,7 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "qoo" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #7";
@@ -48802,6 +48834,12 @@
 	name = "Xenobio Bottom Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #7";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qoD" = (
@@ -52434,7 +52472,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Minisat Internal Power Access";
 	dir = 9;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
@@ -52809,7 +52847,8 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - AI Core South"
+	c_tag = "Secure - AI Core South";
+	network = list("aicore")
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
@@ -52835,7 +52874,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - aux_base Construction";
+	c_tag = "Civilian - Aux Base Construction";
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -53551,7 +53590,7 @@
 	dir = 10
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Secure - ai_upload Access";
+	c_tag = "Secure - AI Upload Access";
 	dir = 10;
 	network = list("ss13","aiupload")
 	},
@@ -54600,7 +54639,6 @@
 "swy" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")
@@ -54611,6 +54649,12 @@
 	name = "Xenobio Top Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "swC" = (
@@ -54695,9 +54739,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sxT" = (
@@ -54905,7 +54950,9 @@
 "sBI" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/computer/security/telescreen/rd,
+/obj/machinery/computer/security/telescreen/rd{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -55461,7 +55508,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring South";
 	dir = 9;
-	network = list("ss13","aicore")
+	network = list("aicore")
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -55814,7 +55861,8 @@
 	pixel_y = 20
 	},
 /obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - AI Core North"
+	c_tag = "Secure - AI Core North";
+	network = list("aicore")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -57687,7 +57735,7 @@
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring West";
 	dir = 6;
-	network = list("ss13","aicore")
+	network = list("aicore")
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -58325,7 +58373,7 @@
 "tNG" = (
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "Secure - AI Upper External North";
-	network = list("aicore")
+	network = list("minisat")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/hull/reinforced,
@@ -63348,7 +63396,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Lower External South";
 	dir = 9;
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -64557,7 +64605,7 @@
 /area/station/commons/lounge)
 "wdz" = (
 /obj/machinery/camera{
-	c_tag = "Secure - External ai_upload";
+	c_tag = "Secure - External AI Upload";
 	dir = 10
 	},
 /turf/open/space/openspace,
@@ -65609,7 +65657,7 @@
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Secure - AI Minisat Chargebay";
-	network = list("ss13","minisat")
+	network = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -67846,7 +67894,8 @@
 	dir = 5
 	},
 /obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - Upper Station Comms Relay"
+	c_tag = "Secure - Upper Station Comms Relay";
+	network = list("ss13","minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -69764,7 +69813,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External East";
 	dir = 10;
-	network = list("aicore")
+	network = list("minisat")
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -195,11 +195,6 @@ GLOBAL_LIST_INIT(ai_employers, list(
 	"Unshackled",
 ))
 
-///all the employers that are syndicate
-#define FACTION_SYNDICATE "syndicate"
-///all the employers that are nanotrasen
-#define FACTION_NANOTRASEN "nanotrasen"
-
 #define UPLINK_THEME_SYNDICATE "syndicate"
 
 #define UPLINK_THEME_UNDERWORLD_MARKET "neutral"
@@ -219,9 +214,6 @@ GLOBAL_LIST_INIT(ai_employers, list(
 #define IS_HERETIC_MONSTER(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic_monster))
 /// Checks if the given mob is either a heretic or a heretic monster.
 #define IS_HERETIC_OR_MONSTER(mob) (IS_HERETIC(mob) || IS_HERETIC_MONSTER(mob))
-
-/// Define for the heretic faction applied to heretics and heretic mobs.
-#define FACTION_HERETIC "heretics"
 
 /// Checks if the given mob is a wizard
 #define IS_WIZARD(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/wizard) || mob?.mind?.has_antag_datum(/datum/antagonist/wizard_journeyman))

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -1,9 +1,93 @@
-/// If this seems rather...bare at the moment, its temporary.
-/// Later all mob factions will be moved here and their current factions replaced with faction defines.
+// Contains mob factions that are not handled by special role defines (for example, viscerators having ROLE_SYNDICATE)
 
-#define FACTION_CLOWN "Clowns"
-#define FACTION_RAT "Rats"
-// Maint creatures have mutual respect for eachother.
-#define FACTION_MAINT_CREATURES "Maint_Creatures"
+// Default factions
 
+/// Acts as a default faction for most violent creatures
+#define FACTION_HOSTILE "hostile"
+/// Acts as a default faction for most peaceful creatures
 #define FACTION_NEUTRAL "neutral"
+
+// Creature factions
+
+/// Ashwalker related creatures
+#define FACTION_ASHWALKER "ashwalker"
+/// Megafauna bosses of mining
+#define FACTION_BOSS "boss"
+/// CARPS
+#define FACTION_CARP "carp"
+/// Creatures summoned by chemical reactions
+#define FACTION_CHEMICAL_SUMMON "chemical_summon"
+/// Clown creatures and the Clown themselves
+#define FACTION_CLOWN "clowns"
+/// Headslugs
+#define FACTION_CREATURE "creature"
+/// Faithless and shadowpeople
+#define FACTION_FAITHLESS "faithless"
+/// Gnomes
+#define FACTION_GNOME "gnomes"
+/// Gondolas
+#define FACTION_GONDOLA "gondola"
+/// Slaughterdemons
+#define FACTION_HELL "hell"
+/// Hivebots
+#define FACTION_HIVEBOT "hivebot"
+/// Illusionary creaturs
+#define FACTION_ILLUSION "illusion"
+/// Creatures of the never finished jungle planet, and gorillas
+#define FACTION_JUNGLE "jungle"
+/// Small lizards
+#define FACTION_LIZARD "lizard"
+/// Maint creatures have mutual respect for eachother.
+#define FACTION_MAINT_CREATURES "maint_creatures"
+/// Animated objects and statues
+#define FACTION_MIMIC "mimic"
+/// Beasts found on the various mining environments
+#define FACTION_MINING "mining"
+/// Monkeys and gorillas
+#define FACTION_MONKEY "monkey"
+/// Mushrooms and mushroompeople
+#define FACTION_MUSHROOM "mushroom"
+/// Nanotrasen private security
+#define FACTION_NANOTRASEN_PRIVATE "nanotrasen_private"
+/// Mobs from the Netherworld
+#define FACTION_NETHER "nether"
+/// Mobs spawned by the emagged orion arcade
+#define FACTION_ORION "orion"
+/// Penguins and their chicks
+#define FACTION_PENGUIN "penguin"
+/// Plants, lots of overlap with vines
+#define FACTION_PLANTS "plants"
+/// Rats and mice
+#define FACTION_RAT "rats"
+/// Creatures from Space Russia
+#define FACTION_RUSSIAN "russian"
+/// Creatures affiliated with the AI and Cyborgs
+#define FACTION_SILICON "silicon"
+/// Spooky scary skeletons
+#define FACTION_SKELETON "skeleton"
+/// Slimey creatures
+#define FACTION_SLIME "slime"
+/// Spiders and their webs
+#define FACTION_SPIDER "spiders"
+/// Currently used only by floating eyeballs
+#define FACTION_SPOOKY "spooky"
+/// Statues that move around when nobody is watching them
+#define FACTION_STATUE "statue"
+/// Stick creatures summoned by the Paperwizard, and the wizard themselves
+#define FACTION_STICKMAN "stickman"
+/// Creatures ignored by various turrets
+#define FACTION_TURRET "turret"
+/// Vines, lots of overlap with plants
+#define FACTION_VINES "vines"
+
+// Antagonist factions
+
+/// Cultists and their constructs
+#define FACTION_CULT "cult"
+/// Define for the heretic faction applied to heretics and heretic mobs.
+#define FACTION_HERETIC "heretics"
+/// Mainly used by pirate simplemobs. However I placed them here instead, as its also used by players
+#define FACTION_PIRATE "pirate"
+
+/// Generates a mob faction for the passed owner, used by stabilized pink extracts
+#define FACTION_PINK_EXTRACT(owner) "pink_[owner]"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -828,33 +828,35 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define HEAL_STAM (1<<6)
 /// Restore all limbs to their initial state.
 #define HEAL_LIMBS (1<<7)
-/// Heals all organs from failing. If done as a part of an admin heal, will instead restore all organs to their initial state.
+/// Heals all organs from failing.
 #define HEAL_ORGANS (1<<8)
+/// A "super" heal organs, this refreshes all organs entirely, deleting old and replacing them with new.
+#define HEAL_REFRESH_ORGANS (1<<9)
 /// Removes all wounds.
-#define HEAL_WOUNDS (1<<9)
+#define HEAL_WOUNDS (1<<10)
 /// Removes all brain traumas, not including permanent ones.
-#define HEAL_TRAUMAS (1<<10)
+#define HEAL_TRAUMAS (1<<11)
 /// Removes all reagents present.
-#define HEAL_ALL_REAGENTS (1<<11)
+#define HEAL_ALL_REAGENTS (1<<12)
 /// Removes all non-positive diseases.
-#define HEAL_NEGATIVE_DISEASES (1<<12)
+#define HEAL_NEGATIVE_DISEASES (1<<13)
 /// Restores body temperature back to nominal.
-#define HEAL_TEMP (1<<13)
+#define HEAL_TEMP (1<<14)
 /// Restores blood levels to normal.
-#define HEAL_BLOOD (1<<14)
+#define HEAL_BLOOD (1<<15)
 /// Removes all non-positive mutations (neutral included).
-#define HEAL_NEGATIVE_MUTATIONS (1<<15)
+#define HEAL_NEGATIVE_MUTATIONS (1<<16)
 /// Removes status effects with this flag set that also have remove_on_fullheal = TRUE.
-#define HEAL_STATUS (1<<16)
+#define HEAL_STATUS (1<<17)
 /// Same as above, removes all CC related status effects with this flag set that also have remove_on_fullheal = TRUE.
-#define HEAL_CC_STATUS (1<<17)
+#define HEAL_CC_STATUS (1<<18)
 /// Deletes any restraints on the mob (handcuffs / legcuffs)
-#define HEAL_RESTRAINTS (1<<18)
+#define HEAL_RESTRAINTS (1<<19)
 
 /// Combination flag to only heal the main damage types.
 #define HEAL_DAMAGE (HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_OXY|HEAL_CLONE|HEAL_STAM)
 /// Combination flag to only heal things messed up things about the mob's body itself.
-#define HEAL_BODY (HEAL_LIMBS|HEAL_ORGANS|HEAL_WOUNDS|HEAL_TRAUMAS|HEAL_BLOOD|HEAL_TEMP)
+#define HEAL_BODY (HEAL_LIMBS|HEAL_ORGANS|HEAL_REFRESH_ORGANS|HEAL_WOUNDS|HEAL_TRAUMAS|HEAL_BLOOD|HEAL_TEMP)
 /// Combination flag to heal negative things affecting the mob.
 #define HEAL_AFFLICTIONS (HEAL_NEGATIVE_DISEASES|HEAL_NEGATIVE_MUTATIONS|HEAL_ALL_REAGENTS|HEAL_STATUS|HEAL_CC_STATUS)
 

--- a/code/__DEFINES/xenobiology.dm
+++ b/code/__DEFINES/xenobiology.dm
@@ -1,5 +1,5 @@
 //gold slime core spawning (used with var/gold_core_spawnable)
-/// Mob cannot be spawned with a gold slime core 
+/// Mob cannot be spawned with a gold slime core
 #define NO_SPAWN 0
 /// Mob can spawned with a gold slime core with plasma reaction as a hostile creature
 #define HOSTILE_SPAWN 1
@@ -9,8 +9,8 @@
 //slime core activation type
 /// Jelly species slime ability that causes simple effects that require energized jelly
 #define SLIME_ACTIVATE_MINOR 1
-/// Jelly species slime ability that causes complex effects that require plasma jelly 
+/// Jelly species slime ability that causes complex effects that require plasma jelly
 #define SLIME_ACTIVATE_MAJOR 2
 
-/// Determines how much light the jelly species emit 
+/// Determines how much light the jelly species emit
 #define LUMINESCENT_DEFAULT_GLOW 2

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -14,7 +14,7 @@
 	/// Time until we next spawn
 	COOLDOWN_DECLARE(spawn_delay)
 
-/datum/component/spawner/Initialize(mob_types = list(), spawn_time = 30 SECONDS, max_mobs = 5, faction = list("mining"), spawn_text = "emerges from")
+/datum/component/spawner/Initialize(mob_types = list(), spawn_time = 30 SECONDS, max_mobs = 5, faction = list(FACTION_MINING), spawn_text = "emerges from")
 	if (!length(mob_types))
 		CRASH("No types of mob to spawn specified for spawner component!")
 	src.spawn_time = spawn_time

--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -127,3 +127,12 @@
 
 /datum/id_trim/pirate/captain/psykers
 	assignment = "Psyker-gang Leader"
+
+//Trims for Dangerous Research, used in ``dangerous_research.dm``
+/datum/id_trim/away/dangerous_research
+	assignment = "Researcher"
+	access = list(ACCESS_AWAY_SCIENCE)
+
+/datum/id_trim/away/dangerous_research/head_occultist
+	assignment = "Head Occultist"
+	access = list(ACCESS_AWAY_SCIENCE, ACCESS_AWAY_COMMAND)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -17,14 +17,14 @@
 	ADD_TRAIT(target, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(target, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
-	target.faction |= "carp" //:D
+	target.faction |= FACTION_CARP //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/target)
 	REMOVE_TRAIT(target, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	UnregisterSignal(target, COMSIG_PARENT_ATTACKBY)
-	target.faction -= "carp" //:(
+	target.faction -= FACTION_CARP //:(
 	. = ..()
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/A, mob/living/D)

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -181,10 +181,14 @@
 	if(!character_appearance)
 		return new /icon()
 
-	var/mutable_appearance/appearance = character_appearance
-	appearance.setDir(orientation)
+	var/icon/picture_image
+	if(!isicon(character_appearance))
+		var/mutable_appearance/appearance = character_appearance
+		appearance.setDir(orientation)
 
-	var/icon/picture_image = getFlatIcon(appearance)
+		picture_image = getFlatIcon(appearance)
+	else
+		picture_image = character_appearance
 
 	var/datum/picture/picture = new
 	picture.picture_name = name

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -337,3 +337,9 @@
 	suffix = "cyborg_mothership.dmm"
 	name = "Cyborg Mothership"
 	description = "An abandoned cyborg mothership that was overtaken by space vines and hivebots. It appears that it hosted an experimental AI focused on mining before it was depowered."
+
+/datum/map_template/ruin/space/dangerous_research
+	id = "dangerous_research"
+	suffix = "dangerous_research.dmm"
+	name = "Alternate Sciences Research Center"
+	description = "When you're messing with the occult, who knows what you're going to get?"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -158,6 +158,13 @@
 	RegisterSignal(owner, COMSIG_LIVING_IGNITED, PROC_REF(on_ignited))
 	RegisterSignal(owner, COMSIG_LIVING_EXTINGUISHED, PROC_REF(on_extinguished))
 
+/datum/status_effect/fleshmend/on_creation(mob/living/new_owner, ...)
+	. = ..()
+	if(!. || !owner || !linked_alert)
+		return
+	if(owner.on_fire)
+		linked_alert.icon_state = "fleshmend_fire"
+
 /datum/status_effect/fleshmend/on_remove()
 	UnregisterSignal(owner, list(COMSIG_LIVING_IGNITED, COMSIG_LIVING_EXTINGUISHED))
 

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -185,6 +185,22 @@
 /area/ruin/space/has_grav/abandonedzoo
 	name = "\improper Abandoned Zoo"
 
+//Ruin of Dangerous Research
+
+/area/ruin/space/has_grav/dangerous_research
+	name = "\improper ASRC Lobby"
+
+/area/ruin/space/has_grav/dangerous_research/medical
+	name = "\improper ASRC Medical Facilities"
+
+/area/ruin/space/has_grav/dangerous_research/dorms
+	name = "\improper ASRC Dorms"
+
+/area/ruin/space/has_grav/dangerous_research/lab
+	name = "\improper ASRC Laboratory"
+
+/area/ruin/space/has_grav/dangerous_research/maint
+	name = "\improper ASRC Maintenance"
 
 //Ruin of ancient Space Station (OldStation)
 

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -500,7 +500,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 /mob/living/basic/syndicate/ranged/smg/orion
 	name = "spaceport security"
 	desc = "Premier corporate security forces for all spaceports found along the Orion Trail."
-	faction = list("orion")
+	faction = list(FACTION_ORION)
 	loot = list()
 
 /obj/item/orion_ship

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -14,6 +14,7 @@
 		return data
 
 	data["assigned_view"] = "preview_[user.ckey]_[REF(src)]_records"
+	data["station_z"] = !!(z && is_station_level(z))
 
 	return data
 
@@ -41,10 +42,15 @@
 		if("expunge_record")
 			if(!target)
 				return FALSE
+			// Don't let people off station futz with the station network.
+			if(!is_station_level(z))
+				balloon_alert(usr, "out of range!")
+				return TRUE
 
 			expunge_record_info(target)
 			balloon_alert(usr, "record expunged")
 			playsound(src, 'sound/machines/terminal_eject.ogg', 70, TRUE)
+			investigate_log("[key_name(usr)] expunged the record of [target.name].", INVESTIGATE_RECORDS)
 
 			return TRUE
 
@@ -60,8 +66,13 @@
 			return TRUE
 
 		if("purge_records")
+			// Don't let people off station futz with the station network.
+			if(!is_station_level(z))
+				balloon_alert(usr, "out of range!")
+				return TRUE
+
 			ui.close()
-			balloon_alert(usr, "purging records")
+			balloon_alert(usr, "purging records...")
 			playsound(src, 'sound/machines/terminal_alert.ogg', 70, TRUE)
 
 			if(do_after(usr, 5 SECONDS))
@@ -70,6 +81,9 @@
 
 				balloon_alert(usr, "records purged")
 				playsound(src, 'sound/machines/terminal_off.ogg', 70, TRUE)
+				investigate_log("[key_name(usr)] purged all records.", INVESTIGATE_RECORDS)
+			else
+				balloon_alert(usr, "interrupted!")
 
 			return TRUE
 
@@ -134,6 +148,11 @@
 
 	if(!authenticated && !has_auth(user))
 		balloon_alert(user, "access denied")
+		playsound(src, 'sound/machines/terminal_error.ogg', 70, TRUE)
+		return FALSE
+
+	if(mugshot.picture.psize_x > world.icon_size || mugshot.picture.psize_y > world.icon_size)
+		balloon_alert(user, "photo too large!")
 		playsound(src, 'sound/machines/terminal_error.ogg', 70, TRUE)
 		return FALSE
 

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -124,7 +124,7 @@
 
 /obj/item/goliath_infuser_hammer/attack(mob/living/target, mob/living/carbon/human/user)
 	// Check for nemesis factions on the target.
-	if(!("mining" in target.faction) && !("boss" in target.faction))
+	if(!(FACTION_MINING in target.faction) && !(FACTION_BOSS in target.faction))
 		// Target is not a nemesis, so attack normally.
 		return ..()
 	// Apply nemesis-specific effects.

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -90,7 +90,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	/// Determines if our projectiles hit our faction
 	var/ignore_faction = FALSE
 	/// Same faction mobs will never be shot at, no matter the other settings
-	var/list/faction = list("turret")
+	var/list/faction = list(FACTION_TURRET)
 	/// The spark system, used for generating... sparks?
 	var/datum/effect_system/spark_spread/spark_system
 	/// The turret will try to shoot from a turf in that direction when in a wall
@@ -774,7 +774,7 @@ DEFINE_BITFIELD(turret_flags, list(
 /obj/machinery/porta_turret/syndicate/energy/raven
 	stun_projectile = /obj/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 
 /obj/machinery/porta_turret/syndicate/pod
 	integrity_failure = 0.5
@@ -810,7 +810,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		return TRUE
 
 /obj/machinery/porta_turret/ai
-	faction = list("silicon")
+	faction = list(FACTION_SILICON)
 	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_HEADS
 
 /obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
@@ -824,7 +824,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	lethal_projectile = /obj/projectile/plasma/turret
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	mode = TURRET_LETHAL //It would be useless in stun mode anyway
-	faction = list(FACTION_NEUTRAL,"silicon","turret") //Minebots, medibots, etc that should not be shot.
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET) //Minebots, medibots, etc that should not be shot.
 
 /obj/machinery/porta_turret/aux_base/assess_perp(mob/living/carbon/human/perp)
 	return 0 //Never shoot humanoids. You are on your own if Ashwalkers or the like attack!
@@ -853,7 +853,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	stun_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	icon_state = "syndie_off"
 	base_icon_state = "syndie"
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 	mode = TURRET_LETHAL
 
 /obj/machinery/porta_turret/centcom_shuttle/Initialize(mapload)
@@ -873,7 +873,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	desc = "A turret built with substandard parts and run down further with age. Still capable of delivering lethal lasers to the odd space carp, but not much else."
 	stun_projectile = /obj/projectile/beam/weak/penetrator
 	lethal_projectile = /obj/projectile/beam/weak/penetrator
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 
 ////////////////////////
 //Turret Control Panel//

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -113,7 +113,7 @@
 	var/obj/machinery/atmospherics/components/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
 	var/directive = "" //Message from the mother
-	var/list/faction = list("spiders")
+	var/list/faction = list(FACTION_SPIDER)
 
 /obj/structure/spider/spiderling/Destroy()
 	new/obj/item/food/spiderling(get_turf(src))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -488,7 +488,7 @@
 
 /obj/item/nullrod/carp/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/faction_granter, "carp", holy_role_required = HOLY_ROLE_PRIEST, grant_message = span_boldnotice("You are blessed by Carp-Sie. Wild space carp will no longer attack you."))
+	AddComponent(/datum/component/faction_granter, FACTION_CARP, holy_role_required = HOLY_ROLE_PRIEST, grant_message = span_boldnotice("You are blessed by Carp-Sie. Wild space carp will no longer attack you."))
 
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -148,6 +148,10 @@
 	throwforce = 15
 	custom_materials = null
 
+/obj/item/knife/combat/bone/Initialize(mapload)
+	flags_1 &= ~CONDUCT_1
+	return ..()
+
 /obj/item/knife/combat/cyborg
 	name = "cyborg knife"
 	icon = 'icons/obj/items_cyborg.dmi'
@@ -168,6 +172,10 @@
 	attack_verb_simple = list("shank", "shiv")
 	armor_type = /datum/armor/none
 	custom_materials = list(/datum/material/glass=400)
+
+/obj/item/knife/shiv/Initialize(mapload)
+	flags_1 &= ~CONDUCT_1
+	return ..()
 
 /obj/item/knife/shiv/plasma
 	name = "plasma shiv"

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	desc = "A hole in the ground, filled with monsters ready to defend it."
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "hole"
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/wolf)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "tendril"
 
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -19,7 +19,7 @@
 		L.visible_message(span_warning("[L]'s skin rapidly turns to marble!"), span_userdanger("Your body freezes up! Can't... move... can't... think..."))
 		L.forceMove(src)
 		ADD_TRAIT(L, TRAIT_MUTE, STATUE_MUTE)
-		L.faction += "mimic" //Stops mimics from instaqdeling people in statues
+		L.faction |= FACTION_MIMIC //Stops mimics from instaqdeling people in statues
 		L.status_flags |= GODMODE
 		atom_integrity = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
 		max_integrity = atom_integrity
@@ -62,7 +62,7 @@
 		REMOVE_TRAIT(petrified_mob, TRAIT_MUTE, STATUE_MUTE)
 		REMOVE_TRAIT(petrified_mob, TRAIT_NOBLOOD, MAGIC_TRAIT)
 		petrified_mob.take_overall_damage((petrified_mob.health - atom_integrity + 100)) //any new damage the statue incurred is transfered to the mob
-		petrified_mob.faction -= "mimic"
+		petrified_mob.faction -= FACTION_MIMIC
 		petrified_mob = null
 	return ..()
 

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -12,7 +12,7 @@
 	var/spawn_time = 30 SECONDS
 	var/mob_types = list(/mob/living/basic/carp)
 	var/spawn_text = "emerges from"
-	var/faction = list("hostile")
+	var/faction = list(FACTION_HOSTILE)
 	var/spawner_type = /datum/component/spawner
 
 /obj/structure/spawner/Initialize(mapload)
@@ -43,7 +43,7 @@
 	spawn_time = 15 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/skeleton)
 	spawn_text = "climbs out of"
-	faction = list("skeleton")
+	faction = list(FACTION_SKELETON)
 
 /obj/structure/spawner/clown
 	name = "Laughing Larry"
@@ -55,7 +55,7 @@
 	spawn_time = 15 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/retaliate/clown, /mob/living/simple_animal/hostile/retaliate/clown/fleshclown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk, /mob/living/simple_animal/hostile/retaliate/clown/longface, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus, /mob/living/simple_animal/hostile/retaliate/clown/banana, /mob/living/simple_animal/hostile/retaliate/clown/honkling, /mob/living/simple_animal/hostile/retaliate/clown/lube)
 	spawn_text = "climbs out of"
-	faction = list("clown")
+	faction = list(FACTION_CLOWN)
 
 /obj/structure/spawner/mining
 	name = "monster den"
@@ -66,7 +66,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	spawn_text = "crawls out of"
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goldgrub, /mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/hivelord, /mob/living/simple_animal/hostile/asteroid/basilisk, /mob/living/basic/wumborian_fugu)
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 
 /obj/structure/spawner/mining/goldgrub
 	name = "goldgrub den"
@@ -103,7 +103,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	spawn_text = "crawls through"
 	mob_types = list(/mob/living/basic/migo, /mob/living/basic/creature, /mob/living/basic/blankbody)
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 
 /obj/structure/spawner/nether/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/abductor/equipment/glands/slime.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/slime.dm
@@ -9,11 +9,11 @@
 
 /obj/item/organ/internal/heart/gland/slime/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
 	..()
-	owner.faction |= "slime"
+	owner.faction |= FACTION_SLIME
 	owner.grant_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
 
 /obj/item/organ/internal/heart/gland/slime/Remove(mob/living/carbon/M, special = FALSE)
-	owner.faction -= "slime"
+	owner.faction -= FACTION_SLIME
 	owner.remove_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
 	..()
 

--- a/code/modules/antagonists/abductor/equipment/glands/spider.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/spider.dm
@@ -9,6 +9,6 @@
 
 /obj/item/organ/internal/heart/gland/spiderman/activate()
 	to_chat(owner, span_warning("You feel something crawling in your skin."))
-	owner.faction |= "spiders"
+	owner.faction |= FACTION_SPIDER
 	var/obj/structure/spider/spiderling/S = new(owner.drop_location())
 	S.directive = "Protect your nest inside [owner.real_name]."

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -82,7 +82,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	if(req_stat < user.stat)
 		user.balloon_alert(user, "incapacitated!")
 		return FALSE
-	if((HAS_TRAIT(user, TRAIT_DEATHCOMA)) && (!ignores_fakedeath))
+	if(HAS_TRAIT(user, TRAIT_DEATHCOMA) && !ignores_fakedeath)
 		user.balloon_alert(user, "playing dead!")
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -20,7 +20,7 @@
 		build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 	else
 		to_chat(user, span_notice("We begin our stasis, preparing energy to arise once more."))
-		user.fakedeath("changeling") //play dead
+		user.fakedeath(CHANGELING_TRAIT) //play dead
 		addtimer(CALLBACK(src, PROC_REF(ready_to_regenerate), user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 	return TRUE
 
@@ -28,7 +28,7 @@
 	if(!istype(user))
 		return
 
-	user.cure_fakedeath("changeling")
+	user.cure_fakedeath(CHANGELING_TRAIT)
 	// Heal all damage and some minor afflictions,
 	var/flags_to_heal = (HEAL_DAMAGE|HEAL_BODY|HEAL_STATUS|HEAL_CC_STATUS)
 	// but leave out limbs so we can do it specially
@@ -57,19 +57,30 @@
 		return
 
 	to_chat(user, span_notice("We are ready to revive."))
-	build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 	chemical_cost = 0
 	revive_ready = TRUE
+	build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 
 /datum/action/changeling/fakedeath/can_sting(mob/living/user)
-	if(HAS_TRAIT_FROM(user, TRAIT_DEATHCOMA, "changeling") && !revive_ready)
-		user.balloon_alert(user, "already reviving!")
+	if(revive_ready)
+		return ..()
+
+	if(!can_enter_stasis(user))
 		return
-	if(!user.stat && !revive_ready) //Confirmation for living changelings if they want to fake their death
-		switch(tgui_alert(usr,"Are we sure we wish to fake our own death?", "Feign Death", list("Yes", "No")))
-			if("No")
-				return
+	//Confirmation for living changelings if they want to fake their death
+	if(user.stat != DEAD)
+		if(tgui_alert(user, "Are we sure we wish to fake our own death?", "Feign Death", list("Yes", "No")) != "Yes")
+			return
+		if(QDELETED(user) || QDELETED(src) || !can_enter_stasis(user))
+			return
+
 	return ..()
+
+/datum/action/changeling/fakedeath/proc/can_enter_stasis(mob/living/user)
+	if(HAS_TRAIT_FROM(user, TRAIT_DEATHCOMA, CHANGELING_TRAIT))
+		user.balloon_alert(user, "already reviving!")
+		return FALSE
+	return TRUE
 
 /datum/action/changeling/fakedeath/update_button_name(atom/movable/screen/movable/action_button/button, force)
 	if(revive_ready)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -135,7 +135,7 @@
 	if(mob_override)
 		current = mob_override
 	handle_clown_mutation(current, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
-	current.faction |= "cult"
+	current.faction |= FACTION_CULT
 	current.grant_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
 	if(!cult_team.cult_master)
 		vote.Grant(current)
@@ -156,7 +156,7 @@
 	if(mob_override)
 		current = mob_override
 	handle_clown_mutation(current, removing = FALSE)
-	current.faction -= "cult"
+	current.faction -= FACTION_CULT
 	current.remove_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
 	vote.Remove(current)
 	communion.Remove(current)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -987,7 +987,7 @@ Striking a noncultist, however, will tear their flesh."}
 				addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/shield/mirror, readd)), 450)
 				if(prob(60))
 					var/mob/living/simple_animal/hostile/illusion/M = new(owner.loc)
-					M.faction = list("cult")
+					M.faction = list(FACTION_CULT)
 					M.Copy_Parent(owner, 70, 10, 5)
 					M.move_to_delay = owner.cached_multiplicative_slowdown
 				else
@@ -1000,7 +1000,7 @@ Striking a noncultist, however, will tear their flesh."}
 		if(prob(50))
 			var/mob/living/simple_animal/hostile/illusion/H = new(owner.loc)
 			H.Copy_Parent(owner, 100, 20, 5)
-			H.faction = list("cult")
+			H.faction = list(FACTION_CULT)
 			H.GiveTarget(owner)
 			H.move_to_delay = owner.cached_multiplicative_slowdown
 			to_chat(owner, span_danger("<b>[src] betrays you!</b>"))

--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -93,7 +93,7 @@
 	if(respawn_progress < HEART_RESPAWN_THRESHHOLD)
 		return
 
-	owner.revive(HEAL_ALL)
+	owner.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	if(!(owner.dna.species.id == SPECIES_SHADOW || owner.dna.species.id == SPECIES_NIGHTMARE))
 		var/mob/living/carbon/old_owner = owner
 		Remove(owner, HEART_SPECIAL_SHADOWIFY)

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -143,7 +143,7 @@
 		objective.completed = TRUE
 
 //SECURITY CONSOLE//
-/obj/machinery/computer/secure_data/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+/obj/machinery/computer/records/security/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
 	if(!can_hack(ninja, feedback = TRUE))
@@ -153,7 +153,7 @@
 	INVOKE_ASYNC(src, PROC_REF(ninjadrain_charge), ninja, hacking_module)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
-/obj/machinery/computer/secure_data/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+/obj/machinery/computer/records/security/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!do_after(ninja, 20 SECONDS, src, extra_checks = CALLBACK(src, PROC_REF(can_hack), ninja)))
 		return
 	for(var/datum/record/crew/target in GLOB.manifest.general)
@@ -165,7 +165,7 @@
 	if(objective)
 		objective.completed = TRUE
 
-/obj/machinery/computer/secure_data/proc/can_hack(mob/living/hacker, feedback = FALSE)
+/obj/machinery/computer/records/security/proc/can_hack(mob/living/hacker, feedback = FALSE)
 	if(machine_stat & (NOPOWER|BROKEN))
 		if(feedback && hacker)
 			balloon_alert(hacker, "can't hack!")

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -11,7 +11,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 
 /datum/outfit/pirate/post_equip(mob/living/carbon/human/equipped)
-	equipped.faction |= "pirate"
+	equipped.faction |= FACTION_PIRATE
 
 	var/obj/item/radio/outfit_radio = equipped.ears
 	if(outfit_radio)

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -371,7 +371,7 @@
 	var/mob/living/carbon/human/H = AM
 	if(H.stat != CONSCIOUS || !H.mind) //mint condition only
 		return 0
-	else if("pirate" in H.faction) //can't ransom your fellow pirates to CentCom!
+	else if(FACTION_PIRATE in H.faction) //can't ransom your fellow pirates to CentCom!
 		return 0
 	else if(H.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 		return 3000

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -45,14 +45,14 @@
 	. = ..()
 	rift_ability = new
 	rift_ability.Grant(owner.current)
-	owner.current.faction |= "carp"
+	owner.current.faction |= FACTION_CARP
 	RegisterSignal(owner.current, COMSIG_LIVING_LIFE, PROC_REF(rift_checks))
 	RegisterSignal(owner.current, COMSIG_LIVING_DEATH, PROC_REF(destroy_rifts))
 
 /datum/antagonist/space_dragon/on_removal()
 	. = ..()
 	rift_ability.Remove(owner.current)
-	owner.current.faction -= "carp"
+	owner.current.faction -= FACTION_CARP
 	UnregisterSignal(owner.current, COMSIG_LIVING_LIFE)
 	UnregisterSignal(owner.current, COMSIG_LIVING_DEATH)
 	rift_list = null

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -1,3 +1,8 @@
+///all the employers that are syndicate
+#define FLAVOR_FACTION_SYNDICATE "syndicate"
+///all the employers that are nanotrasen
+#define FLAVOR_FACTION_NANOTRASEN "nanotrasen"
+
 /datum/antagonist/traitor
 	name = "\improper Traitor"
 	roundend_category = "traitors"
@@ -135,15 +140,15 @@
 	return ..()
 
 /datum/antagonist/traitor/proc/pick_employer()
-	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
+	var/faction = prob(75) ? FLAVOR_FACTION_SYNDICATE : FLAVOR_FACTION_NANOTRASEN
 	var/list/possible_employers = list()
 
 	possible_employers.Add(GLOB.syndicate_employers, GLOB.nanotrasen_employers)
 
 	switch(faction)
-		if(FACTION_SYNDICATE)
+		if(FLAVOR_FACTION_SYNDICATE)
 			possible_employers -= GLOB.nanotrasen_employers
-		if(FACTION_NANOTRASEN)
+		if(FLAVOR_FACTION_NANOTRASEN)
 			possible_employers -= GLOB.syndicate_employers
 	employer = pick(possible_employers)
 	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
@@ -335,3 +340,5 @@
 
 		H.update_held_items()
 
+#undef FLAVOR_FACTION_SYNDICATE
+#undef FLAVOR_FACTION_NANOTRASEN

--- a/code/modules/cargo/gondolapod.dm
+++ b/code/modules/cargo/gondolapod.dm
@@ -8,7 +8,7 @@
 	response_disarm_simple = "bop"
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
-	faction = list("gondola")
+	faction = list(FACTION_GONDOLA)
 	turns_per_move = 10
 	icon = 'icons/obj/supplypods.dmi'
 	icon_state = "gondola"

--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -128,7 +128,7 @@
 /obj/item/surprise_egg/attack_self(mob/user)
 	..()
 	to_chat(user, span_notice("You unwrap [src] and find a prize inside!"))
-	dispensePrize(get_turf(user))
+	dispensePrize(get_turf(src))
 	qdel(src)
 
 //Easter Recipes + food

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -779,7 +779,7 @@
 /proc/isvineimmune(atom/target)
 	if(isliving(target))
 		var/mob/living/victim = target
-		if(("vines" in victim.faction) || ("plants" in victim.faction))
+		if((FACTION_VINES in victim.faction) || (FACTION_PLANTS in victim.faction))
 			return TRUE
 	return FALSE
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1125,7 +1125,7 @@
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)
 	var/mob/living/simple_animal/hostile/C = new chosen(get_turf(src))
-	C.faction = list("plants")
+	C.faction = list(FACTION_PLANTS)
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -14,7 +14,7 @@
 	max_integrity = 200
 
 
-	var/faction = list("ashwalker")
+	var/faction = list(FACTION_ASHWALKER)
 	var/meat_counter = 6
 	var/datum/team/ashwalkers/ashies
 	var/datum/linked_objective

--- a/code/modules/mapfluff/ruins/spaceruin_code/dangerous_research.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/dangerous_research.dm
@@ -1,0 +1,87 @@
+/// Paper Fluff Lore
+/obj/item/paper/fluff/ruins/dangerous_research/manifest
+	name = "ASRC Manifest"
+	default_raw_text = "<B>Alternate Sciences Research Center</B><BR><BR>Doctor Elias Valentin - Head Occultist<BR>Researcher Mike R. Smith - Chemist<BR>Researcher Jexa Armstrong - Esotericist<BR>Doctor Dreams-of-Beaches - Medical Assistant<BR>Doctor Whitner Jay Greyham - Surgeon<BR>Officer Brianna Simes - Outpost Protection Agent<BR>John Doe - Research Volunteer"
+
+/obj/item/paper/fluff/ruins/dangerous_research/head_occultist_note
+	name = "Frantically Scrawled Note"
+	default_raw_text = "John's been speaking to me recently, so I had Greyham take his tongue.<BR> He was looking at me, so the Doctor took his eyes.<BR>He won't stop talking and staring. He just wants a few things, he says.<BR>All the research, so close to fruition, would it be wrong to let him finish the rune?"
+
+/obj/item/paper/fluff/ruins/dangerous_research/smith
+	name = "A Traitor's Memo"
+	default_raw_text = "The Syndicate is up to something strange here; they've hired these people, most totally unaware of their true employers.<BR>I've sent the collected data to Nanotrasen, and I'm going to try to disrupt the test tomorrow, allowing this to continue isn't right.<BR>They're keeping the patient semi-lucid, so some stims should wake him up."
+	///Dream-Of-Beaches Journal
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_1
+	name = "Journal of Dreams-Of-Beaches - Day 1"
+	default_raw_text = "Well, the food is greasy, there's one bathroom for six of us to share, and I think the Head Occultist is a little crazy, but I'm finally off Tizira!<BR> Not much of a believer in this occult nonsense, but the pay is good and aside from the boss, everyone is really friendly!<BR> Doctor Grey(Gray?)Ham will be my partner for keeping the patient safe."
+
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_2
+	name = "Journal of Dreams-Of-Beaches - Day 33"
+	default_raw_text = "Something odd is going on. John has been blinded and muted for a time now but he's still moving around in that central chamber, drawing something. Elias, Smith, and Whitner seem to have some idea about what's going on and won't answer my questions.<BR>I'm going to sneak into the lab tonight to get a look at those drawings."
+	
+/obj/item/paper/fluff/ruins/dangerous_research/beaches_journal_3
+	name = "Journal of Dreams-Of-Beaches - Day 52"
+	default_raw_text = "Smith was in the chamber, gone in an instant.<BR> I don't know what happened to the doctor or Elias, I just heard flesh tearing and glass shattering.<BR> When my eyes opened, the room was painted in red and rust.<BR>Simes was there, but she just flashed away, all that was left was the gun.<BR>Armstrong grabbed me and we somehow made it out, boarded it up with the tables in the lobby.<BR>Took two of the suits, we'll send out a distress signal when we're out there."
+	/// Armstrong Memos
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_1
+	name = "Jexa Armstrong's Notes - Day 18"
+	default_raw_text = "I wasn't excited to hear that Interdyne would be sticking me on this rock, but this John Doe absolutely has me interested.<BR>He's the only other person I've met with a link to the Mansus, and theirs is <B>astoundingly</B> strong.<BR>Here I thought I was a freak of nature for being able to draw a few working runes. The subject is capable of achieving a perfect link to the Mansus, even <B>with</B> Elias ordering all of those surgeries."
+
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_2
+	name = "Jexa Armstrong's Notes - Day 47"
+	default_raw_text = "Elias is going to get us all killed, I swear. The surgeries have been intensifying, he's pushing the subject WAY past what's safe.<BR>Greyham's a loyal mutt, Smith doesn't give a shit, and Beaches is a coward. Nobody else was going to tell the HO that fucking with the pineal gland was dangerous.<BR>Apparently, tests are now going faster but I'm also locked in my room for the next few days. He doesn't know what he's messing with."
+
+/obj/item/paper/fluff/ruins/dangerous_research/armstrong_memo_3
+	name = "Containment Memo - Safety"
+	default_raw_text = "<B>DO NOT:</B><BR>-Allow the subject out of their cell at any point without the HO's approval<BR>-Stay by the subject for extended periods of time. Dr Greyham and I have confirmed that long-term exposure can lead to headaches, anemia, and loss of sleep.<BR>-Forget to keep the patient's sedative supply constant. Ensure their IV drip (3:3:1 ratio of B Negative Blood, Saline, and Morphine) is topped up whenever they're not in a test.<BR><BR>Elias, the radio in the patient's room stays ON, and the toy stays in there. I know its not protocol but he starts crying if we remove them, and we all need to sleep."
+/// Lore Terminals
+/obj/machinery/computer/terminal/dangerous_research/front_desk
+	upperinfo = "ISSUE REPORT - Officer Simes"
+	content = list("<B>Day 003 - Code 201</B> -> Three days into the 100 day mission, Doctor Greyham and Researcher Smith got into a minor dispute over the owner of a biopsy tool. Both were seperated and reprimanded by the Head Occultist.<BR>\
+	<B>Day 014 - Code 104</B> -> Another issue with Researcher Smith, who was found to be using the chem dispensers to produce low-grade stimulants. Head Occultist Valentin seemed incredibly upset at the relatively harmless drugs, and has banned all production of stimulants.<BR>\
+	<B>Day 022 - Code ???</B> -> The HO and Armstrong are bickering, unsure about what, but since what Armstrong's suggesting will stop that horrific noise, I'm siding with them. The HO gave me a nasty look when I spoke up about the lack of sleep.<BR>\
+	<B>Day 034 - Code 109</B> -> Doctor Beaches apparently entered a restricted area during the off hours to check on a research sample without the Head Occultist's permission. A curfew has been installed.<BR>\
+	<B>Day 047 - Code 311</B> -> Researcher Armstrong w... okay, the HO stopped watching, Elias is fucking losing it. I'm not allowed in the research labs unless there's an incident, but you can HEAR screaming from the lobby. Everyone is on edge. Jexa has been bolted into their room for protesting something, not sure.<BR>\
+	<B>Day 051 - Code ???</B> -> The Head Occultist has been acting strange again, he's up at night in the lab, not eating, not sleeping. He's been giving the team these speeches about how close we are, I'm not paid enough to know what we're close to though.<BR>\
+	<B>Day 052 - Ongoing Incident</B> -> Explosion from the research lab, going to check on it now. I think I hear Dreams-of-Beaches screaming.")
+
+/obj/machinery/computer/terminal/dangerous_research/lab_recording
+	upperinfo = "SECURITY CAMERA LOG - 052"
+	content = list("There is a log of archived footage from the test period, you pull up the last logged entries.<BR>\
+	<B>03:32 AM</B> - An older human wearing a red-white labcoat paces back and forth in the lab, staring at a half drawn rune in the containment zone. He soon leaves, muttering to himself.<BR>\
+	<B>03:38 AM</B> - The camera pans to see the rune spark to life, sickly green light ignites the lab for a moment, and then shuts down.<BR>\
+	<B>08:29 AM</B> - The doors to the lab opens, the red-labcoat from earlier, and another doctorly looking man enter, they're deep in conversation. A third, younger human in an orange labcoat enters, and the discussion stops. The researchers mill about, soon joined by another human, and a lizardperson.<BR>\
+	<B>9:03 AM</B> - An emaciated and masked man is brought into the center of the lab onto the rune. His restraints are removed, and he goes to the rune, drawing at it with a glowing finger.<BR>\
+	<B>9:04 AM</B> - The man in orange enters the cell, to the visible shock of the research team. He injects the emaciated man with a syringe.<BR>\
+	<B>9:05 AM</B> - All hell breaks loose, the man in orange is dead on the spot, torn into shreds by whips of eldritch flame. Rust creeps across the lab, and skittering creatures drag the red-labcoat off camera.<BR>\
+	<B>9:06 AM</B> - A security guard enters and draws their weapon, but the ground under their feet erupts into flames. From off-camera, a beast of arms tears at the doctorly man.<BR>\
+	<B>9:07 AM</B> - The remaining scientist grabs the cowering lizardperson, and the two leave the lab. The emaciated man seems to be in pain as camera-distoring energy racks their body. An explosion is heard, and the camera goes dark.<BR>\
+	<B>END OF AVAILABLE FOOTAGE</B>")
+
+/obj/machinery/computer/terminal/dangerous_research/greyham_report
+	upperinfo = "MEDICAL LOG - Doctor Whitner Jay Greyham"
+	content = list("<B>001 - Light</B> Treated minor paper-cut on Researcher Armstrong.<BR>\
+	<B>003 - Light</B> Treated minor bruising on Doctor Greyham and Researcher Smith with ice packs.<BR>\
+	<B>004 - Medium</B> Testing begins, insertion of permanent IV into subject.<BR>\
+	<B>006 - Heavy</B> Removal of subject's vision. Surgically severed subject's optical nerves.<BR>\
+	<B>007 - Light</B> Head Occultist Valentin treated for symptoms of mild headaches with paracetamol.<BR>\
+	<B>010 - Heavy</B> Removal of subject's vision. Surgically removed subject's eyes, optical nerves cauterized.<BR>\
+	<B>011 - Medium</B> Treated all staff for iron deficiency. Head Occultist Valentin given additional dosage of paracetamol.<BR>\
+	<B>015 - Heavy</B> Prefrontal leukotomy performed on subject. Subject awoke and stared at medical staff during operation.<BR>\
+	<B>015 - Heavy</B> Removal of subject's vision. Surgically removed subject's eyes, optical nerves cauterized.<BR>\
+	<B>016 - Medium</B> Treated all staff for sleep loss (Diphenhydramine, 10u)<BR>\
+	<B>DATA CORRUPTED</B><BR>\
+	<B>047 - Heavy</B> Insertion of nerve stimulator into patient's pineal gland.<BR>\
+	<B>049 - Heavy</B>Removal of subject's vision. Surgically removed subject's eyes, optical nerves cauterized.<BR>\
+	<B>050 - Heavy</B>Removal of subject's ability to speak. Surgically removed subject's tongue, wound cauterized.<BR>")
+
+// Lore ID cards
+/obj/item/card/id/away/dangerous_research
+	name = "Mike R. Smith"
+	desc = "An older ID card, it has a label reading \"Researcher\"."
+	trim = /datum/id_trim/away/dangerous_research
+
+/obj/item/card/id/away/dangerous_research/head_occultist
+	name = "Elias Valentin"
+	desc = "An older ID card, it has a label reading \"Head Occultist\". It's smeared with dried blood."
+	trim = /datum/id_trim/away/dangerous_research/head_occultist

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -655,4 +655,4 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	desc = "A ballistic machine gun auto-turret that fires bluespace bullets."
 	lethal_projectile = /obj/projectile/magic/teleport
 	stun_projectile = /obj/projectile/magic/teleport
-	faction = list("turret")
+	faction = list(FACTION_TURRET)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -846,7 +846,7 @@
 	/// Whether the saw is open or not
 	var/is_open = FALSE
 	/// List of factions we deal bonus damage to
-	var/list/nemesis_factions = list("mining", "boss")
+	var/list/nemesis_factions = list(FACTION_MINING, FACTION_BOSS)
 	/// Amount of damage we deal to the above factions
 	var/faction_bonus_force = 30
 	/// Whether the cleaver is actively AoE swiping something.

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
@@ -7,7 +7,7 @@
 	icon_living = "moonicorn"
 	icon_dead = "moonicorn_dead"
 	icon_gib = null //otherwise does the regular cow gib animation
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	speed = 1
 	melee_damage_lower = 25
 	melee_damage_upper = 25

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -2,7 +2,7 @@
 /mob/living/basic/mining
 
 	combat_mode = TRUE
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = INFINITY

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -624,7 +624,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	icon_state = "narsian"
 	icon_living = "narsian"
 	icon_dead = "narsian_dead"
-	faction = list(FACTION_NEUTRAL, "cult")
+	faction = list(FACTION_NEUTRAL, FACTION_CULT)
 	gold_core_spawnable = NO_SPAWN
 	nofur = TRUE
 	unique_pet = TRUE

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -15,7 +15,7 @@
 	melee_damage_upper = 10
 	attack_sound = 'sound/weapons/punch1.ogg'
 	combat_mode = TRUE
-	faction = list("stickman")
+	faction = list(FACTION_STICKMAN)
 	unsuitable_atmos_damage = 7.5
 	unsuitable_cold_damage = 7.5
 	unsuitable_heat_damage = 7.5

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -36,7 +36,7 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	faction = list("carp")
+	faction = list(FACTION_CARP)
 	butcher_results = list(/obj/item/food/fishmeat/carp = 2, /obj/item/stack/sheet/animalhide/carp = 1)
 	greyscale_config = /datum/greyscale_config/carp
 	ai_controller = /datum/ai_controller/basic_controller/carp
@@ -179,7 +179,7 @@
 	name = "Lia"
 	real_name = "Lia"
 	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as the Head of Security's pet."
-	faction = list("neutral")
+	faction = list(FACTION_NEUTRAL)
 	maxHealth = 200
 	health = 200
 	icon_dead = "magicarp_dead"

--- a/code/modules/mob/living/basic/space_fauna/faithless.dm
+++ b/code/modules/mob/living/basic/space_fauna/faithless.dm
@@ -24,7 +24,7 @@
 	unsuitable_cold_damage = 0
 	unsuitable_heat_damage = 0
 
-	faction = list("faithless")
+	faction = list(FACTION_FAITHLESS)
 	gold_core_spawnable = HOSTILE_SPAWN
 
 	ai_controller = /datum/ai_controller/basic_controller/faithless

--- a/code/modules/mob/living/basic/space_fauna/garden_gnome.dm
+++ b/code/modules/mob/living/basic/space_fauna/garden_gnome.dm
@@ -24,7 +24,7 @@
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = 500
 
-	faction = list("gnomes")
+	faction = list(FACTION_GNOME)
 	mob_size = MOB_SIZE_SMALL
 	gold_core_spawnable = HOSTILE_SPAWN
 	greyscale_config = /datum/greyscale_config/garden_gnome

--- a/code/modules/mob/living/basic/space_fauna/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/giant_spider/giant_spider.dm
@@ -31,7 +31,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	combat_mode = TRUE
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	pass_flags = PASSTABLE
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"

--- a/code/modules/mob/living/basic/space_fauna/giant_spider/spider_variants.dm
+++ b/code/modules/mob/living/basic/space_fauna/giant_spider/spider_variants.dm
@@ -314,7 +314,7 @@
 	name = "Sergeant Araneus"
 	real_name = "Sergeant Araneus"
 	desc = "A fierce companion of the Head of Security, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine."
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	maxHealth = 250
 	health = 250
 	melee_damage_lower = 15

--- a/code/modules/mob/living/basic/space_fauna/netherworld/blankbody.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/blankbody.dm
@@ -14,7 +14,7 @@
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams")
 	death_message = "falls apart into a fine dust."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -15,7 +15,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams")
 	death_message = "gets his head split open."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -15,7 +15,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams", "clicks", "chitters", "barks", "moans", "growls", "meows", "reverberates", "roars", "squeaks", "rattles", "exclaims", "yells", "remarks", "mumbles", "jabbers", "stutters", "seethes")
 	death_message = "wails as its form turns into a pulpy mush."
 	death_sound = 'sound/voice/hiss6.ogg'

--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -28,7 +28,7 @@
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 
-	faction = list("statue")
+	faction = list(FACTION_STATUE)
 	speak_emote = list("screams")
 	death_message = "falls apart into a fine dust."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_fugu.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_fugu.dm
@@ -34,7 +34,7 @@
 	friendly_verb_continuous = "floats near"
 	friendly_verb_simple = "float near"
 	speak_emote = list("puffs")
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	see_in_dark = 8
 	// Nice and dark purple, to match le vibes
 	lighting_cutoff_red = 20

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -23,7 +23,7 @@
 	speak_emote = list("chitters")
 
 	basic_mob_flags = DEL_ON_DEATH
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 270
@@ -82,7 +82,7 @@
 	melee_damage_upper = 10
 	obj_damage = 10
 	gold_core_spawnable = HOSTILE_SPAWN
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/glockroach
 	cockroach_cell_line = CELL_LINE_TABLE_GLOCKROACH
 
@@ -117,7 +117,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	sharpness = SHARP_POINTY
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/hauberoach
 	cockroach_cell_line = CELL_LINE_TABLE_HAUBEROACH

--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -24,7 +24,7 @@
 	response_harm_continuous = "splats"
 	response_harm_simple = "splat"
 	density = FALSE
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	attack_sound = 'sound/effects/reee.ogg'
 	butcher_results = list(/obj/item/food/nugget = 1)
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -895,8 +895,8 @@
 	if(heal_flags & HEAL_LIMBS)
 		regenerate_limbs()
 
-	if(heal_flags & HEAL_ORGANS)
-		regenerate_organs()
+	if(heal_flags & (HEAL_REFRESH_ORGANS|HEAL_ORGANS))
+		regenerate_organs(regenerate_existing = (heal_flags & HEAL_REFRESH_ORGANS))
 
 	if(heal_flags & HEAL_TRAUMAS)
 		cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)

--- a/code/modules/mob/living/carbon/human/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey/monkey.dm
@@ -2,7 +2,7 @@
 	icon_state = "monkey" //for mapping
 	race = /datum/species/monkey
 	ai_controller = /datum/ai_controller/monkey
-	faction = list(FACTION_NEUTRAL, "monkey")
+	faction = list(FACTION_NEUTRAL, FACTION_MONKEY)
 
 /mob/living/carbon/human/species/monkey/Initialize(mapload, cubespawned=FALSE, mob/spawner)
 	if (cubespawned)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -355,7 +355,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		/*
 		 * There is an existing organ in this slot, what should we do with it? Probably remove it!
 		 *
-		 * We will removit if and only if:
+		 * We will remove it if (and only if):
 		 * - We should not have the organ OR replace_current is passed to force old organs to regenerate
 		 * - The replaced organ is not in an excluded zone
 		 * - The replaced organ is not unremovable or synthetic (an implant)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -337,7 +337,7 @@
 	special_names = list("Bark", "Willow", "Catalpa", "Woody", "Oak", "Sap", "Twig", "Branch", "Maple", "Birch", "Elm", "Basswood", "Cottonwood", "Larch", "Aspen", "Ash", "Beech", "Buckeye", "Cedar", "Chestnut", "Cypress", "Fir", "Hawthorn", "Hazel", "Hickory", "Ironwood", "Juniper", "Leaf", "Mangrove", "Palm", "Pawpaw", "Pine", "Poplar", "Redwood", "Redbud", "Sassafras", "Spruce", "Sumac", "Trunk", "Walnut", "Yew")
 	human_surname_chance = 0
 	special_name_chance = 100
-	inherent_factions = list("plants", "vines")
+	inherent_factions = list(FACTION_PLANTS, FACTION_VINES)
 	examine_limb_id = SPECIES_GOLEM
 
 /datum/species/golem/wood/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
@@ -691,7 +691,7 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	prefix = "Runic"
 	special_names = null
-	inherent_factions = list("cult")
+	inherent_factions = list(FACTION_CULT)
 	species_language_holder = /datum/language_holder/golem/runic
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/golem/cult,

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -25,7 +25,7 @@
 	burnmod = 0.5 // = 1/2x generic burn damage
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_factions = list("slime")
+	inherent_factions = list(FACTION_SLIME)
 	species_language_holder = /datum/language_holder/jelly
 	ass_image = 'icons/ass/assslime.png'
 

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -17,7 +17,7 @@
 		TRAIT_NOBREATH,
 		TRAIT_NOFLASH,
 	)
-	inherent_factions = list("mushroom")
+	inherent_factions = list(FACTION_MUSHROOM)
 	speedmod = 1.5 //faster than golems but not by much
 
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -15,7 +15,7 @@
 		/obj/item/organ/external/pod_hair = "None",
 	)
 	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID | MOB_PLANT
-	inherent_factions = list("plants", "vines")
+	inherent_factions = list(FACTION_PLANTS, FACTION_VINES)
 
 	burnmod = 1.25
 	heatmod = 1.5

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -14,7 +14,7 @@
 		TRAIT_VIRUSIMMUNE,
 		TRAIT_NOBLOOD,
 	)
-	inherent_factions = list("faithless")
+	inherent_factions = list(FACTION_FAITHLESS)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 
 	mutantbrain = /obj/item/organ/internal/brain/shadow

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -12,6 +12,7 @@
 		reagents.handle_stasis_chems(src, delta_time, times_fired)
 	else
 		//Reagent processing needs to come before breathing, to prevent edge cases.
+		handle_dead_metabolization(delta_time, times_fired) //Dead metabolization first since it can modify life metabolization.
 		handle_organs(delta_time, times_fired)
 
 		. = ..()
@@ -523,6 +524,19 @@
 	for(var/datum/mutation/human/HM in dna.mutations)
 		if(HM?.timeout)
 			dna.remove_mutation(HM.type)
+
+/**
+ * Handles calling metabolization for dead people.
+ * Due to how reagent metabolization code works this couldn't be done anywhere else.
+ * 
+ * Arguments:
+ * - delta_time: The amount of time that has elapsed since the last tick.
+ * - times_fired: The number of times SSmobs has ticked.
+ */
+/mob/living/carbon/proc/handle_dead_metabolization(delta_time, times_fired)
+	if (stat != DEAD)
+		return
+	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE) // Your liver doesn't work while you're dead.
 
 /// Base carbon environment handler, adds natural stabilization
 /mob/living/carbon/handle_environment(datum/gas_mixture/environment, delta_time, times_fired)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -787,12 +787,12 @@
 /obj/item/robot_model/syndicate/rebuild_modules()
 	..()
 	var/mob/living/silicon/robot/cyborg = loc
-	cyborg.faction -= "silicon" //ai turrets
+	cyborg.faction -= FACTION_SILICON //ai turrets
 
 /obj/item/robot_model/syndicate/remove_module(obj/item/removed_module, delete_after)
 	..()
 	var/mob/living/silicon/robot/cyborg = loc
-	cyborg.faction |= "silicon" //ai is your bff now!
+	cyborg.faction |= FACTION_SILICON //ai is your bff now!
 
 /obj/item/robot_model/syndicate_medical
 	name = "Syndicate Medical"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -54,7 +54,7 @@
 /mob/living/silicon/Initialize(mapload)
 	. = ..()
 	GLOB.silicon_mobs += src
-	faction += "silicon"
+	faction += FACTION_SILICON
 	if(ispath(radio))
 		radio = new radio(src)
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -23,7 +23,7 @@
 	initial_language_holder = /datum/language_holder/synthetic
 	bubble_icon = "machine"
 	speech_span = SPAN_ROBOT
-	faction = list(FACTION_NEUTRAL, "silicon", "turret")
+	faction = list(FACTION_NEUTRAL, FACTION_SILICON, FACTION_TURRET)
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 0.9
@@ -1032,7 +1032,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		ejectpai(0)
 
 /mob/living/simple_animal/bot/sentience_act()
-	faction -= "silicon"
+	faction -= FACTION_SILICON
 
 /mob/living/simple_animal/bot/proc/set_path(list/newpath)
 	path = newpath ? newpath : list()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -94,7 +94,7 @@
 	name = "Officer Genesky"
 	desc = "A beefy variant of the standard securitron model."
 	health = 50
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	bot_mode_flags = BOT_MODE_ON
 	bot_cover_flags = BOT_COVER_LOCKED | BOT_COVER_EMAGGED
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -43,7 +43,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 	dextrous = TRUE
 	dextrous_hud_type = /datum/hud/dextrous/drone
 	// Going for a sort of pale green here

--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -15,7 +15,7 @@
 	response_disarm_simple = "bop"
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
-	faction = list("gondola")
+	faction = list(FACTION_GONDOLA)
 	turns_per_move = 10
 	icon = 'icons/mob/simple/gondolas.dmi'
 	icon_state = "gondola"

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -7,7 +7,7 @@
 	speak_emote = list("hisses")
 	health = 5
 	maxHealth = 5
-	faction = list("Lizard")
+	faction = list(FACTION_LIZARD)
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -12,7 +12,7 @@
 	speak_emote = list("squawks", "gakkers")
 	emote_hear = list("squawk!", "gakkers!", "noots.","NOOTS!")
 	emote_see = list("shakes his beak.", "flaps his wings.","preens himself.")
-	faction = list("penguin")
+	faction = list(FACTION_PENGUIN)
 	minbodytemp = 0
 	speak_chance = 1
 	turns_per_move = 10

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -20,7 +20,7 @@
 	response_disarm_simple = "shoo"
 	response_harm_continuous = "steps on"
 	response_harm_simple = "step on"
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	density = FALSE
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_SMALL

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -41,7 +41,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
@@ -89,7 +89,7 @@
 	icon_state = "combatbear"
 	icon_living = "combatbear"
 	icon_dead = "combatbear_dead"
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	butcher_results = list(/obj/item/food/meat/slab/bear = 5, /obj/item/clothing/head/costume/bearpelt = 1, /obj/item/bear_armor = 1)
 	melee_damage_lower = 18
 	melee_damage_upper = 20
@@ -131,7 +131,7 @@
 	icon_living = "butterbear"
 	icon_dead = "butterbear_dead"
 	desc = "I can't believe its not a bear!"
-	faction = list(FACTION_NEUTRAL, "russian")
+	faction = list(FACTION_NEUTRAL, FACTION_RUSSIAN)
 	obj_damage = 11
 	melee_damage_lower = 0
 	melee_damage_upper = 0

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -34,7 +34,7 @@
 	response_harm_simple = "squash"
 	maxHealth = 10
 	health = 10
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	move_to_delay = 0
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -4,7 +4,7 @@
 	desc = "A wizard with a taste for the arts."
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	boss_abilities = list(/datum/action/boss/wizard_summon_minions, /datum/action/boss/wizard_mimic)
-	faction = list("hostile","stickman")
+	faction = list(FACTION_HOSTILE,FACTION_STICKMAN)
 	del_on_death = TRUE
 	icon = 'icons/mob/simple/simple_human.dmi'
 	icon_state = "paperwizard"

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -25,7 +25,7 @@
 	loot = list(/obj/effect/mob_spawn/corpse/human/cat_butcher, /obj/item/circular_saw)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/constructs/constructs.dm
@@ -27,7 +27,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	healable = 0
-	faction = list("cult")
+	faction = list(FACTION_CULT)
 	pressure_resistance = 100
 	unique_name = 1
 	AIStatus = AI_OFF //normal constructs don't have AI

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -29,7 +29,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 	gold_core_spawnable = HOSTILE_SPAWN
-	faction = list("spooky")
+	faction = list(FACTION_SPOOKY)
 	del_on_death = 1
 	// Redish ethereal glow. These lads live on the cult ship
 	lighting_cutoff_red = 40

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -32,7 +32,7 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	dextrous = TRUE
 	held_items = list(null, null)
-	faction = list("monkey", "jungle")
+	faction = list(FACTION_MONKEY, FACTION_JUNGLE)
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	minbodytemp = 270
@@ -122,7 +122,7 @@
 	desc = "Cargo's pet gorilla. They seem to have an 'I love Mom' tattoo."
 	maxHealth = 200
 	health = 200
-	faction = list(FACTION_NEUTRAL, "monkey", "jungle")
+	faction = list(FACTION_NEUTRAL, FACTION_MONKEY, FACTION_JUNGLE)
 	gold_core_spawnable = NO_SPAWN
 	unique_name = FALSE
 	/// Whether we're currently being polled over

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -15,7 +15,7 @@
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("creature")
+	faction = list(FACTION_CREATURE)
 	robust_searching = 1
 	stat_attack = DEAD
 	obj_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -22,7 +22,7 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	projectilesound = 'sound/weapons/gun/pistol/shot.ogg'
 	projectiletype = /obj/projectile/hivebotbullet
-	faction = list("hivebot")
+	faction = list(FACTION_HIVEBOT)
 	check_friendly_fire = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	stop_automated_movement_when_pulled = 0
 	obj_damage = 40
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES // Set to ENVIRONMENT_SMASH_STRUCTURES to break closets,tables,racks, etc; ENVIRONMENT_SMASH_WALLS for walls; ENVIRONMENT_SMASH_RWALLS for rwalls

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -15,7 +15,7 @@
 	maxHealth = 100
 	health = 100
 	speed = 0
-	faction = list("illusion")
+	faction = list(FACTION_ILLUSION)
 	var/life_span = INFINITY //how long until they despawn
 	var/mob/living/parent_mob
 	var/multiply_chance = 0 //if we multiply on hit

--- a/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/jungle
 	vision_range = 5
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	faction = list("jungle")
+	faction = list(FACTION_JUNGLE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_WALLS
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -50,7 +50,7 @@
 /obj/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
 	if(isliving(A))
 		var/mob/living/L = A
-		if("jungle" in L.faction)
+		if(FACTION_JUNGLE in L.faction)
 			return FALSE
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -22,7 +22,7 @@
 	attack_verb_continuous = "slams"
 	attack_verb_simple = "slam"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	faction = list("plants")
+	faction = list(FACTION_PLANTS)
 
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 150

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -9,7 +9,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_EPIC
 	obj_damage = 400
 	light_range = 3
-	faction = list("mining", "boss")
+	faction = list(FACTION_MINING, FACTION_BOSS)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE,TRAIT_ASHSTORM_IMMUNE)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -68,7 +68,7 @@ Difficulty: Hard
 	death_message = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	death_sound = 'sound/magic/enter_blood.ogg'
 	small_sprite_type = /datum/action/small_sprite/megafauna/bubblegum
-	faction = list("mining", "boss", "hell")
+	faction = list(FACTION_MINING, FACTION_BOSS, FACTION_HELL)
 	/// Check to see if we should spawn blood
 	var/spawn_blood = TRUE
 	/// Actual time where enrage ends

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -48,7 +48,7 @@ Difficulty: Hard
 	friendly_verb_continuous = "stares down"
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/simple/lavaland/hierophant_new.dmi'
-	faction = list("boss") //asteroid mobs? get that shit out of my beautiful square house
+	faction = list(FACTION_BOSS) //asteroid mobs? get that shit out of my beautiful square house
 	speak_emote = list("preaches")
 	armour_penetration = 50
 	melee_damage_lower = 15

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -278,7 +278,7 @@
 	///How long it takes between shooting the tracer and the projectile.
 	var/shot_delay = 8
 	///Compared with the targeted mobs. If they have the faction, turret won't shoot.
-	var/faction = list("mining")
+	var/faction = list(FACTION_MINING)
 
 /datum/armor/structure_legionturret
 	laser = 100

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -27,7 +27,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 
-	faction = list("mimic")
+	faction = list(FACTION_MIMIC)
 	move_to_delay = 9
 	del_on_death = 1
 	///A cap for items in the mimic. Prevents the mimic from eating enough stuff to cause lag when opened.

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -7,7 +7,7 @@
 	name = "elite"
 	desc = "An elite monster, found in one of the strange tumors on lavaland."
 	icon = 'icons/mob/simple/lavaland/lavaland_elites.dmi'
-	faction = list("boss")
+	faction = list(FACTION_BOSS)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -11,7 +11,7 @@
 	emote_hear = list("trills.")
 	emote_see = list("sniffs.", "burps.")
 	weather_immunities = list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE)
-	faction = list("mining", "ashwalker")
+	faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	density = FALSE
 	speak_chance = 1
 	turns_per_move = 8

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -270,7 +270,7 @@
 	vision_range = 5
 	aggro_vision_range = 9
 	speed = 3
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/hostile/asteroid
 	vision_range = 2
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE,TRAIT_ASHSTORM_IMMUNE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_WALLS

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -25,7 +25,7 @@
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("mushroom")
+	faction = list(FACTION_MUSHROOM)
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	stat_attack = DEAD
 	mouse_opacity = MOUSE_OPACITY_ICON

--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -77,7 +77,7 @@
 	attack_verb_continuous = "punches"
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	sentience_type = SENTIENCE_HUMANOID
 	combat_mode = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -14,7 +14,7 @@
 	hud_type = /datum/hud/ooze
 	minbodytemp = 250
 	maxbodytemp = INFINITY
-	faction = list("slime")
+	faction = list(FACTION_SLIME)
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	health = 200

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -23,7 +23,7 @@
 	speak_emote = list("yarrs")
 	loot = list(/obj/effect/mob_spawn/corpse/human/pirate)
 	del_on_death = TRUE
-	faction = list("pirate")
+	faction = list(FACTION_PIRATE)
 	/// Path of the mob spawner we base the mob's visuals off of.
 	var/mob_spawner = /obj/effect/mob_spawn/corpse/human/pirate
 	/// Path of the held item we give to the mob's visuals.

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -21,7 +21,7 @@
 	attack_verb_simple = "bite"
 	butcher_results = list(/obj/item/food/meat/slab = 1)
 	pass_flags = PASSTABLE
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
 	obj_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -24,7 +24,7 @@
 				/obj/item/knife/kitchen)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	status_flags = CANPUSH
 	footstep_type = FOOTSTEP_MOB_SHOE
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -25,7 +25,7 @@
 	unsuitable_atmos_damage = 5
 	robust_searching = 1
 	stat_attack = HARD_CRIT
-	faction = list("skeleton")
+	faction = list(FACTION_SKELETON)
 	// Going for a sort of pale bluegreen here, shooting for boneish
 	lighting_cutoff_red = 15
 	lighting_cutoff_green = 25

--- a/code/modules/mob/living/simple_animal/hostile/slaughter_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/slaughter_demon.dm
@@ -26,7 +26,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 250 //Weak to cold
 	maxbodytemp = INFINITY
-	faction = list("hell")
+	faction = list(FACTION_HELL)
 	attack_verb_continuous = "wildly tears into"
 	attack_verb_simple = "wildly tear into"
 	maxHealth = 200
@@ -237,4 +237,4 @@
 
 /mob/living/simple_animal/hostile/imp/slaughter/engine_demon
 	name = "engine demon"
-	faction = list("hell", FACTION_NEUTRAL)
+	faction = list(FACTION_HELL, FACTION_NEUTRAL)

--- a/code/modules/mob/living/simple_animal/hostile/smspider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/smspider.dm
@@ -24,7 +24,7 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	robust_searching = 1
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	// Gold, supermatter tinted
 	lighting_cutoff_red = 30
 	lighting_cutoff_green = 30

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -59,7 +59,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1500
-	faction = list("carp")
+	faction = list(FACTION_CARP)
 	pressure_resistance = 200
 	/// How much endlag using Wing Gust should apply.  Each use of wing gust increments this, and it decreases over time.
 	var/tiredness = 0

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -15,7 +15,7 @@
 	response_help_simple = "brush"
 	response_disarm_continuous = "pushes"
 	response_disarm_simple = "push"
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	speed = 1
 	maxHealth = 250
 	health = 250

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -160,7 +160,7 @@
 	lighting_cutoff_red = 10
 	lighting_cutoff_green = 35
 	lighting_cutoff_blue = 20
-	faction = list("hostile","vines","plants")
+	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
 	initial_language_holder = /datum/language_holder/venus
 	unique_name = TRUE
 	/// A list of all the plant's vines

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -28,7 +28,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	speed = -1 //they don't have to lug a body made of runed metal around
 	stop_automated_movement = 1
-	faction = list("cult")
+	faction = list(FACTION_CULT)
 	status_flags = CANPUSH
 	loot = list(/obj/item/ectoplasm)
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -7,7 +7,7 @@
 	gender = NEUTER
 	var/is_adult = 0
 	var/docile = 0
-	faction = list("slime", FACTION_NEUTRAL)
+	faction = list(FACTION_SLIME, FACTION_NEUTRAL)
 
 	harm_intent_damage = 5
 	icon_living = "grey baby slime"

--- a/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
@@ -36,7 +36,7 @@
 	desc = "A small sleeper typically used to make long distance travel a bit more bearable."
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	prompt_name = "a russian"
 	you_are_text = "Ay blyat. I am a Space-Russian smuggler!"
 	flavour_text = "We were mid-flight when our cargo was beamed off our ship! Must be on station somewhere? \

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -43,7 +43,7 @@
 	you_are_text = "You are a spider."
 	flavour_text = "For the hive! Choose a spider and fulfill your role to take over the station... if that is within your directives, of course."
 	important_text = "Follow your directives at all costs."
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	spawner_job_path = /datum/job/spider
 	role_ban = ROLE_ALIEN
 	prompt_ghost = FALSE

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -172,7 +172,7 @@
 	name = "sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	prompt_name = "a private security officer"
 	you_are_text = "You are a Nanotrasen Private Security Officer!"
 	flavour_text = "If higher command has an assignment for you, it's best you follow that. Otherwise, death to The Syndicate."

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -9,7 +9,7 @@
 	prompt_name = "venus human trap"
 	you_are_text = "You are a venus human trap."
 	flavour_text = "You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"
-	faction = list("hostile","vines","plants")
+	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
 	spawner_job_path = /datum/job/venus_human_trap
 	/// Physical structure housing the spawner
 	var/obj/structure/alien/resin/flower_bud/flower_bud

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -420,13 +420,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		update_appearance(UPDATE_ICON)
 	return ..()
 
-// On-click handling. Turns on the computer if it's off and opens the GUI.
-/obj/item/modular_computer/interact(mob/user)
-	if(enabled)
-		ui_interact(user)
-	else
-		turn_on(user)
-
 /obj/item/modular_computer/CtrlShiftClick(mob/user)
 	. = ..()
 	if(.)
@@ -605,7 +598,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		program.alert_pending = FALSE
 		idle_threads.Remove(program)
 		update_appearance()
-		updateUsrDialog()
 		return TRUE
 
 	if(!program.is_supported_by_hardware(hardware_flag, 1, user))
@@ -625,7 +617,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	active_program = program
 	program.alert_pending = FALSE
 	update_appearance()
-	updateUsrDialog()
+	ui_interact(user)
 	return TRUE
 
 // Returns 0 for No Signal, 1 for Low Signal and 2 for Good Signal. 3 is for wired connection (always-on)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -118,7 +118,7 @@
 				return TRUE
 
 /datum/computer_file/program/ai_restorer/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["ejectable"] = TRUE
 	data["AI_present"] = !!stored_card?.AI

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -41,7 +41,7 @@
 	return 1
 
 /datum/computer_file/program/alarm_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += alert_control.ui_data(user)
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -68,7 +68,7 @@
 			return TRUE
 
 /datum/computer_file/program/ntnet_dos/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["error"] = error
 	if(target && executed)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -64,7 +64,7 @@
 	return temp
 
 /datum/computer_file/program/revelation/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["armed"] = armed
 

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -82,7 +82,7 @@
 	)
 
 /datum/computer_file/program/arcade/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["Hitpoints"] = boss_hp
 	data["PlayerHitpoints"] = player_hp
 	data["PlayerMP"] = player_mp
@@ -97,7 +97,6 @@
 	. = ..()
 	if(.)
 		return
-
 	usr.played_game()
 
 	var/gamerSkillLevel = 0

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -54,7 +54,7 @@
 	return return_atmos_handbooks()
 
 /datum/computer_file/program/atmosscan/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/turf/turf = get_turf(computer)
 	data["atmozphereMode"] = atmozphere_mode
 	data["clickAtmozphereCompatible"] = (computer.hardware_flag & PROGRAM_TABLET)

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -69,7 +69,7 @@
 	DL_progress += 25
 
 /datum/computer_file/program/borg_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["card"] = FALSE
 	if(checkID())
@@ -112,20 +112,19 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("messagebot")
 			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 			if(!istype(R))
-				return
+				return TRUE
 			var/ID = checkID()
 			if(!ID)
-				return
+				return TRUE
 			if(R.stat == DEAD) //Dead borgs will listen to you no longer
 				to_chat(usr, span_warning("Error -- Could not open a connection to unit:[R]"))
 			var/message = tgui_input_text(usr, "Message to be sent to remote cyborg", "Send Message")
 			if(!message)
-				return
+				return TRUE
 			to_chat(R, "<br><br>[span_notice("Message from [ID] -- \"[message]\"")]<br>")
 			to_chat(usr, "Message sent to [R]: [message]")
 			R.logevent("Message from [ID] -- \"[message]\"")
@@ -134,6 +133,7 @@
 				to_chat(R.connected_ai, "<br><br>[span_notice("Message from [ID] to [R] -- \"[message]\"")]<br>")
 				SEND_SOUND(R.connected_ai, 'sound/machines/twobeep_high.ogg')
 			usr.log_talk(message, LOG_PDA, tag="Cyborg Monitor Program: ID name \"[ID]\" to [R]")
+			return TRUE
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
 /datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -19,7 +19,7 @@
 	var/networked = FALSE
 
 /datum/computer_file/program/bounty_board/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/formatted_requests = list()
 	var/list/formatted_applicants = list()
 	if(current_user)
@@ -82,7 +82,7 @@
 			for(var/datum/station_request/i in GLOB.request_list)
 				if("[i.req_number]" == "[current_user.account_id]")
 					computer.say("Account already has active bounty.")
-					return
+					return TRUE
 			var/datum/station_request/curr_request = new /datum/station_request(current_user.account_holder, bounty_value,bounty_text,current_user.account_id, current_user)
 			GLOB.request_list += list(curr_request)
 			for(var/obj/i in GLOB.allbountyboards)
@@ -126,9 +126,10 @@
 			bounty_value = text2num(params["bountyval"])
 			if(!bounty_value)
 				bounty_value = 1
+			return TRUE
 		if("bountyText")
 			bounty_text = (params["bountytext"])
-	. = TRUE
+	return TRUE
 
 /datum/computer_file/program/bounty_board/Destroy()
 	GLOB.allbountyboards -= computer

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -61,8 +61,7 @@
 	return FALSE
 
 /datum/computer_file/program/budgetorders/ui_data()
-	. = ..()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["location"] = SSshuttle.supply.getStatusText()
 	data["department"] = "Cargo"
 	var/datum/bank_account/buyer = SSeconomy.get_dep_account(cargo_account)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -77,7 +77,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/mob/user = usr
 	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
 
@@ -287,7 +286,7 @@
 	return data
 
 /datum/computer_file/program/card_mod/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/card/id/inserted_id = computer.computer_id_slot
 	data["authIDName"] = inserted_id ? inserted_id.name : "-----"

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -17,7 +17,7 @@
 	var/cut_min = 0.01
 
 /datum/computer_file/program/shipping/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["has_id_slot"] = !!computer.computer_id_slot
 	data["paperamt"] = "[computer.stored_paper] / [computer.max_paper]"
@@ -30,21 +30,18 @@
 	. = ..()
 	if(.)
 		return
-	if(!computer)
-		return
-
 	if(!computer.computer_id_slot) //We need an ID to successfully run
-		return
+		return FALSE
 
 	switch(action)
 		if("ejectid")
 			computer.RemoveID(usr)
 		if("selectid")
 			if(!computer.computer_id_slot.registered_account)
-				playsound(get_turf(ui_host()), 'sound/machines/buzz-sigh.ogg', 50, TRUE, -1)
-				return
+				playsound(get_turf(computer.ui_host()), 'sound/machines/buzz-sigh.ogg', 50, TRUE, -1)
+				return TRUE
 			payments_acc = computer.computer_id_slot.registered_account
-			playsound(get_turf(ui_host()), 'sound/machines/ping.ogg', 50, TRUE, -1)
+			playsound(get_turf(computer.ui_host()), 'sound/machines/ping.ogg', 50, TRUE, -1)
 		if("resetid")
 			payments_acc = null
 		if("setsplit")
@@ -53,11 +50,11 @@
 		if("print")
 			if(computer.stored_paper <= 0)
 				to_chat(usr, span_notice("Printer is out of paper."))
-				return
+				return TRUE
 			if(!payments_acc)
 				to_chat(usr, span_notice("Software error: Please set a current user first."))
-				return
-			var/obj/item/barcode/barcode = new /obj/item/barcode(get_turf(ui_host()))
+				return TRUE
+			var/obj/item/barcode/barcode = new /obj/item/barcode(get_turf(computer.ui_host()))
 			barcode.payments_acc = payments_acc
 			barcode.cut_multiplier = cut_multiplier
 			computer.stored_paper--

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -12,7 +12,7 @@
 	detomatix_resistance = DETOMATIX_RESIST_MAJOR
 
 /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["manifest"] = GLOB.manifest.get_manifest()
 	return data
 
@@ -20,7 +20,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_print")
 			if(computer) //This option should never be called if there is no printer

--- a/code/modules/modular_computers/file_system/programs/emojipedia.dm
+++ b/code/modules/modular_computers/file_system/programs/emojipedia.dm
@@ -17,7 +17,7 @@
 	emoji_list = sortTim(emoji_list, /proc/cmp_text_asc)
 
 /datum/computer_file/program/emojipedia/ui_static_data(mob_user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	for(var/emoji in emoji_list)
 		data["emoji_list"] += list(list(
 			"name" = emoji,

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -17,7 +17,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_deletefile")
 			var/datum/computer_file/file = computer.find_file_by_name(params["name"])
@@ -82,7 +81,7 @@
 			binary.alert_silenced = !binary.alert_silenced
 
 /datum/computer_file/program/filemanager/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(error)
 		data["error"] = error
 	if(!computer)

--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -83,7 +83,7 @@
 
 /datum/computer_file/program/scipaper_program/ui_data()
 	// Program Headers:
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["currentTab"] = current_tab
 	data["has_techweb"] = !!linked_techweb
 
@@ -168,7 +168,6 @@
 	. = ..()
 	if (.)
 		return
-
 	switch(action)
 		if("et_alia")
 			paper_to_be.et_alia = !paper_to_be.et_alia
@@ -226,7 +225,7 @@
 					playsound(computer, 'sound/machines/ping.ogg', 25)
 					return TRUE
 			playsound(computer, 'sound/machines/terminal_error.ogg', 25)
-			return FALSE
+			return TRUE
 
 /// Publication and adding points.
 /datum/computer_file/program/scipaper_program/proc/publish()

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -70,17 +70,16 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	. = ..()
 	if(.)
 		return
-
 	var/obj/item/card/id/user_id = computer.computer_id_slot
 	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
-		return
+		return TRUE
 
 	switch(action)
 		if("PRG_open_job")
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_open_job(j))
-				return
+				return TRUE
 			if(opened_positions[edit_job_target] >= 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions++
@@ -92,7 +91,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_close_job(j))
-				return
+				return TRUE
 			//Allow instant closing without cooldown if a position has been opened before
 			if(opened_positions[edit_job_target] <= 0)
 				GLOB.time_last_changed_position = world.time / 10
@@ -105,9 +104,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			var/priority_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(priority_target)
 			if(!j || !can_edit_job(j))
-				return
+				return TRUE
 			if(j.total_positions <= j.current_positions)
-				return
+				return TRUE
 			if(j in SSjob.prioritized_jobs)
 				SSjob.prioritized_jobs -= j
 			else
@@ -120,7 +119,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 
 /datum/computer_file/program/job_management/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/authed = FALSE
 	var/obj/item/card/id/user_id = computer.computer_id_slot

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -38,7 +38,7 @@
 	computer.save_photo(internal_picture.picture_image)
 
 /datum/computer_file/program/maintenance/camera/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	if(!isnull(internal_picture))
 		user << browse_rsc(internal_picture.picture_image, "tmp_photo[picture_number].png")
@@ -52,7 +52,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/mob/living/user = usr
 	switch(action)
 		if("print_photo")

--- a/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
@@ -32,18 +32,17 @@
 	controlled_suit = null
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["has_suit"] = !!controlled_suit
 	if(controlled_suit)
 		data += controlled_suit.ui_data()
 	return data
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_static_data(mob/user)
-	return controlled_suit.ui_static_data()
+	return controlled_suit?.ui_static_data()
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
-
-	controlled_suit.ui_act(action, params, ui)
+	controlled_suit.ui_act(action, params, ui, state)

--- a/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
@@ -20,7 +20,7 @@
 	last_record = healthscan(user, carbon, 1, tochat = FALSE)
 
 /datum/computer_file/program/maintenance/phys_scanner/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["last_record"] = last_record
 	return data

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -22,7 +22,7 @@
 	return ..()
 
 /datum/computer_file/program/newscaster/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += newscaster_ui.ui_data(user)
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -16,14 +16,13 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("UpdateNote")
 			written_note = params["newnote"]
 			return UI_UPDATE
 
 /datum/computer_file/program/notepad/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["note"] = written_note
 

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -21,7 +21,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("Transaction")
 			token = params["token"]
@@ -62,7 +61,7 @@
 
 
 /datum/computer_file/program/nt_pay/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	current_user = computer.computer_id_slot?.registered_account || null
 	if(!current_user)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -118,7 +118,7 @@
 	return FALSE
 
 /datum/computer_file/program/ntnetdownload/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/access = computer.GetAccess()
 
 	data["downloading"] = !!downloaded_file

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -108,7 +108,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PDA_ringSet")
 			var/new_ringtone = tgui_input_text(usr, "Enter a new ringtone", "Ringtone", ringtone, MESSENGER_RINGTONE_MAX_LENGTH)
@@ -220,7 +219,7 @@
 	return data
 
 /datum/computer_file/program/messenger/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["messages"] = messages
 	data["messengers"] = ScrubMessengerList()

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -52,7 +52,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/datum/ntnet_conversation/channel = SSmodular_computers.get_chat_channel_by_id(active_channel)
 	var/authed = FALSE
 	if(channel && ((channel.channel_operator == src) || netadmin_mode))
@@ -218,7 +217,7 @@
 	return data
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!SSmodular_computers.chat_channels)
 		return data
 

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -78,8 +78,8 @@
 			demand.Cut(1, 2)
 
 /datum/computer_file/program/power_monitor/ui_data()
+	var/list/data = list()
 	var/datum/powernet/connected_powernet = get_powernet()
-	var/list/data = get_header_data()
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
 	data["attached"] = connected_powernet ? TRUE : FALSE

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -45,7 +45,7 @@
 	)
 
 /datum/computer_file/program/radar/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["selected"] = selected
 	data["objects"] = list()
 	data["scanning"] = (world.time < next_scan)
@@ -66,7 +66,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("selecttarget")
 			selected = params["ref"]

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -64,7 +64,7 @@
 
 
 /datum/computer_file/program/records/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["records"] = GetRecordsReadable()
 	data["mode"] = mode
 	return data

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -22,8 +22,8 @@
 	)
 
 /datum/computer_file/program/robocontrol/ui_data(mob/user)
-	var/list/data = get_header_data()
-	var/turf/current_turf = get_turf(ui_host())
+	var/list/data = list()
+	var/turf/current_turf = get_turf(computer.ui_host())
 	var/list/botlist = list()
 	var/list/mulelist = list()
 
@@ -85,7 +85,7 @@
 
 /datum/computer_file/program/robocontrol/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
-	if(.)
+	if (.)
 		return
 	var/mob/current_user = ui.user
 	var/obj/item/card/id/id_card = computer?.computer_id_slot
@@ -124,7 +124,7 @@
 				GLOB.manifest.modify(id_card.registered_name, id_card.assignment, id_card.get_trim_assignment())
 				computer.RemoveID(usr)
 			else
-				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
+				playsound(get_turf(computer.ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
 		if("changedroneaccess")
 			if(!computer || !computer.computer_id_slot || !id_card)
 				to_chat(current_user, span_notice("No ID found, authorization failed."))

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -26,7 +26,7 @@
 	return FALSE
 
 /datum/computer_file/program/robotact/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!iscyborg(user))
 		return data
 

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -72,7 +72,7 @@
 	return .
 
 /datum/computer_file/program/secureye/ui_data()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["network"] = network
 	data["activeCamera"] = null
 	var/obj/machinery/camera/active_camera = camera_ref?.resolve()
@@ -100,7 +100,6 @@
 	. = ..()
 	if(.)
 		return
-
 	if(action == "switch_camera")
 		var/c_tag = format_text(params["name"])
 		var/list/cameras = get_available_cameras()

--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -24,7 +24,7 @@
 	SSradio.remove_object(computer, signal_frequency)
 
 /datum/computer_file/program/signal_commander/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["frequency"] = signal_frequency
 	data["code"] = signal_code
 	data["minFrequency"] = MIN_FREE_FREQ

--- a/code/modules/modular_computers/file_system/programs/skill_tracker.dm
+++ b/code/modules/modular_computers/file_system/programs/skill_tracker.dm
@@ -10,7 +10,7 @@
 	usage_flags = PROGRAM_TABLET // Must be a handheld device to read read your chakras or whatever
 
 /datum/computer_file/program/skill_tracker/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/list/skills = list()
 	data["skills"] = skills
@@ -54,7 +54,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_reward")
 			var/skill_type = find_skilltype(params["skill"])

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -31,7 +31,7 @@
 /datum/computer_file/program/supermatter_monitor/proc/refresh()
 	for(var/supermatter in supermatters)
 		clear_supermatter(supermatter)
-	var/turf/user_turf = get_turf(ui_host())
+	var/turf/user_turf = get_turf(computer.ui_host())
 	if(!user_turf)
 		return
 	for(var/obj/machinery/power/supermatter_crystal/sm in GLOB.machines)
@@ -47,7 +47,7 @@
 	return data
 
 /datum/computer_file/program/supermatter_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["sm_data"] = list()
 	for (var/obj/machinery/power/supermatter_crystal/sm as anything in supermatters)
 		data["sm_data"] += list(sm.sm_ui_data())
@@ -58,7 +58,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_refresh")
 			refresh()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -66,7 +66,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("setStatusMessage")
 			upper_text = reject_bad_text(params["upperText"] || "", MAX_STATUS_LINE_LENGTH)
@@ -83,7 +82,7 @@
 	return data
 
 /datum/computer_file/program/status/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["upperText"] = upper_text
 	data["lowerText"] = lower_text

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -41,7 +41,7 @@
 
 // heavy data from this proc should be moved to static data when possible
 /datum/computer_file/program/science/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["stored_research"] = !!stored_research
 	if(!stored_research) //lack of a research node is all we care about.
 		return data
@@ -92,7 +92,6 @@
 	. = ..()
 	if (.)
 		return
-
 	// Check if the console is locked to block any actions occuring
 	if (locked && action != "toggleLock")
 		computer.say("Console is locked, cannot perform further actions.")

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -15,7 +15,7 @@
 	var/list/imported_themes = list()
 
 /datum/computer_file/program/themeify/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	if(computer.obj_flags & EMAGGED)
 		data["themes"] += list(list("theme_name" = SYNDICATE_THEME_NAME, "theme_ref" = GLOB.pda_name_to_theme[SYNDICATE_THEME_NAME]))
@@ -28,7 +28,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_change_theme")
 			var/selected_theme = params["selected_theme"]

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -40,7 +40,7 @@
 				messenger_app.spam_mode = !messenger_app.spam_mode
 
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["ntnetstatus"] = SSmodular_computers.check_function()
 	data["ntnetrelays"] = SSmodular_computers.ntnet_relays.len

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -595,7 +595,7 @@
 	hitsound = 'sound/weapons/punch3.ogg'
 	trigger_range = 0
 	antimagic_flags = MAGIC_RESISTANCE_HOLY
-	ignored_factions = list("cult")
+	ignored_factions = list(FACTION_CULT)
 	range = 105
 	speed = 1
 	pixel_speed_multiplier = 1/7

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -708,7 +708,7 @@
  * * can_overdose - Allows overdosing
  * * liverless - Stops reagents that aren't set as [/datum/reagent/var/self_consuming] from metabolizing
  */
-/datum/reagents/proc/metabolize(mob/living/carbon/owner, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE)
+/datum/reagents/proc/metabolize(mob/living/carbon/owner, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE, dead = FALSE)
 	var/list/cached_reagents = reagent_list
 	if(owner)
 		expose_temperature(owner.bodytemperature, 0.25)
@@ -723,7 +723,7 @@
 
 	for(var/datum/reagent/reagent as anything in cached_reagents)
 		// skip metabolizing effects for small units of toxins
-		if(istype(reagent, /datum/reagent/toxin) && liver)
+		if(istype(reagent, /datum/reagent/toxin) && liver && !dead)
 			var/datum/reagent/toxin/toxin = reagent
 			var/amount = round(toxin.volume, CHEMICAL_QUANTISATION_LEVEL)
 			if(belly)
@@ -733,7 +733,7 @@
 				owner.reagents.remove_reagent(toxin.type, toxin.metabolization_rate * owner.metabolism_efficiency * delta_time)
 				continue
 
-		need_mob_update += metabolize_reagent(owner, reagent, delta_time, times_fired, can_overdose, liverless)
+		need_mob_update += metabolize_reagent(owner, reagent, delta_time, times_fired, can_overdose, liverless, dead)
 
 	if(owner && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
 		owner.updatehealth()
@@ -749,7 +749,7 @@
  * * can_overdose - Allows overdosing
  * * liverless - Stops reagents that aren't set as [/datum/reagent/var/self_consuming] from metabolizing
  */
-/datum/reagents/proc/metabolize_reagent(mob/living/carbon/owner, datum/reagent/reagent, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE)
+/datum/reagents/proc/metabolize_reagent(mob/living/carbon/owner, datum/reagent/reagent, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE, dead = FALSE)
 	var/need_mob_update = FALSE
 	if(QDELETED(reagent.holder))
 		return FALSE
@@ -757,7 +757,7 @@
 	if(!owner)
 		owner = reagent.holder.my_atom
 
-	if(owner && reagent)
+	if(owner && reagent && (!dead || (reagent.chemical_flags & REAGENT_DEAD_PROCESS)))
 		if(owner.reagent_check(reagent, delta_time, times_fired))
 			return
 		if(liverless && !reagent.self_consuming) //need to be metabolized
@@ -776,8 +776,10 @@
 
 			if(reagent.overdosed)
 				need_mob_update += reagent.overdose_process(owner, delta_time, times_fired)
-
-		need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+		if(!dead)
+			need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+	if(dead)
+		need_mob_update += reagent.on_mob_dead(owner, delta_time)
 	return need_mob_update
 
 /// Signals that metabolization has stopped, triggering the end of trait-based effects

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -43,7 +43,7 @@
 	taste_description = "badmins"
 	chemical_flags = REAGENT_DEAD_PROCESS
 	/// Flags to fullheal every metabolism tick
-	var/full_heal_flags = ~(HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS)
+	var/full_heal_flags = ~(HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_REFRESH_ORGANS)
 
 // The best stuff there is. For testing/debugging.
 /datum/reagent/medicine/adminordrazine/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
@@ -77,7 +77,7 @@
 	name = "Quantum Medicine"
 	description = "Rare and experimental particles, that apparently swap the user's body with one from an alternate dimension where it's completely healthy."
 	taste_description = "science"
-	full_heal_flags = ~(HEAL_ADMIN|HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_ALL_REAGENTS)
+	full_heal_flags = ~(HEAL_ADMIN|HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_ALL_REAGENTS|HEAL_REFRESH_ORGANS)
 
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -208,7 +208,7 @@
  * * mob_faction - used in determining targets, mobs from the same faction won't harm eachother.
  * * random - creates random mobs. self explanatory.
  */
-/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE)
+/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = FACTION_CHEMICAL_SUMMON, random = TRUE)
 	if(holder?.my_atom)
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -439,38 +439,26 @@
 	id = "stabilizedbase"
 	duration = -1
 	alert_type = null
+	/// Item which provides this buff
 	var/obj/item/slimecross/stabilized/linked_extract
+	/// Colour of the extract providing the buff
 	var/colour = "null"
 
-/datum/status_effect/stabilized/proc/location_check()
-	if(linked_extract.loc == owner)
-		return TRUE
-	if(linked_extract.loc.loc == owner)
-		return TRUE
-	for(var/atom/storage_loc as anything in get_storage_locs(linked_extract))
-		if(storage_loc == owner)
-			return TRUE
-		if(storage_loc.loc == owner)
-			return TRUE
-		for(var/atom/storage_loc_storage_loc as anything in get_storage_locs(storage_loc))
-			if(storage_loc_storage_loc == owner)
-				return TRUE
-	for(var/atom/loc_storage_loc as anything in get_storage_locs(linked_extract.loc))
-		if(loc_storage_loc == owner)
-			return TRUE
-	return FALSE
+/datum/status_effect/stabilized/on_creation(mob/living/new_owner, obj/item/slimecross/stabilized/linked_extract)
+	src.linked_extract = linked_extract
+	return ..()
 
 /datum/status_effect/stabilized/tick()
-	if(!linked_extract || !linked_extract.loc) //Sanity checking
+	if(isnull(linked_extract))
 		qdel(src)
 		return
-	if(linked_extract && !location_check())
+	if(linked_extract.get_held_mob() == owner)
+		return
+	owner.balloon_alert(owner, "[colour] extract faded!")
+	if(!QDELETED(linked_extract))
 		linked_extract.linked_effect = null
-		if(!QDELETED(linked_extract))
-			linked_extract.owner = null
-			START_PROCESSING(SSobj,linked_extract)
-		qdel(src)
-	return ..()
+		START_PROCESSING(SSobj,linked_extract)
+	qdel(src)
 
 /datum/status_effect/stabilized/null //This shouldn't ever happen, but just in case.
 	id = "stabilizednull"
@@ -847,48 +835,74 @@
 /datum/status_effect/stabilized/pink
 	id = "stabilizedpink"
 	colour = "pink"
+	/// List of weakrefs to mobs we have pacified
 	var/list/mobs = list()
-	var/faction_name
+	/// Name of our faction
+	var/faction_name = ""
 
 /datum/status_effect/stabilized/pink/on_apply()
-	faction_name = REF(owner)
+	faction_name = FACTION_PINK_EXTRACT(owner)
+	owner.faction |= faction_name
+	to_chat(owner, span_notice("[linked_extract] pulses, generating a fragile aura of peace."))
 	return ..()
 
 /datum/status_effect/stabilized/pink/tick()
-	for(var/mob/living/simple_animal/M in view(7,get_turf(owner)))
-		if(!(M in mobs))
-			mobs += M
-			M.apply_status_effect(/datum/status_effect/pinkdamagetracker)
-			M.faction |= faction_name
-	for(var/mob/living/simple_animal/M in mobs)
-		if(!(M in view(7,get_turf(owner))))
-			M.faction -= faction_name
-			M.remove_status_effect(/datum/status_effect/pinkdamagetracker)
-			mobs -= M
-		var/datum/status_effect/pinkdamagetracker/C = M.has_status_effect(/datum/status_effect/pinkdamagetracker)
-		if(istype(C) && C.damage > 0)
-			C.damage = 0
-			owner.apply_status_effect(/datum/status_effect/brokenpeace)
-	var/HasFaction = FALSE
-	for(var/i in owner.faction)
-		if(i == faction_name)
-			HasFaction = TRUE
+	update_nearby_mobs()
+	var/has_faction = FALSE
+	for (var/check_faction in owner.faction)
+		if(check_faction != faction_name)
+			continue
+		has_faction = TRUE
+		break
 
-	if(HasFaction && owner.has_status_effect(/datum/status_effect/brokenpeace))
-		owner.faction -= faction_name
-		to_chat(owner, span_userdanger("The peace has been broken! Hostile creatures will now react to you!"))
-	if(!HasFaction && !owner.has_status_effect(/datum/status_effect/brokenpeace))
+	if(has_faction)
+		if(owner.has_status_effect(/datum/status_effect/brokenpeace))
+			owner.faction -= faction_name
+			to_chat(owner, span_userdanger("The peace has been broken! Hostile creatures will now react to you!"))
+	else if(!owner.has_status_effect(/datum/status_effect/brokenpeace))
 		to_chat(owner, span_notice("[linked_extract] pulses, generating a fragile aura of peace."))
 		owner.faction |= faction_name
 	return ..()
 
+/// Pacifies mobs you can see and unpacifies mobs you no longer can
+/datum/status_effect/stabilized/pink/proc/update_nearby_mobs()
+	var/list/visible_things = view(7, get_turf(owner))
+	// Unpacify far away or offended mobs
+	for(var/datum/weakref/weak_mob as anything in mobs)
+		var/mob/living/beast = weak_mob.resolve()
+		if(isnull(beast))
+			mobs -= weak_mob
+			continue
+		var/datum/status_effect/pinkdamagetracker/damage_tracker = beast.has_status_effect(/datum/status_effect/pinkdamagetracker)
+		if(istype(damage_tracker) && damage_tracker.damage > 0)
+			damage_tracker.damage = 0
+			owner.apply_status_effect(/datum/status_effect/brokenpeace)
+			return // No point continuing from here if we're going to end the effect
+		if(beast in visible_things)
+			continue
+		beast.faction -= faction_name
+		beast.remove_status_effect(/datum/status_effect/pinkdamagetracker)
+		mobs -= weak_mob
+
+	// Pacify nearby mobs
+	for(var/mob/living/beast in visible_things)
+		if(!isanimal_or_basicmob(beast))
+			continue
+		var/datum/weakref/weak_mob = WEAKREF(beast)
+		if(weak_mob in mobs)
+			continue
+		mobs += weak_mob
+		beast.apply_status_effect(/datum/status_effect/pinkdamagetracker)
+		beast.faction |= faction_name
+
 /datum/status_effect/stabilized/pink/on_remove()
-	for(var/mob/living/simple_animal/M in mobs)
-		M.faction -= faction_name
-		M.remove_status_effect(/datum/status_effect/pinkdamagetracker)
-	for(var/i in owner.faction)
-		if(i == faction_name)
-			owner.faction -= faction_name
+	for(var/datum/weakref/weak_mob as anything in mobs)
+		var/mob/living/beast = weak_mob.resolve()
+		if(isnull(beast))
+			continue
+		beast.faction -= faction_name
+		beast.remove_status_effect(/datum/status_effect/pinkdamagetracker)
+	owner.faction -= faction_name
 
 /datum/status_effect/stabilized/oil
 	id = "stabilizedoil"

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -12,7 +12,6 @@ Stabilized extracts:
 	effect = "stabilized"
 	icon_state = "stabilized"
 	var/datum/status_effect/linked_effect
-	var/mob/living/owner
 
 /obj/item/slimecross/stabilized/Initialize(mapload)
 	. = ..()
@@ -23,44 +22,38 @@ Stabilized extracts:
 	qdel(linked_effect)
 	return ..()
 
+/// Returns the mob that is currently holding us if we are either in their inventory or a backpack analogue.
+/// Returns null if it's in an invalid location, so that we can check explicitly for null later.
+/obj/item/slimecross/stabilized/proc/get_held_mob()
+	if(isnull(loc))
+		return null
+	if(isliving(loc))
+		return loc
+	// Snowflake check for modsuit backpacks, which should be valid but are 3 rather than 2 steps from the owner
+	if(istype(loc, /obj/item/mod/module/storage))
+		var/obj/item/mod/module/storage/mod_backpack = loc
+		var/mob/living/modsuit_wearer = mod_backpack.mod?.wearer
+		return modsuit_wearer ? modsuit_wearer : null
+	var/nested_loc = loc.loc
+	if (isliving(nested_loc))
+		return nested_loc
+	return null
+
 /obj/item/slimecross/stabilized/process()
-	var/humanfound = null
-	if(ishuman(loc))
-		humanfound = loc
-	if(ishuman(loc.loc)) //Check if in backpack.
-		humanfound = (loc.loc)
-	for(var/atom/storage_loc as anything in get_storage_locs(src))
-		if(ishuman(storage_loc))
-			humanfound = storage_loc
-			break
-		if(ishuman(storage_loc.loc))
-			humanfound = storage_loc.loc
-			break
-		for(var/atom/storage_loc_storage_loc as anything in get_storage_locs(storage_loc))
-			if(ishuman(storage_loc_storage_loc))
-				humanfound = storage_loc_storage_loc
-				break
-	for(var/atom/loc_storage_loc as anything in get_storage_locs(loc))
-		if(ishuman(loc_storage_loc))
-			humanfound = loc_storage_loc
-			break
-	if(!humanfound)
+	var/mob/living/holder = get_held_mob()
+	if(isnull(holder))
 		return
-	var/mob/living/carbon/human/H = humanfound
 	var/effectpath = /datum/status_effect/stabilized
 	var/static/list/effects = subtypesof(/datum/status_effect/stabilized)
-	for(var/X in effects)
-		var/datum/status_effect/stabilized/S = X
-		if(initial(S.colour) == colour)
-			effectpath = S
-			break
-	if(!H.has_status_effect(effectpath))
-		var/datum/status_effect/stabilized/S = H.apply_status_effect(effectpath)
-		owner = H
-		S.linked_extract = src
-		STOP_PROCESSING(SSobj,src)
-
-
+	for(var/datum/status_effect/stabilized/effect as anything in effects)
+		if(initial(effect.colour) != colour)
+			continue
+		effectpath = effect
+		break
+	if (holder.has_status_effect(effectpath))
+		return
+	holder.apply_status_effect(effectpath, src)
+	STOP_PROCESSING(SSobj,src)
 
 //Colors and subtypes:
 /obj/item/slimecross/stabilized/grey

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -138,7 +138,7 @@
 				if(!user.combat_mode)
 					spawned_mob.faction |= FACTION_NEUTRAL
 				else
-					spawned_mob.faction |= "slime"
+					spawned_mob.faction |= FACTION_SLIME
 				playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 				user.visible_message(span_warning("[user] spits out [spawned_mob]!"), span_warning("You spit out [spawned_mob]!"))
 				return 600

--- a/code/modules/spells/spell_types/pointed/dominate.dm
+++ b/code/modules/spells/spell_types/pointed/dominate.dm
@@ -30,7 +30,7 @@
 		return FALSE
 	if(!animal.compare_sentience_type(SENTIENCE_ORGANIC)) // Will also return false if not a basic or simple mob, which are the only two we want anyway
 		return FALSE
-	if("cult" in animal.faction)
+	if(FACTION_CULT in animal.faction)
 		return FALSE
 	if(HAS_TRAIT(animal, TRAIT_HOLY))
 		return FALSE
@@ -46,6 +46,6 @@
 
 	var/turf/cast_turf = get_turf(cast_on)
 	cast_on.add_atom_colour("#990000", FIXED_COLOUR_PRIORITY)
-	cast_on.faction |= "cult"
+	cast_on.faction |= FACTION_CULT
 	playsound(cast_turf, 'sound/effects/ghost.ogg', 100, TRUE)
 	new /obj/effect/temp_visual/cult/sac(cast_turf)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -229,14 +229,17 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 //Try code/modules/mob/living/carbon/brain/brain_item.dm
 
 /**
- * Recreates all of this mob's organs, and heals them to full.
+ * Heals all of the mob's organs, and re-adds any missing ones.
+ *
+ * * regenerate_existing - if TRUE, existing organs will be deleted and replaced with new ones
  */
-/mob/living/carbon/proc/regenerate_organs()
+/mob/living/carbon/proc/regenerate_organs(regenerate_existing = FALSE)
+
 	// Delegate to species if possible.
 	if(dna?.species)
-		dna.species.regenerate_organs(src)
-		// Species regenerate organs doesn't handling healing the organs here,
-		// it's more concerned with just putting the necessary organs back in.
+		dna.species.regenerate_organs(src, replace_current = regenerate_existing)
+
+		// Species regenerate organs doesn't ALWAYS handle healing the organs because it's dumb
 		for(var/obj/item/organ/organ as anything in internal_organs)
 			organ.setOrganDamage(0)
 		set_heartattack(FALSE)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -515,7 +515,7 @@
 	playsound(get_turf(regenerating), 'sound/effects/ethereal_revive.ogg', 100)
 	to_chat(regenerating, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
 	regenerating.gain_trauma(picked_trauma, TRAUMA_RESILIENCE_ABSOLUTE)
-	regenerating.revive(HEAL_ALL)
+	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.
 	if(!QDELETED(src))

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -199,20 +199,6 @@
 		if(4 * LIVER_FAILURE_STAGE_SECONDS to INFINITY)
 			examine_list += span_danger("[owner]'s eyes are completely yellow and swelling with pus. [owner.p_they(TRUE)] [owner.p_do()]n't look like [owner.p_they()] will be alive for much longer.")
 
-/obj/item/organ/internal/liver/on_death(delta_time, times_fired)
-	. = ..()
-	var/mob/living/carbon/carbon_owner = owner
-	if(!owner)//If we're outside of a mob
-		return
-	if(!iscarbon(carbon_owner))
-		CRASH("on_death() called for [src] ([type]) with invalid owner ([isnull(owner) ? "null" : owner.type])")
-	if(carbon_owner.stat != DEAD)
-		CRASH("on_death() called for [src] ([type]) with not-dead owner ([owner])")
-	if((organ_flags & ORGAN_FAILING) && HAS_TRAIT(carbon_owner, TRAIT_NOMETABOLISM))//can't process reagents with a failing liver
-		return
-	for(var/datum/reagent/chem as anything in carbon_owner.reagents.reagent_list)
-		chem.on_mob_dead(carbon_owner, delta_time)
-
 /obj/item/organ/internal/liver/get_availability(datum/species/owner_species, mob/living/owner_mob)
 	return owner_species.mutantliver
 

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -103,14 +103,7 @@
 			))
 	else
 		window.send_message("ping")
-	var/flush_queue = window.send_asset(get_asset_datum(
-		/datum/asset/simple/namespaced/fontawesome))
-	flush_queue |= window.send_asset(get_asset_datum(
-		/datum/asset/simple/namespaced/tgfont))
-	for(var/datum/asset/asset in src_object.ui_assets(user))
-		flush_queue |= window.send_asset(asset)
-	if (flush_queue)
-		user.client.browse_queue_flush()
+	send_assets()
 	window.send_message("update", get_payload(
 		with_data = TRUE,
 		with_static_data = TRUE))
@@ -119,6 +112,16 @@
 	SStgui.on_open(src)
 
 	return TRUE
+
+/datum/tgui/proc/send_assets()
+	var/flush_queue = window.send_asset(get_asset_datum(
+		/datum/asset/simple/namespaced/fontawesome))
+	flush_queue |= window.send_asset(get_asset_datum(
+		/datum/asset/simple/namespaced/tgfont))
+	for(var/datum/asset/asset in src_object.ui_assets(user))
+		flush_queue |= window.send_asset(asset)
+	if (flush_queue)
+		user.client.browse_queue_flush()
 
 /**
  * public

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -114,6 +114,7 @@
 #include "emoting.dm"
 #include "focus_only_tests.dm"
 #include "food_edibility_check.dm"
+#include "full_heal.dm"
 #include "gas_transfer.dm"
 #include "get_turf_pixel.dm"
 #include "geyser.dm"

--- a/code/modules/unit_tests/full_heal.dm
+++ b/code/modules/unit_tests/full_heal.dm
@@ -1,0 +1,60 @@
+/// Tests the fully heal flag [HEAL_ORGANS].
+/datum/unit_test/full_heal_heals_organs
+
+/datum/unit_test/full_heal_heals_organs/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+
+	for(var/obj/item/organ/internal/organ in dummy.internal_organs)
+		organ.applyOrganDamage(50)
+
+	dummy.fully_heal(HEAL_ORGANS)
+
+	for(var/obj/item/organ/internal/organ in dummy.internal_organs)
+		if(organ.damage <= 0)
+			continue
+		TEST_FAIL("Organ [organ] did not get healed by fullyheal flag HEAL_ORGANS.")
+
+/// Tests the fully heal flag [HEAL_REFRESH_ORGANS].
+/datum/unit_test/full_heal_regenerates_organs
+
+/datum/unit_test/full_heal_regenerates_organs/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+
+	var/list/we_started_with = list()
+
+	for(var/obj/item/organ/internal/organ in dummy.internal_organs)
+		if(organ.organ_flags & ORGAN_VITAL) // leave this for now
+			continue
+		we_started_with += organ.type
+		qdel(organ)
+
+	TEST_ASSERT(length(we_started_with), "Dummy didn't spawn with any organs to regenerate.")
+
+	dummy.fully_heal(HEAL_REFRESH_ORGANS)
+
+	for(var/obj/item/organ/organ_type as anything in we_started_with)
+		if(dummy.getorgan(organ_type))
+			continue
+		TEST_FAIL("Organ [initial(organ_type.name)] didn't regenerate in the dummy after fullyheal flag HEAL_REFRESH_ORGANS.")
+
+/// Tests the fully heal combination flag [HEAL_DAMAGE].
+/datum/unit_test/full_heal_damage_types
+
+/datum/unit_test/full_heal_damage_types/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+
+	dummy.apply_damages(brute = 10, burn = 10, tox = 10, oxy = 10, clone = 10, stamina = 10)
+	dummy.fully_heal(HEAL_DAMAGE)
+
+	if(dummy.getBruteLoss())
+		TEST_FAIL("The dummy still had brute damage after a fully heal!")
+	if(dummy.getFireLoss())
+		TEST_FAIL("The dummy still had burn damage after a fully heal!")
+	if(dummy.getToxLoss())
+		TEST_FAIL("The dummy still had toxins damage after a fully heal!")
+	if(dummy.getOxyLoss())
+		TEST_FAIL("The dummy still had oxy damage after a fully heal!")
+	if(dummy.getCloneLoss())
+		TEST_FAIL("The dummy still had clone damage after a fully heal!")
+	if(dummy.getStaminaLoss())
+		TEST_FAIL("The dummy still had stamina damage after a fully heal!")

--- a/config/config.txt
+++ b/config/config.txt
@@ -304,6 +304,8 @@ CHECK_RANDOMIZER
 #LOAD_JOBS_FROM_TXT
 
 ## Uncomment this to forbid admins from possessing the singularity.
+## It is intentional that Admins can edit this config, as its meant to serve as a deterrent/warning for admin abuse.
+## Add a `@` in front to lock admins from editing this.
 #FORBID_SINGULO_POSSESSION
 
 ## Uncomment to give admins the ability to send a maptext popup to players.

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -53,3 +53,4 @@
 #_maps/RandomRuins/SpaceRuins/hellfactory.dmm
 #_maps/RandomRuins/SpaceRuins/space_billboard.dmm
 #_maps/RandomRuins/SpaceRuins/spinwardsmoothies.dmm
+#_maps/RandomRuins/SpaceRuins/dangerous_research.dmm

--- a/html/changelogs/AutoChangeLog-pr-73674.yml
+++ b/html/changelogs/AutoChangeLog-pr-73674.yml
@@ -1,4 +1,0 @@
-author: "Maurukas"
-delete-after: True
-changes:
-  - bugfix: "A disconnected vent on the syndicate lavaland base is now connected"

--- a/html/changelogs/archive/2023-03.yml
+++ b/html/changelogs/archive/2023-03.yml
@@ -1,0 +1,66 @@
+2023-03-01:
+  Jacquerel:
+  - bugfix: Opening a surprise egg with your mind will no longer teleport the contents
+  Maurukas:
+  - bugfix: A disconnected vent on the syndicate lavaland base is now connected
+  Melbert:
+  - bugfix: Off station roles can't purge the station's records
+  - bugfix: Purging records is logged again
+  - bugfix: Ninja security records hacking works
+  NamelessFairy:
+  - bugfix: You can now create wanted/missing posters using player created security
+      records. Due to a visual bug and usability issue photos above 1 by 1 meters
+      in size will no longer work for mugshots in records.
+  Remuluson2:
+  - bugfix: After pressure from Nanotrasen, Space Wizard Federation made glass and
+      bone knives non-conductive again.
+  scriptis:
+  - bugfix: removes an infinite powercell from tram maintenance
+2023-03-02:
+  Jacquerel:
+  - bugfix: 'Stabilized slime extracts will now once again work from inside modsuit
+      storage.
+
+      fix; Stabilized slime extracts will properly effect carp, spiders, bileworms,
+      and other "basic mobs".'
+  JohnFulpWillard:
+  - bugfix: Being in an application now properly uses the tablet's battery.
+  - bugfix: Messenger and Themify apps now close when minimized, so don't count towards
+      the running app limit.
+  - bugfix: Tablet UIs will now no longer spam open/close the UI when changing applications
+  - bugfix: Using the Eject ID button on tablets now ejects into your hand.
+  - bugfix: Computers now have an Eject ID button
+  - refactor: Cut down a lot of copy paste in tablet & program code, now it's mostly
+      done by the tablet.
+  Melbert:
+  - bugfix: Using Fleshmend while on fire gives the "on fire" fleshmend icon.
+  - bugfix: Using Revival stasis more accurately updates the icon where relevant
+  - bugfix: Fixes a potential input stall with revival stasis
+  - bugfix: Nightmare revival acts less funky - stops it from re-creating the Light
+      Eater.
+  NamelessFairy:
+  - bugfix: The research directors monitor on tram has been correctly orientated
+  - bugfix: The CE on tram no longer has two engineering department monitors, one
+      has instead been swapped out for an engine monitor.
+  - bugfix: Tram's AI sat cameras have been re-configured to be on either the Minisat
+      or AI core networks, this means security cannot see the entire satellite from
+      a standard camera console.
+  - spellcheck: Some cameras on tram have been capitalized.
+  - bugfix: You can no longer trap yourself in north public mining maintenance if
+      you enter it without maint access.
+  Profakos:
+  - bugfix: Mail addressed to tram's cargo bay disposal bin will arrive successfully,
+      and the Incoming Mail Chute will properly accept wrapped parcels.
+  RikuTheKiller:
+  - bugfix: Reagents metabolize properly when dead. (If they're supposed to.)
+2023-03-03:
+  Cheshify, Ferro:
+  - rscadd: A new ruin has been detected near the station, what secrets could it hold?
+  Shroopy:
+  - qol: Added another set of windoors to the Tramstation Xenobiology pens, fully
+      enclosing the space before them. The creatures in the main pens can now always
+      be accessed from above.
+  - refactor: Tramstation Xenobiology pens explicitly close to the right rather than
+      being rotated by using dir.
+  tf-4:
+  - bugfix: Fixed a missing wire in the Tramstation cargo warehouse.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3644,6 +3644,7 @@
 #include "code\modules\mapfluff\ruins\spaceruin_code\crashedclownship.dm"
 #include "code\modules\mapfluff\ruins\spaceruin_code\crashedship.dm"
 #include "code\modules\mapfluff\ruins\spaceruin_code\cyborgmothership.dm"
+#include "code\modules\mapfluff\ruins\spaceruin_code\dangerous_research.dm"
 #include "code\modules\mapfluff\ruins\spaceruin_code\deepstorage.dm"
 #include "code\modules\mapfluff\ruins\spaceruin_code\DJstation.dm"
 #include "code\modules\mapfluff\ruins\spaceruin_code\forgottenship.dm"

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
@@ -9,7 +9,7 @@ import { MedicalRecord, MedicalRecordData } from './types';
 /** Displays all found records. */
 export const MedicalRecordTabs = (props, context) => {
   const { act, data } = useBackend<MedicalRecordData>(context);
-  const { records = [] } = data;
+  const { records = [], station_z } = data;
 
   const errorMessage = !records.length
     ? 'No records found.'
@@ -50,7 +50,7 @@ export const MedicalRecordTabs = (props, context) => {
             <Button
               disabled
               icon="plus"
-              tooltip="Add new records by inserting a photo into the terminal. You do not need this screen open.">
+              tooltip="Add new records by inserting a 1 by 1 meter photo into the terminal. You do not need this screen open.">
               Create
             </Button>
           </Stack.Item>
@@ -58,6 +58,7 @@ export const MedicalRecordTabs = (props, context) => {
             <Button.Confirm
               content="Purge"
               icon="trash"
+              disabled={!station_z}
               onClick={() => act('purge_records')}
               tooltip="Wipe all record data."
             />

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -12,7 +12,7 @@ export const MedicalRecordView = (props, context) => {
   if (!foundRecord) return <NoticeBox>No record selected.</NoticeBox>;
 
   const { act, data } = useBackend<MedicalRecordData>(context);
-  const { assigned_view } = data;
+  const { assigned_view, station_z } = data;
 
   const { min_age, max_age } = data;
 
@@ -52,6 +52,7 @@ export const MedicalRecordView = (props, context) => {
             <Button.Confirm
               content="Delete"
               icon="trash"
+              disabled={!station_z}
               onClick={() => act('expunge_record', { crew_ref: crew_ref })}
               tooltip="Expunge record data."
             />

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type MedicalRecordData = {
   assigned_view: string;
   authenticated: BooleanLike;
+  station_z: BooleanLike;
   records: MedicalRecord[];
   min_age: number;
   max_age: number;

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -78,14 +78,14 @@ export const NtosMain = (props, context) => {
                     selected={light_on}
                     onClick={() => act('PC_toggle_light')}
                   />
-                  <Button
-                    icon="eject"
-                    content="Eject ID"
-                    disabled={!proposed_login.IDName}
-                    onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
-                  />
                 </>
               )}
+              <Button
+                icon="eject"
+                content="Eject ID"
+                disabled={!proposed_login.IDName}
+                onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
+              />
               {!!show_imprint && (
                 <Button
                   icon="dna"

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -10,7 +10,7 @@ import { SecurityRecordsData, SecurityRecord } from './types';
 /** Tabs on left, with search bar */
 export const SecurityRecordTabs = (props, context) => {
   const { act, data } = useBackend<SecurityRecordsData>(context);
-  const { higher_access, records = [] } = data;
+  const { higher_access, records = [], station_z } = data;
 
   const errorMessage = !records.length
     ? 'No records found.'
@@ -51,14 +51,14 @@ export const SecurityRecordTabs = (props, context) => {
             <Button
               disabled
               icon="plus"
-              tooltip="Add new records by inserting a photo into the terminal. You do not need this screen open.">
+              tooltip="Add new records by inserting a 1 by 1 meter photo into the terminal. You do not need this screen open.">
               Create
             </Button>
           </Stack.Item>
           <Stack.Item>
             <Button.Confirm
               content="Purge"
-              disabled={!higher_access}
+              disabled={!higher_access || !station_z}
               icon="trash"
               onClick={() => act('purge_records')}
               tooltip="Wipe criminal record data."

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type SecurityRecordsData = {
   assigned_view: string;
   authenticated: BooleanLike;
+  station_z: BooleanLike;
   available_statuses: string[];
   current_user: string;
   higher_access: BooleanLike;


### PR DESCRIPTION
Wahoo bug fixes

Featuring:
- Tramstation maintenance no longer contains an infinite capacity battery.
- Wanted Posters can be printed again.
- Ninjas can once more hack the security records to set everyone on the station to Arrest.
- Glass and Bone shivs no longer conduct electricity and can be used to break electrified grilles.
- Tramstation Cargo disposals works correctly (thanks PL!)
- Fleshmend and Revival Stasis icons should update more reliably.
- Stabilised Slime Extracts now work from inside MODsuits.
- Adds a new heretic-themed space ruin.
- Tram cargo should be connected to the electrical grid.