### PR TITLE
Wizard Tweaks

### DIFF
--- a/orbstation/code/antagonists/grand_ritual.dm
+++ b/orbstation/code/antagonists/grand_ritual.dm
@@ -47,15 +47,3 @@
 
 /datum/grand_finale/armageddon/death_yell(mob/living/carbon/human/invoker)
 	priority_announce(pick(possible_last_words + orb_last_words), null, 'sound/magic/voidblink.ogg', sender_override = "[invoker.real_name]")
-
-#define RITUAL_EXTRA_TIME 3 MINUTES
-
-// Extend active shuttle timers
-/obj/effect/grand_rune/on_invocation_complete(mob/living/user)
-	if (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED))
-		SSshuttle.emergency.setTimer(SSshuttle.emergency.timeLeft(1) + RITUAL_EXTRA_TIME)
-		var/time_left = SSshuttle.emergency.timeLeft()
-		priority_announce("Unexpected interference with shuttle routing calculations. [SSshuttle.emergency.mode == SHUTTLE_CALL ? "arrival" : "departure"] will now occur in an estimated [(time_left / 60) % 60]:[add_leading(num2text(time_left % 60), 2, "0")] minutes.", sound = ANNOUNCER_SPANOMALIES)
-	return ..()
-
-#undef RITUAL_EXTRA_TIME

--- a/orbstation/code/antagonists/grand_ritual.dm
+++ b/orbstation/code/antagonists/grand_ritual.dm
@@ -47,3 +47,11 @@
 
 /datum/grand_finale/armageddon/death_yell(mob/living/carbon/human/invoker)
 	priority_announce(pick(possible_last_words + orb_last_words), null, 'sound/magic/voidblink.ogg', sender_override = "[invoker.real_name]")
+
+// Don't summon people off the emergency shuttle
+/datum/grand_side_effect/summon_crewmate/is_valid_crewmate(mob/living/carbon/human/crewmate, area/our_area)
+	. = ..()
+	if (!.)
+		return FALSE
+
+	return is_station_level(crewmate.z) || is_mining_level(crewmate.z)


### PR DESCRIPTION
## About The Pull Request

- The grand ritual will no longer extend the shuttle timer.
- The "summon crewmate" side effect will now only target people on the station or who are mining.

## Why It's Good For The Game

We tried this as an experiment and it doesn't really bear out to have any clear upsides.
Also as much as I think grabbing people off the shuttle is funny, it's kind of only funny once or twice.

## Changelog

:cl:
balance: Wizard rituals will no longer delay the arrival or departure of the emergency shuttle
balance: Wizard rituals can no longer pull somoene who escaped back off of the shuttle
/:cl:
