### PR TITLE
Map voting upon shuttle arrival.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -181,7 +181,8 @@ SUBSYSTEM_DEF(vote)
 	var/to_display = current_vote.initiate_vote(vote_initiator_name, duration)
 
 	log_vote(to_display)
-	to_chat(world, span_infoplain(vote_font("\n[span_bold(to_display)]\n\
+	//ORBSTATION EDIT - MADE TITLE BIGGER
+	to_chat(world, span_infoplain(vote_font("\n[span_minorannounce(to_display)]\n\
 		Type <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\n\
 		You have [DisplayTimeText(duration)] to vote.")))
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -511,7 +511,8 @@
 				setTimer(SSshuttle.emergency_escape_time * engine_coeff)
 				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
-				SSmapping.mapvote() //If no map vote has been run yet, start one.
+				//ORBSTATION REMOVAL
+				//SSmapping.mapvote() //If no map vote has been run yet, start one.
 
 		if(SHUTTLE_STRANDED, SHUTTLE_DISABLED)
 			SSshuttle.checkHostileEnvironment()
@@ -558,6 +559,7 @@
 				dock_id(destination_dock)
 				mode = SHUTTLE_ENDGAME
 				timer = 0
+				SSmapping.mapvote() //ORBSTATION ADDITION - voting when the round ENDS
 
 /obj/docking_port/mobile/emergency/transit_failure()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In a minor, but important, change, automatic map voting will now occur at the end of the round instead of near the end - specifically, the map vote will pop up only when the emergency shuttle _docks_ rather than when it leaves the station. Otherwise, map voting functions exactly the same. This _does_ function regardless of whether the shuttle docks at CentCom or the Syndicate base.

As an extra quality of life bonus, map voting now has a larger header that is much more obvious in the chat.

![image](https://user-images.githubusercontent.com/105025397/223027943-a77bd089-265f-404d-a458-575458daa215.png)

This change may ideally be accompanied by a config change to make the map voting period slightly longer - possibly a minute and a half. To ensure everything functions properly, this would be accompanied by a slight extension of the end-of-round timer, maybe a minute at most.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's been obvious for a while that map voting occurs at one of the most inopportune times possible. Voting when the shuttle leaves the station is all well and good when the shuttle ride is perfectly calm and orderly... but how often does _that_ happen? The shuttle ride is part of the round, and can be rather intense - especially when antags attempt to hijack. It doesn't seem fair to leave people out of the map vote because they were too busy playing the game.

While people do still tend to finish up RPing and such once the shuttle arrives, as far as I'm concerned, the end screen popping up indicates the end of the round. Coupled with the more obvious announcement of the vote and the probable extension of the map voting timer, this should give everyone enough time and notice to vote for a map that wants to.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The map vote happens when the end screen pops up, and its announcement is more obvious
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
