### PR TITLE
Nerfotoxin

### DIFF
--- a/orbstation/code/antagonists/xenomorph/neurotoxin.dm
+++ b/orbstation/code/antagonists/xenomorph/neurotoxin.dm
@@ -1,0 +1,43 @@
+// Neurotoxin does stamina damage over time
+/obj/projectile/neurotoxin
+	paralyze = 0 SECONDS
+	/// If we should stamina crit people
+	var/apply_debuff = TRUE
+
+/obj/projectile/neurotoxin/damaging
+	apply_debuff = FALSE
+
+/obj/projectile/neurotoxin/on_hit(mob/living/target, blocked = FALSE)
+	if (isalien(target))
+		return ..()
+	if (apply_debuff && istype(target))
+		target.apply_status_effect(/datum/status_effect/xeno_neurotoxin)
+	return ..()
+
+/// Deals stamina damage on application and more over time
+/datum/status_effect/xeno_neurotoxin
+	duration = 6 SECONDS
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/xeno_neurotoxin
+	/// Stamina damage to apply on application or refresh
+	var/instant_damage = 20
+	/// Stamina damage to apply every second while debuff is active
+	var/damage_per_tick = 6
+
+/atom/movable/screen/alert/status_effect/xeno_neurotoxin
+	name = "Neurotoxicity"
+	desc = "You can feel yourself going numb."
+	icon_state = "woozy"
+
+/datum/status_effect/xeno_neurotoxin/on_apply()
+	. = ..()
+	owner.apply_damage(instant_damage, damagetype = STAMINA)
+
+/datum/status_effect/xeno_neurotoxin/refresh(effect, ...)
+	duration += initial(duration)
+	owner.apply_damage(instant_damage, damagetype = STAMINA)
+
+/datum/status_effect/xeno_neurotoxin/tick(delta_time, times_fired)
+	owner.apply_damage(damage_per_tick, damagetype = STAMINA)
+	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA)) // Entered stamina crit
+		qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5169,6 +5169,7 @@
 #include "orbstation\code\antagonists\wizard_journeyman\diploma\spell_defensive.dm"
 #include "orbstation\code\antagonists\wizard_journeyman\diploma\spell_offensive.dm"
 #include "orbstation\code\antagonists\wizard_journeyman\diploma\spell_other.dm"
+#include "orbstation\code\antagonists\xenomorph\neurotoxin.dm"
 #include "orbstation\code\antagonists\zetan\abductor_bouncer.dm"
 #include "orbstation\code\antagonists\zetan\transform_gland.dm"
 #include "orbstation\code\antagonists\zetan\zetan_pirates.dm"


### PR DESCRIPTION
## About The Pull Request

Adjusts xenomorph neurotoxin (used by Praetorians, Queens, and Sentinels... and maybe implanted humans?) to apply stamina damage instead of being an instant stun.
Specifically it deals 20 stamina damage upon application and then an additional 30 over the next 6 seconds.
Hitting someone more than once will extend the current effect duration.
This means that hitting someone twice with Neurotoxin _will_ stun them for ~8 seconds... after 10 seconds.

The debuff removes itself once someone is stamina crit, so it cannot chain-apply.

The duration and initial damage are reduced by bio armour, so a biosuit will give you complete immunity but some other surprising items (EVA winter coats?) have a 50% reduction.

For reference a Sentinel can "bank" 5 charges of neurotoxin (enough to immediately stamina crit someone if they hit with _all_ of them) and regenerates enough chemicals to do another one every 6 seconds while stood on weeds.
Queens and Praetorians have a deeper chemical reserve, enough to use 10 in a row.

This still leaves neurotoxin as a reasonably potent self-defence tool but it's closer in function to a stun baton and harder to apply to more than one person at a time. 

## Why It's Good For The Game

The 10 second instant ranged stun is designed for a larger playerbase, playing an older version of the game.
This version allows an increased amount of counterplay and reaction. It's not an instant disable, so players have time to attempt to make distance or do something about it, however it is still quite dangerous.

## Changelog

:cl:
balance: Xenomorph Neurotoxin now applies stamina damage over time rather than an instant stun.
/:cl:
