### PR TITLE
More Mining Safety

### DIFF
--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
@@ -122,3 +122,5 @@
 	playsound(devourer, 'sound/effects/splat.ogg', 50, TRUE)
 	//to be recieved on death
 	target.forceMove(devourer)
+	target.death()
+	target.AddElement(/datum/element/safe_stomach) // ORBSTATION: Preserve mob, has to go here because of sleep loop

--- a/orbstation/code/jobs/mining/safer_stomach.dm
+++ b/orbstation/code/jobs/mining/safer_stomach.dm
@@ -1,0 +1,56 @@
+#define STASIS_SOURCE_EATEN "stasis_stomach"
+
+// Preserve you if a mining mob eats you, also fully heal you if a legion eats you because it's cute
+
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/infest(mob/living/carbon/human/victim)
+	. = ..()
+	victim.AddElement(/datum/element/safe_stomach, regenerative_stomach = TRUE)
+
+/datum/action/cooldown/mob_cooldown/devour/burrow_and_devour(mob/living/devourer, mob/living/target)
+	. = ..()
+	if (target.loc != devourer)
+		return
+	target.AddElement(/datum/element/safe_stomach)
+	target.death() // Force untarget
+
+/**
+ * Attached to a mob who has been eaten by another mob...
+ * Prevents decay and optionally also heals them.
+ */
+/datum/element/safe_stomach
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// If true we will heal the target and give them a moodlet when rescued
+	var/regenerative_stomach
+
+/datum/element/safe_stomach/Attach(datum/target, regenerative_stomach = FALSE)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+
+	var/mob/living/victim = target
+
+	src.regenerative_stomach = regenerative_stomach
+	victim.extinguish_mob() // It's wet in there
+	victim.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_SOURCE_EATEN)
+	if (regenerative_stomach)
+		victim.fully_heal(HEAL_DAMAGE)
+	RegisterSignal(victim, COMSIG_MOVABLE_MOVED, PROC_REF(on_rescued))
+
+/datum/element/safe_stomach/Detach(mob/living/source, ...)
+	. = ..()
+	source.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_SOURCE_EATEN)
+	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
+
+/// Remove the stasis effect
+/datum/element/safe_stomach/proc/on_rescued(mob/living/rescued)
+	SIGNAL_HANDLER
+	if (regenerative_stomach)
+		rescued.add_mood_event("regenerative core", /datum/mood_event/healsbadman/long_term) // This will still probably mostly be gone before you are alive
+	rescued.RemoveElement(/datum/element/safe_stomach, regenerative_stomach = regenerative_stomach)
+
+// Fluff moodlet from being healed by being inside a legion
+/datum/mood_event/healsbadman/long_term
+	timeout = 10 MINUTES
+
+#undef STASIS_SOURCE_EATEN

--- a/orbstation/code/jobs/mining/safer_stomach.dm
+++ b/orbstation/code/jobs/mining/safer_stomach.dm
@@ -6,13 +6,6 @@
 	. = ..()
 	victim.AddElement(/datum/element/safe_stomach, regenerative_stomach = TRUE)
 
-/datum/action/cooldown/mob_cooldown/devour/burrow_and_devour(mob/living/devourer, mob/living/target)
-	. = ..()
-	if (target.loc != devourer)
-		return
-	target.AddElement(/datum/element/safe_stomach)
-	target.death() // Force untarget
-
 /**
  * Attached to a mob who has been eaten by another mob...
  * Prevents decay and optionally also heals them.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5224,6 +5224,7 @@
 #include "orbstation\code\jobs\mining\chasm_rescue.dm"
 #include "orbstation\code\jobs\mining\demonic_portal.dm"
 #include "orbstation\code\jobs\mining\megafauna.dm"
+#include "orbstation\code\jobs\mining\safer_stomach.dm"
 #include "orbstation\code\jobs\mining\tendril.dm"
 #include "orbstation\code\jobs\mining\voucher_sets.dm"
 #include "orbstation\code\jobs\research\digitgrade_legs.dm"


### PR DESCRIPTION
## About The Pull Request

Adds two further mining QoL features:

- Being eaten by a mining creature (Bileworm or Legion) will preserve your corpse indefinitely and render it immune to weather, and also extinguish it if it is on fire. Being eaten by a Legion will also fully heal your corpse so you're ready to revive just after being popped out, just seems like that's what it would do if you were completely covered in regenerative cores.
- When you climb out of a chasm it will attempt to place you in an open tile within 3 tiles of the chasm you fell into. It prefers to pick diagonal tiles rather than orthogonal ones which is mildly annoying aesthetically but beggars can't be choosers.

The latter is not entirely foolproof because if you're not careful you can get yourself stuck, but you're not in a chasm any more so at that point you can yell into the radio for rescue I guess.
![image](https://user-images.githubusercontent.com/7483112/222806275-5106fb04-6686-4d69-a72d-ba97af0635ba.png)

If there's no free area within 3 tiles it will return to trying to fling you like before.

## Why It's Good For The Game

Makes some annoying situations more recoverable.

## Changelog

:cl:
balance: Miners escaping from chasms will now be slightly less vigorous and try to gently emerge onto a nearby tile rather than fling themselves with force into the distance.
balance: People who are eaten by a Legion or Bileworm will find that their bodies are surprisingly well-preserved for ressurection if rescued.
/:cl:
