### PR TITLE
Birthday biodome update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1092,6 +1092,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/research)
+"atU" = (
+/obj/structure/sign/picture_frame/showroom/one{
+	pixel_y = 32
+	},
+/turf/open/floor/eighties,
+/area/station/hallway/secondary/exit/departure_lounge)
 "atZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Courtroom Holding Area"
@@ -1812,6 +1818,11 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
+"aHS" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/grass,
+/area/station/biodome/fore)
 "aHZ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3197,6 +3208,7 @@
 /area/station/cargo/miningdock)
 "bjW" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "bkh" = (
@@ -3335,6 +3347,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"bmc" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "bmm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -5924,6 +5940,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "cqU" = (
 /obj/structure/sign/clock/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/noslip,
 /area/station/biodome/aft)
 "cqY" = (
@@ -9728,6 +9745,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dNn" = (
@@ -10758,12 +10776,6 @@
 "ejf" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"ejg" = (
-/obj/item/wallframe/picture{
-	pixel_y = 32
-	},
-/turf/open/floor/eighties,
-/area/station/hallway/secondary/exit/departure_lounge)
 "ejh" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/disposalpipe/segment{
@@ -13575,6 +13587,7 @@
 "fnr" = (
 /obj/structure/bed/maint,
 /obj/effect/decal/remains/human,
+/obj/effect/landmark/start/hangover,
 /turf/open/misc/ashplanet/wateryrock/biodome,
 /area/station/biodome/aft)
 "fnz" = (
@@ -13965,6 +13978,14 @@
 "fuu" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/radshelter/civil)
+"fuM" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fuP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -18019,6 +18040,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"haT" = (
+/obj/structure/sign/picture_frame/showroom/four{
+	pixel_y = 32
+	},
+/turf/open/floor/eighties,
+/area/station/hallway/secondary/exit/departure_lounge)
 "haU" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
@@ -21588,6 +21615,13 @@
 "iAO" = (
 /turf/open/floor/iron/vaporwave,
 /area/station/science/lab)
+"iAV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "iAY" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/loading_area/white,
@@ -24905,13 +24939,6 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/chapel)
-"jVu" = (
-/obj/item/wallframe/picture{
-	pixel_y = 32
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/eighties,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jVv" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -28151,6 +28178,12 @@
 /obj/structure/bonfire/dense,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"lel" = (
+/obj/structure/sign/picture_frame/showroom/three{
+	pixel_y = 32
+	},
+/turf/open/floor/eighties,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lep" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -28416,6 +28449,7 @@
 /area/station/engineering/gravity_generator)
 "lke" = (
 /obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
 "lkg" = (
@@ -28741,6 +28775,22 @@
 "lqG" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
+/obj/structure/table,
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/hand_labeler,
+/obj/item/toner,
+/obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lqI" = (
@@ -33028,6 +33078,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/chapel)
 "mYc" = (
@@ -35033,6 +35084,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"nMj" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/station/cargo/lobby)
 "nMm" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/floor,
@@ -36916,6 +36971,7 @@
 /obj/structure/closet/emcloset{
 	name = "annoying emergency closet"
 	},
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
 "oyk" = (
@@ -37072,6 +37128,7 @@
 "oAj" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oAm" = (
@@ -38459,6 +38516,7 @@
 	},
 /obj/item/multitool,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/wood,
 /area/station/cargo/office)
 "pdG" = (
@@ -41617,6 +41675,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
 /area/station/security/prison)
+"qsh" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/biodome)
 "qsv" = (
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
@@ -42320,6 +42382,7 @@
 "qGx" = (
 /obj/structure/flora/bush/jungle/c/style_random,
 /obj/item/stack/rods/twentyfive,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
 "qGD" = (
@@ -44420,6 +44483,12 @@
 "rtw" = (
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
+"rty" = (
+/obj/structure/sign/picture_frame/showroom/two{
+	pixel_y = 32
+	},
+/turf/open/floor/eighties,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rtB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -44533,6 +44602,11 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"rvx" = (
+/obj/structure/chair/sofa/bamboo,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
 "rvE" = (
 /obj/structure/closet{
 	name = "Evidence Closet 2"
@@ -46576,6 +46650,13 @@
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"snK" = (
+/obj/structure/chair/sofa/bamboo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "snL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -47070,6 +47151,7 @@
 "syR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sza" = (
@@ -49594,6 +49676,10 @@
 "txv" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"txw" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "txM" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun{
@@ -55835,6 +55921,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"wcs" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/station/biodome/aft)
 "wcB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56858,6 +56948,7 @@
 "wuP" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wuR" = (
@@ -59031,6 +59122,7 @@
 "xkU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_green/full,
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "xkX" = (
@@ -59938,6 +60030,11 @@
 	},
 /turf/open/floor/noslip,
 /area/station/biodome/aft)
+"xEP" = (
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xEV" = (
 /obj/structure/chair/bronze{
 	dir = 4
@@ -61000,6 +61097,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "xXz" = (
@@ -88897,7 +88995,7 @@ ktR
 ktR
 ktR
 eIi
-frW
+txw
 rBj
 ktR
 ktR
@@ -90150,7 +90248,7 @@ haP
 haP
 haP
 haP
-mov
+aHS
 dit
 eBC
 eBC
@@ -96608,7 +96706,7 @@ uBO
 bdX
 bdX
 rmE
-sAB
+wcs
 ota
 aUW
 frW
@@ -98904,7 +99002,7 @@ auR
 auR
 auR
 auR
-asD
+niN
 asD
 lCA
 ngd
@@ -100958,7 +101056,7 @@ oHx
 vEK
 abE
 fNG
-qKr
+bmc
 gHP
 doI
 qlZ
@@ -103009,7 +103107,7 @@ qKr
 qKr
 bJY
 hDB
-hDB
+qsh
 hDB
 qKr
 qKr
@@ -106383,7 +106481,7 @@ kdK
 dQX
 enZ
 oqE
-teO
+snK
 sbp
 tIP
 dms
@@ -155983,7 +156081,7 @@ fQs
 fQs
 jpN
 aEf
-swn
+fuM
 nIC
 vxC
 dST
@@ -167754,7 +167852,7 @@ xys
 rWo
 jzd
 pqA
-jzd
+kLA
 nfE
 sZD
 sZD
@@ -169058,7 +169156,7 @@ jzd
 jzd
 nCa
 jzd
-jzd
+kLA
 jzd
 jzd
 jzd
@@ -169603,7 +169701,7 @@ neH
 bFh
 neH
 jdW
-neH
+gJo
 oAm
 uCA
 cEV
@@ -170080,7 +170178,7 @@ xIJ
 tLj
 pGm
 qfh
-jzd
+kLA
 mbe
 idP
 gDN
@@ -170092,7 +170190,7 @@ aha
 cjF
 pGm
 bGv
-tiN
+iAV
 bGv
 eZB
 dfk
@@ -171095,7 +171193,7 @@ xdO
 xdO
 nHe
 sGo
-pmV
+xEP
 xdO
 ovE
 ovE
@@ -171346,7 +171444,7 @@ kcO
 cZC
 kcO
 jpl
-tYp
+atU
 xdO
 bIQ
 euh
@@ -171603,7 +171701,7 @@ gPr
 oLp
 oLp
 jpl
-ejg
+tYp
 xdO
 tWy
 qxL
@@ -171860,7 +171958,7 @@ apJ
 vwm
 xvs
 jpl
-tYp
+rty
 xdO
 bJR
 euh
@@ -172117,7 +172215,7 @@ gkL
 xaF
 oLp
 jpl
-jVu
+rQb
 xdO
 iXN
 qLq
@@ -172137,7 +172235,7 @@ hNy
 rAn
 rAn
 hKx
-wlo
+nMj
 wlo
 jnX
 tNi
@@ -172374,7 +172472,7 @@ oLp
 oLp
 oLp
 jpl
-tYp
+lel
 xdO
 bUG
 vEr
@@ -172434,7 +172532,7 @@ uJh
 svB
 syv
 dmf
-dmf
+rvx
 nzQ
 nUl
 nUl
@@ -172631,7 +172729,7 @@ ijH
 wZn
 cZC
 jpl
-ejg
+tYp
 xdO
 ron
 euh
@@ -172888,7 +172986,7 @@ jpl
 jpl
 jpl
 jpl
-tYp
+haT
 xdO
 xdO
 xdO


### PR DESCRIPTION
 - added birthday wrappers and birthday cake ingredient spawners to the biodome
- previously missing public mail supplies have been added to the cargo lobby
- portraits outside the Employee Of The Shift Celebration Chamber now carry over between rounds (same IDs as the metastation portraits in the showroom)
- added more hangover spawn spots (this is also used by birthdays!)