### PR TITLE
bakery crate didnt have weight now it does

### DIFF
--- a/orbstation/code/jobs/cargo/pizza.dm
+++ b/orbstation/code/jobs/cargo/pizza.dm
@@ -99,7 +99,7 @@
 
 /datum/supply_pack/organic/randomized/dough/fill(obj/structure/closet/crate/newcrate)
 	for(var/i in 1 to 10)
-		var/item = pick(contains)
+		var/item = pick_weight(contains)
 		new item(newcrate)
 
 /obj/item/pizzabox/mothic_margherita


### PR DESCRIPTION
## About The Pull Request

title

## Changelog

:cl:
fix: bakery crates no longer wastefully send the same amount of mothic pizza dough as other kinds of dough
/:cl: