### PR TITLE
Nuclear operatives have randomized species.

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -34,7 +34,13 @@
 	if(!nukeop_outfit) // this variable is null in instances where an antagonist datum is granted via enslaving the mind (/datum/mind/proc/enslave_mind_to_creator), like in golems.
 		return
 
-	operative.set_species(/datum/species/human) //Plasmamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.
+	//ORBSTATION EDIT - Nukies can be multiple species picked from a whitelist. This cannot go upstream due to Asimov AI policy.
+	var/datum/species/nukie_species = pick(GLOB.nukeops_species_whitelist)
+	if(nukie_species)
+		operative.set_species(nukie_species)
+	else
+		operative.set_species(/datum/species/human) //just in case
+	//END ORBSTATION EDIT
 
 	operative.equipOutfit(nukeop_outfit)
 	return TRUE

--- a/orbstation/code/_global/nuclear_operative.dm
+++ b/orbstation/code/_global/nuclear_operative.dm
@@ -1,0 +1,7 @@
+GLOBAL_LIST_INIT(nukeops_species_whitelist, list(
+	/datum/species/human,
+	/datum/species/human/felinid,
+	/datum/species/lizard,
+	/datum/species/moth,
+	/datum/species/ratfolk,
+))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5111,6 +5111,7 @@
 #include "interface\skin.dmf"
 #include "orbstation\code\_global\categories.dm"
 #include "orbstation\code\_global\moth_colors.dm"
+#include "orbstation\code\_global\nuclear_operative.dm"
 #include "orbstation\code\_global\pod_bloodtypes.dm"
 #include "orbstation\code\_global\traits.dm"
 #include "orbstation\code\_global\wizard_journeyman.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When nuclear operatives (including Lone Op!) spawn, they will now receive a randomized species from a defined whitelist. This whitelist contains humans, felinids, moths, lizards, and ratfolk. Other roundstart species have been included due to having notably different mechanics that might make things weird, though the list can be expanded if desired.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/105025397/223924179-bf8bd43d-79a0-4530-bb61-a4d3c0b52bbd.png)
Looks cool.

Also, the reasons given for Nukies being only human upstream are:
a) Balance concerns for Plasmaman nukies.
b) Asimov AIs.

As I've introduced a whitelist to prevent mechanics problems, and Asimov policy on our server includes all roundstart species, neither of these is a concern. Thus, there's no reason _not_ to change the fact that the Syndicate only sends humans to blow up space stations for some reason.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nuclear Operative species is now randomized on spawn, from a whitelist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
