### PR TITLE
Biodome plaques + more

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2793,12 +2793,14 @@
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "bbS" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -3034,6 +3036,12 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/engine/hull,
 /area/station/asteroid)
+"bhM" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bhN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4903,6 +4911,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"bVn" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bVF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -6008,6 +6022,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"ctk" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ctr" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
@@ -8170,6 +8191,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"dhV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "die" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/engineering/vending_restock,
@@ -9403,6 +9431,15 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"dHf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dHl" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/west,
@@ -9704,6 +9741,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"dOd" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dOh" = (
 /obj/item/holosign_creator/robot_seat/bar,
 /obj/structure/table/wood,
@@ -9782,6 +9825,15 @@
 /obj/effect/turf_decal/siding/dark_green/corner,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"dQj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dQs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -11966,6 +12018,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"eJH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "eJI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Warehouse Maintenance"
@@ -14021,6 +14085,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"fxt" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fxx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -14469,6 +14538,12 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"fIe" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fIK" = (
 /obj/effect/turf_decal/tile/dark_red/anticorner{
 	dir = 1
@@ -14696,6 +14771,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "fNa" = (
@@ -14916,6 +14994,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Zoo Starboard"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "fQs" = (
@@ -15155,6 +15234,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"fUm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fUq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16789,6 +16878,12 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
+"gAP" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gBb" = (
 /obj/structure/flora/bush/leafy,
 /mob/living/basic/cockroach,
@@ -22070,6 +22165,18 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research)
+"iNi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "iND" = (
 /obj/structure/chair{
 	dir = 1
@@ -22980,6 +23087,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
+"jhU" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jhZ" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
@@ -23429,10 +23542,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "jrQ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "jsf" = (
@@ -24014,6 +24129,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"jEf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jED" = (
 /turf/open/floor/circuit/green{
 	luminosity = 2
@@ -26181,6 +26308,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"kuy" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kuz" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -26189,6 +26322,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"kuD" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kuJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -26992,6 +27131,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/grass,
 /area/station/maintenance/aft/upper)
+"kJN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kJT" = (
 /obj/item/paper_bin/bundlenatural,
 /turf/open/misc/asteroid/airless,
@@ -29281,6 +29432,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/fakebasalt,
 /area/station/security/brig/entrance)
+"lCs" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lCx" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics"
@@ -33682,6 +33839,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -41323,6 +41483,15 @@
 "qpX" = (
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"qqk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qqy" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
@@ -42006,6 +42175,16 @@
 /obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"qDE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qDI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/rnd/server,
@@ -42362,6 +42541,15 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"qLl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qLq" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
@@ -43203,8 +43391,10 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "rac" = (
-/obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rar" = (
@@ -44573,6 +44763,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"rAm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rAn" = (
 /turf/closed/wall,
 /area/station/cargo/lobby)
@@ -45159,6 +45358,12 @@
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rOS" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rPb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -47792,6 +47997,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/bridge)
+"sSk" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sSm" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/titanium,
@@ -48248,6 +48459,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"tbu" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tbw" = (
 /turf/closed/wall,
 /area/station/biodome)
@@ -49795,6 +50012,13 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"tFF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tFG" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -50045,6 +50269,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"tKx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tKB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electric_shock,
@@ -50885,6 +51121,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"ufi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ufj" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -51093,6 +51342,7 @@
 /area/station/science/xenobiology)
 "ukV" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ulb" = (
@@ -54101,6 +54351,16 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"vyr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vyt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54929,6 +55189,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Commissary"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "vOG" = (
@@ -156970,7 +157231,7 @@ fQs
 jpN
 neH
 swn
-nIC
+fxt
 vxC
 dST
 dST
@@ -158201,10 +158462,10 @@ oWu
 nso
 pGx
 phW
-jzd
-kME
-jzd
-nfE
+nCa
+qDE
+nCa
+pGm
 ggF
 dIi
 dmh
@@ -158254,8 +158515,8 @@ uyN
 hjh
 jpN
 fQl
-wWM
-uCA
+fUm
+qQw
 jKM
 jKM
 jKM
@@ -158461,7 +158722,7 @@ phW
 ukV
 kME
 jzd
-nfE
+pGm
 ggF
 dIi
 dFm
@@ -158718,7 +158979,7 @@ phW
 jzd
 kME
 uck
-nfE
+pGm
 pnK
 dIi
 dIi
@@ -158974,7 +159235,7 @@ xIb
 oKS
 jzd
 kME
-pEk
+dhV
 pGm
 ggF
 fgk
@@ -160258,8 +160519,8 @@ cSp
 pGx
 phW
 dSl
-kME
-jzd
+eJH
+dOd
 nfE
 iOT
 rGt
@@ -160309,8 +160570,8 @@ fQs
 fQs
 pEf
 sXp
-neH
-eij
+kuy
+qLl
 neH
 dfj
 lqj
@@ -160515,8 +160776,8 @@ aMm
 chi
 lSi
 jzd
-kME
-jzd
+tKx
+fIe
 pGm
 uHs
 wsv
@@ -160566,8 +160827,8 @@ fQs
 xfO
 sAB
 sXp
-neH
-eij
+gAP
+rAm
 nIC
 jAa
 lqj
@@ -160772,8 +161033,8 @@ hrn
 qSh
 lSi
 wFv
-sro
-jzd
+jEf
+lCs
 lEQ
 pIP
 cFb
@@ -160823,8 +161084,8 @@ fQs
 sfY
 vHb
 ief
-neH
-eij
+bVn
+qqk
 dtJ
 jAa
 whu
@@ -161028,7 +161289,7 @@ iMz
 xRc
 bkL
 lSi
-nCa
+jzd
 bbS
 rac
 pGm
@@ -161080,9 +161341,9 @@ fQs
 fda
 cqU
 jpN
-qQw
+bhM
 jrQ
-qQw
+neH
 jAa
 jbE
 nTy
@@ -161287,7 +161548,7 @@ qdZ
 lSi
 mss
 fMI
-jzd
+rOS
 mRH
 qgJ
 xAj
@@ -161337,8 +161598,8 @@ sAB
 sLe
 xEH
 ief
-neH
-eij
+sSk
+dQj
 neH
 jAa
 wSx
@@ -161543,8 +161804,8 @@ mOZ
 lSi
 lSi
 jfX
-sro
-jzd
+kJN
+tbu
 nfE
 qNA
 iGo
@@ -161594,8 +161855,8 @@ xly
 lcT
 ixe
 jpN
-neH
-eij
+jhU
+dHf
 ioR
 jAa
 lqj
@@ -161800,8 +162061,8 @@ iBV
 nff
 dNl
 jzd
-sro
-jzd
+iNi
+kuD
 nfE
 ftO
 kfd
@@ -161851,7 +162112,7 @@ fQs
 fQs
 uzh
 jpN
-euf
+ctk
 nop
 vGo
 xRU
@@ -163600,7 +163861,7 @@ fxn
 fxn
 fxn
 sro
-uck
+tFF
 pGm
 pGm
 iGo
@@ -163650,9 +163911,9 @@ fQs
 fQs
 ctJ
 jpN
-neH
-plF
-neH
+qQw
+ufi
+qQw
 jAa
 cwz
 xAr
@@ -164883,10 +165144,10 @@ bzb
 asA
 aIe
 wgo
-jzd
-pqA
-jzd
-nfE
+nCa
+vyr
+nCa
+pGm
 sZD
 sZD
 sZD
@@ -166168,7 +166429,7 @@ lHe
 lHe
 lHe
 lHe
-jzd
+mss
 pqA
 jzd
 nfE

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1108,12 +1108,6 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"auF" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "auK" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
@@ -2556,6 +2550,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
+"aWo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "aWy" = (
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/carpet/lone/star,
@@ -3678,6 +3679,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"bvL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bvV" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio8";
@@ -4058,19 +4068,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
-"bCQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "bCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4958,12 +4955,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
-"bWv" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "bWE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7248,6 +7239,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"cNE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "cNY" = (
 /obj/machinery/door/airlock{
 	name = "Aft Emergency Storage Hut"
@@ -8120,13 +8124,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"dgK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "dgU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8149,6 +8146,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"dhg" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dhk" = (
 /obj/structure/railing{
 	dir = 1
@@ -8991,12 +8994,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
-"dzi" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "dzy" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 1
@@ -10676,13 +10673,6 @@
 "egZ" = (
 /turf/open/floor/light/colour_cycle,
 /area/station/maintenance/starboard/central)
-"ehD" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "ehR" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
@@ -11555,18 +11545,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"eAV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "eBf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -14119,15 +14097,6 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
-"fyL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "fyZ" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
@@ -15514,6 +15483,18 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"fZr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fZz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16262,18 +16243,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"gpT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "gqA" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -17373,6 +17342,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"gMu" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gMF" = (
 /obj/machinery/computer/records/medical,
 /turf/open/floor/iron/white,
@@ -17947,18 +17922,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"gYI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "gYR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -19517,12 +19480,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/vaporwave,
 /area/station/science/lab)
-"hIg" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "hIo" = (
 /obj/item/trash/candle,
 /turf/open/floor/plating,
@@ -20506,6 +20463,18 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"icX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "idm" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Main Equipment"
@@ -20531,7 +20500,7 @@
 /area/station/hallway/primary/central/fore)
 "ief" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
+/obj/machinery/door/airlock/public/glass{
 	name = "Aft Biotube Station"
 	},
 /turf/open/floor/plating,
@@ -22310,15 +22279,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"iRv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "iRw" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Maintenance"
@@ -23237,6 +23197,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"jkS" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jle" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -25136,6 +25102,18 @@
 /obj/item/banner/red,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"jZm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jZs" = (
 /obj/structure/chair/sofa/bamboo/right,
 /turf/open/floor/iron/dark,
@@ -26635,6 +26613,12 @@
 "kAW" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"kAY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kBa" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/royalblack,
@@ -26874,6 +26858,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"kFT" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kFW" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -27045,6 +27035,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"kIS" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kIT" = (
 /obj/item/binoculars,
 /turf/open/floor/plating,
@@ -27454,12 +27450,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"kPK" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "kPU" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/structure/cable,
@@ -28331,16 +28321,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/chapel)
-"liH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "liW" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor,
 /obj/effect/turf_decal/delivery,
@@ -29530,12 +29510,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "lEQ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Biotube Station"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "lEX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29788,12 +29766,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
-"lIY" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "lJa" = (
 /obj/item/picket_sign,
 /turf/open/misc/asteroid,
@@ -32764,7 +32736,7 @@
 /area/station/security/courtroom)
 "mRH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
+/obj/machinery/door/airlock/public/glass{
 	name = "Fore Biotube Station"
 	},
 /turf/open/floor/plating,
@@ -33199,11 +33171,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"nbD" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "nbP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33606,6 +33573,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/neon/simple/red,
 /area/station/commons/dorms)
+"nio" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nit" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -33828,6 +33802,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"nov" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "noy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -35114,6 +35100,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"nOu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nOw" = (
 /obj/structure/table/wood,
 /obj/structure/displaycase/forsale/kitchen{
@@ -35698,6 +35693,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"oaf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oaw" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -36893,6 +36894,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"oyu" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oyC" = (
 /obj/structure/flora/rock/pile,
 /turf/open/water/jungle/biodome,
@@ -38014,6 +38021,15 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"oVE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oVH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -39462,12 +39478,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"pAv" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "pAz" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner,
 /turf/open/floor/iron/white/smooth_large,
@@ -40378,18 +40388,6 @@
 	},
 /turf/open/lava/plasma/biodome,
 /area/station/security/execution/education)
-"pUA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "pUC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40533,6 +40531,13 @@
 /obj/item/instrument/harmonica,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"pYA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pYG" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
@@ -41708,16 +41713,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"qvy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "qvC" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid,
@@ -41904,15 +41899,6 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/station/biodome/aft)
-"qzj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qzw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid,
@@ -42704,15 +42690,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/orange,
 /area/station/security/prison)
-"qOy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qOJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
@@ -42799,12 +42776,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"qPY" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "qPZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -43133,6 +43104,15 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"qVM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qVP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -43309,6 +43289,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"qYi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qYn" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet,
@@ -44183,6 +44173,16 @@
 "rps" = (
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
+"rpy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rpA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44636,6 +44636,12 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/station/hallway/secondary/service)
+"rxU" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rxV" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -47017,16 +47023,6 @@
 	dir = 8
 	},
 /area/station/commons/storage/art)
-"syF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "syG" = (
 /turf/closed/wall,
 /area/station/tcommsat/computer)
@@ -47299,12 +47295,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/hydroponics)
-"sEk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "sET" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
@@ -49076,12 +49066,6 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"tmA" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "tmB" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -52446,6 +52430,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"uKv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uKD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52518,12 +52511,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"uLM" = (
+"uLY" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "L1"
+	icon_state = "L4"
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/central/fore)
 "uMc" = (
 /obj/structure/holosign/barrier/atmos/sturdy,
 /turf/open/floor/plating/plasma,
@@ -53871,13 +53864,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
-"vnM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "vnQ" = (
 /obj/structure/sign/painting/library{
 	pixel_x = -32
@@ -54277,6 +54263,18 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"vwD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vwN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -56439,6 +56437,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"wni" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wnj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/photosynthetic,
@@ -56879,6 +56883,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"wwz" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wwD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57266,6 +57276,16 @@
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"wCQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wDd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -58604,24 +58624,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/research)
-"xcL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
-"xcR" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "xdw" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
@@ -59062,15 +59064,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"xni" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "xnk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -157231,7 +157224,7 @@ fQs
 jpN
 neH
 swn
-nbD
+lEQ
 vxC
 dST
 dST
@@ -158463,7 +158456,7 @@ nso
 pGx
 phW
 nCa
-liH
+qYi
 nCa
 pGm
 ggF
@@ -158515,7 +158508,7 @@ uyN
 hjh
 jpN
 fQl
-syF
+wCQ
 qQw
 jKM
 jKM
@@ -159235,7 +159228,7 @@ xIb
 oKS
 jzd
 kME
-vnM
+aWo
 pGm
 ggF
 fgk
@@ -160519,8 +160512,8 @@ cSp
 pGx
 phW
 dSl
-gYI
-hIg
+vwD
+kIS
 nfE
 iOT
 rGt
@@ -160570,8 +160563,8 @@ fQs
 fQs
 pEf
 sXp
-uLM
-xni
+jkS
+oVE
 neH
 dfj
 lqj
@@ -160776,8 +160769,8 @@ aMm
 chi
 lSi
 jzd
-pUA
-lIY
+jZm
+uLY
 pGm
 uHs
 wsv
@@ -160827,8 +160820,8 @@ fQs
 xfO
 sAB
 sXp
-kPK
-iRv
+oaf
+qVM
 nIC
 jAa
 lqj
@@ -161033,9 +161026,9 @@ hrn
 qSh
 lSi
 wFv
-eAV
-pAv
-lEQ
+icX
+kFT
+mRH
 pIP
 cFb
 sZD
@@ -161084,8 +161077,8 @@ fQs
 sfY
 vHb
 ief
-tmA
-qzj
+gMu
+bvL
 dtJ
 jAa
 whu
@@ -161341,7 +161334,7 @@ fQs
 fda
 cqU
 jpN
-xcR
+dhg
 jrQ
 neH
 jAa
@@ -161548,7 +161541,7 @@ qdZ
 lSi
 mss
 fMI
-dzi
+rxU
 mRH
 qgJ
 xAj
@@ -161598,8 +161591,8 @@ sAB
 sLe
 xEH
 ief
-sEk
-fyL
+wwz
+nOu
 neH
 jAa
 wSx
@@ -161804,8 +161797,8 @@ mOZ
 lSi
 lSi
 jfX
-gpT
-qPY
+fZr
+wni
 nfE
 qNA
 iGo
@@ -161855,8 +161848,8 @@ xly
 lcT
 ixe
 jpN
-auF
-qOy
+oyu
+uKv
 ioR
 jAa
 lqj
@@ -162061,8 +162054,8 @@ iBV
 nff
 dNl
 jzd
-xcL
-bWv
+nov
+kAY
 nfE
 ftO
 kfd
@@ -162112,7 +162105,7 @@ fQs
 fQs
 uzh
 jpN
-ehD
+nio
 nop
 vGo
 xRU
@@ -163861,7 +163854,7 @@ fxn
 fxn
 fxn
 sro
-dgK
+pYA
 pGm
 pGm
 iGo
@@ -163912,7 +163905,7 @@ fQs
 ctJ
 jpN
 qQw
-bCQ
+cNE
 qQw
 jAa
 cwz
@@ -165145,7 +165138,7 @@ asA
 aIe
 wgo
 nCa
-qvy
+rpy
 nCa
 pGm
 sZD

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1108,6 +1108,12 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"auF" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "auK" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
@@ -3036,12 +3042,6 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/engine/hull,
 /area/station/asteroid)
-"bhM" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "bhN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4058,6 +4058,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"bCQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4911,12 +4924,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"bVn" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "bVF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -4951,6 +4958,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"bWv" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bWE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -6022,13 +6035,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"ctk" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "ctr" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
@@ -8114,6 +8120,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"dgK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dgU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8191,13 +8204,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"dhV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "die" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/engineering/vending_restock,
@@ -8985,6 +8991,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
+"dzi" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dzy" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 1
@@ -9431,15 +9443,6 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"dHf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "dHl" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/west,
@@ -9741,12 +9744,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"dOd" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "dOh" = (
 /obj/item/holosign_creator/robot_seat/bar,
 /obj/structure/table/wood,
@@ -9825,15 +9822,6 @@
 /obj/effect/turf_decal/siding/dark_green/corner,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
-"dQj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "dQs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -10688,6 +10676,13 @@
 "egZ" = (
 /turf/open/floor/light/colour_cycle,
 /area/station/maintenance/starboard/central)
+"ehD" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ehR" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
@@ -11560,6 +11555,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"eAV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "eBf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -12018,18 +12025,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"eJH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "eJI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Warehouse Maintenance"
@@ -14085,11 +14080,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"fxt" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "fxx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -14129,6 +14119,15 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"fyL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fyZ" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
@@ -14538,12 +14537,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"fIe" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "fIK" = (
 /obj/effect/turf_decal/tile/dark_red/anticorner{
 	dir = 1
@@ -15234,16 +15227,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"fUm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "fUq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16279,6 +16262,18 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"gpT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "gqA" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -16878,12 +16873,6 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
-"gAP" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "gBb" = (
 /obj/structure/flora/bush/leafy,
 /mob/living/basic/cockroach,
@@ -17958,6 +17947,18 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"gYI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "gYR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -19516,6 +19517,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/vaporwave,
 /area/station/science/lab)
+"hIg" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hIo" = (
 /obj/item/trash/candle,
 /turf/open/floor/plating,
@@ -20525,7 +20532,7 @@
 "ief" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	name = "Not A Shortcut"
+	name = "Aft Biotube Station"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
@@ -22165,18 +22172,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research)
-"iNi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "iND" = (
 /obj/structure/chair{
 	dir = 1
@@ -22315,6 +22310,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"iRv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iRw" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Maintenance"
@@ -23087,12 +23091,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
-"jhU" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "jhZ" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
@@ -24129,18 +24127,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"jEf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "jED" = (
 /turf/open/floor/circuit/green{
 	luminosity = 2
@@ -26308,12 +26294,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
-"kuy" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "kuz" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -26322,12 +26302,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"kuD" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "kuJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -27131,18 +27105,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/grass,
 /area/station/maintenance/aft/upper)
-"kJN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "kJT" = (
 /obj/item/paper_bin/bundlenatural,
 /turf/open/misc/asteroid/airless,
@@ -27492,6 +27454,12 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"kPK" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kPU" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/structure/cable,
@@ -28363,6 +28331,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/chapel)
+"liH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "liW" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor,
 /obj/effect/turf_decal/delivery,
@@ -29432,12 +29410,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/fakebasalt,
 /area/station/security/brig/entrance)
-"lCs" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "lCx" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics"
@@ -29559,7 +29531,7 @@
 /area/station/engineering/engine_smes)
 "lEQ" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Not A Shortcut"
+	name = "Fore Biotube Station"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -29816,6 +29788,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
+"lIY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lJa" = (
 /obj/item/picket_sign,
 /turf/open/misc/asteroid,
@@ -32787,7 +32765,7 @@
 "mRH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	name = "Not A Shortcut"
+	name = "Fore Biotube Station"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
@@ -33221,6 +33199,11 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nbD" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nbP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39479,6 +39462,12 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"pAv" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pAz" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner,
 /turf/open/floor/iron/white/smooth_large,
@@ -40389,6 +40378,18 @@
 	},
 /turf/open/lava/plasma/biodome,
 /area/station/security/execution/education)
