### PR TITLE
Lone ops as a regular, non-scaling event.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -66,6 +66,7 @@
 		/datum/round_event_control/immovable_rod,
 		/datum/round_event_control/meteor_wave,
 		/datum/round_event_control/portal_storm_syndicate,
+		/datum/round_event_control/operative, //ORBSTATION ADDITION
 	)
 	var/list/picked_events = list()
 	for(var/type in unfavorable_random_events)

--- a/orbstation/code/antagonists/lone_operative.dm
+++ b/orbstation/code/antagonists/lone_operative.dm
@@ -1,0 +1,12 @@
+//Give the lone op three minutes to get set up before they have a chance of having their presence announced
+#define LONEOP_ANNOUNCE_DELAY = 180
+
+/datum/round_event_control/operative
+	weight = 5 //may need adjusting, lone op should be rare but not nonexistent
+
+//The nuke disk no longer changes the weight of lone op.
+/obj/item/disk/nuclear/secured_process(last_move)
+	return
+
+/obj/item/disk/nuclear/unsecured_process(last_move)
+	return

--- a/orbstation/code/antagonists/lone_operative.dm
+++ b/orbstation/code/antagonists/lone_operative.dm
@@ -1,6 +1,7 @@
 /datum/round_event_control/operative
 	weight = 5 //May need adjusting, lone op should be rare but not nonexistent.
 	min_players = 15 //We probably don't want lone ops at extremely low population.
+	earliest_start = 20 MINUTES
 
 //The nuke disk no longer changes the weight of lone op.
 /obj/item/disk/nuclear/secured_process(last_move)

--- a/orbstation/code/antagonists/lone_operative.dm
+++ b/orbstation/code/antagonists/lone_operative.dm
@@ -1,8 +1,6 @@
-//Give the lone op three minutes to get set up before they have a chance of having their presence announced
-#define LONEOP_ANNOUNCE_DELAY = 180
-
 /datum/round_event_control/operative
-	weight = 5 //may need adjusting, lone op should be rare but not nonexistent
+	weight = 5 //May need adjusting, lone op should be rare but not nonexistent.
+	min_players = 15 //We probably don't want lone ops at extremely low population.
 
 //The nuke disk no longer changes the weight of lone op.
 /obj/item/disk/nuclear/secured_process(last_move)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5119,6 +5119,7 @@
 #include "orbstation\code\antagonists\acting_captain_check.dm"
 #include "orbstation\code\antagonists\blood_brothers.dm"
 #include "orbstation\code\antagonists\grand_ritual.dm"
+#include "orbstation\code\antagonists\lone_operative.dm"
 #include "orbstation\code\antagonists\mindshield.dm"
 #include "orbstation\code\antagonists\rulesets_latejoin.dm"
 #include "orbstation\code\antagonists\rulesets_midround.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This (experimental) change makes the Lone Operative event have a flat weight of 5, rather than scaling up gradually while the disk is unsecured and back down while it's secured. In fact, the only thing securing the disk does now is keep the disk secured! Which is still good to do.

In addition to this, a few other minor changes:
- Lone Operative requires 15 players on the server to run. There are no other requirements, so this shouldn't be too strict, but lone op with an extremely lowpop station feels like overkill to me.
- Lone Operative will not run until 20 minutes have passed. An edge case maybe, but it doesn't sound fun to get interrupted by imminent nuking when you're still, like, getting your blorbo dressed.
- Lone Operative can run when a traitor calls in an unfavorable situation. I'm not completely certain if this will work correctly since other unfavorable situations don't require ghosts - if this makes unfavorable situation do nothing, admins should probably just set off a meteor wave or something.

As these changes are experimental and may need adjusting, this PR may be reverted as necessary.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've long been of the opinion that the spawn conditions for Lone Operative are kind of silly. The person who has to steal the disk and blow up the station can only show up... if the disk happens to be sitting in a conveniently empty room because someone forgot to pick it up. This makes it incredibly easy for a lone op to take the disk and turn on the nuke - and sometimes this still leads to fun and wild situations, but more variety would be nice. This change means that a lone op might attack _regardless_ of whether the disk is secured, so whoever's holding it (if anyone) needs to stay on their toes.

This is also somewhat important due to our recent changes to acting captain. If no one has the captain's ID, which is otherwise usually fine, it means the disk is unattended in the captain's office - which frequently leads to lone op spawns beyond what is expected. Removing that element from the lone op event means that they won't be _too_ common while still being a possible big threat.

Also, because I'm petty, this means that admins won't be spammed with messages about the disk being unsecured.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: the Lone Operative event now has a flat weight rather than a scaling one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