+"pUA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pUC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -41483,15 +41484,6 @@
 "qpX" = (
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
-"qqk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qqy" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
@@ -41716,6 +41708,16 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"qvy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qvC" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid,
@@ -41902,6 +41904,15 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/station/biodome/aft)
+"qzj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qzw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid,
@@ -42175,16 +42186,6 @@
 /obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"qDE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "qDI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/rnd/server,
@@ -42541,15 +42542,6 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"qLl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qLq" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
@@ -42712,6 +42704,15 @@
 /obj/structure/table,
 /turf/open/floor/carpet/orange,
 /area/station/security/prison)
+"qOy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qOJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
@@ -42798,6 +42799,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"qPY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qPZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -44763,15 +44770,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"rAm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "rAn" = (
 /turf/closed/wall,
 /area/station/cargo/lobby)
@@ -45358,12 +45356,6 @@
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rOS" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "rPb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -47025,6 +47017,16 @@
 	dir = 8
 	},
 /area/station/commons/storage/art)
+"syF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "syG" = (
 /turf/closed/wall,
 /area/station/tcommsat/computer)
@@ -47297,6 +47299,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/hydroponics)
+"sEk" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sET" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
@@ -47997,12 +48005,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/bridge)
-"sSk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "sSm" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/titanium,
@@ -48459,12 +48461,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
-"tbu" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "tbw" = (
 /turf/closed/wall,
 /area/station/biodome)
@@ -49080,6 +49076,12 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"tmA" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "tmB" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -50012,13 +50014,6 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
-"tFF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "tFG" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -50269,18 +50264,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"tKx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "tKB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electric_shock,
@@ -51121,19 +51104,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"ufi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "ufj" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -52548,6 +52518,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"uLM" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uMc" = (
 /obj/structure/holosign/barrier/atmos/sturdy,
 /turf/open/floor/plating/plasma,
@@ -53895,6 +53871,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"vnM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vnQ" = (
 /obj/structure/sign/painting/library{
 	pixel_x = -32
@@ -54351,16 +54334,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"vyr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "vyt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58631,6 +58604,24 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/research)
+"xcL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"xcR" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xdw" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
@@ -59071,6 +59062,15 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"xni" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xnk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -157231,7 +157231,7 @@ fQs
 jpN
 neH
 swn
-fxt
+nbD
 vxC
 dST
 dST
@@ -158463,7 +158463,7 @@ nso
 pGx
 phW
 nCa
-qDE
+liH
 nCa
 pGm
 ggF
@@ -158515,7 +158515,7 @@ uyN
 hjh
 jpN
 fQl
-fUm
+syF
 qQw
 jKM
 jKM
@@ -159235,7 +159235,7 @@ xIb
 oKS
 jzd
 kME
-dhV
+vnM
 pGm
 ggF
 fgk
@@ -160519,8 +160519,8 @@ cSp
 pGx
 phW
 dSl
-eJH
-dOd
+gYI
+hIg
 nfE
 iOT
 rGt
@@ -160570,8 +160570,8 @@ fQs
 fQs
 pEf
 sXp
-kuy
-qLl
+uLM
+xni
 neH
 dfj
 lqj
@@ -160776,8 +160776,8 @@ aMm
 chi
 lSi
 jzd
-tKx
-fIe
+pUA
+lIY
 pGm
 uHs
 wsv
@@ -160827,8 +160827,8 @@ fQs
 xfO
 sAB
 sXp
-gAP
-rAm
+kPK
+iRv
 nIC
 jAa
 lqj
@@ -161033,8 +161033,8 @@ hrn
 qSh
 lSi
 wFv
-jEf
-lCs
+eAV
+pAv
 lEQ
 pIP
 cFb
@@ -161084,8 +161084,8 @@ fQs
 sfY
 vHb
 ief
-bVn
-qqk
+tmA
+qzj
 dtJ
 jAa
 whu
@@ -161341,7 +161341,7 @@ fQs
 fda
 cqU
 jpN
-bhM
+xcR
 jrQ
 neH
 jAa
@@ -161548,7 +161548,7 @@ qdZ
 lSi
 mss
 fMI
-rOS
+dzi
 mRH
 qgJ
 xAj
@@ -161598,8 +161598,8 @@ sAB
 sLe
 xEH
 ief
-sSk
-dQj
+sEk
+fyL
 neH
 jAa
 wSx
@@ -161804,8 +161804,8 @@ mOZ
 lSi
 lSi
 jfX
-kJN
-tbu
+gpT
+qPY
 nfE
 qNA
 iGo
@@ -161855,8 +161855,8 @@ xly
 lcT
 ixe
 jpN
-jhU
-dHf
+auF
+qOy
 ioR
 jAa
 lqj
@@ -162061,8 +162061,8 @@ iBV
 nff
 dNl
 jzd
-iNi
-kuD
+xcL
+bWv
 nfE
 ftO
 kfd
@@ -162112,7 +162112,7 @@ fQs
 fQs
 uzh
 jpN
-ctk
+ehD
 nop
 vGo
 xRU
@@ -163861,7 +163861,7 @@ fxn
 fxn
 fxn
 sro
-tFF
+dgK
 pGm
 pGm
 iGo
@@ -163912,7 +163912,7 @@ fQs
 ctJ
 jpN
 qQw
-ufi
+bCQ
 qQw
 jAa
 cwz
@@ -165145,7 +165145,7 @@ asA
 aIe
 wgo
 nCa
-vyr
+qvy
 nCa
 pGm
 sZD


### PR DESCRIPTION
- Adds the missing "SPACE STATION 13" plaque to Biodome. Two instances, one outside of each biotube dock.
- Moved some firelocks to make space for the plaques.
- Lit up a dark spot near the "zoo".
- Renamed the doors leading to the biotube stations, and made them into glass airlocks rather than maint ones.