### PR TITLE
Biodome locks

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1434,13 +1434,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"aAA" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 5
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/reinforced,
-/area/station/maintenance/radshelter/civil)
 "aAD" = (
 /obj/structure/sign/clock/directional/south,
 /turf/open/floor/iron/grimy,
@@ -4455,6 +4448,13 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"bLR" = (
+/obj/structure/stairs/wood,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/closed/wall/mineral/wood,
+/area/station/biodome)
 "bLU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4926,6 +4926,12 @@
 /obj/item/folder/yellow,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"bVc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "bVg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -5576,6 +5582,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cix" = (
@@ -6186,6 +6193,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
+"cvl" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "cvI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -6551,11 +6564,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "cAW" = (
-/obj/structure/stairs/wood,
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/iron/stairs/right,
+/turf/open/floor/wood/stairs,
 /area/station/biodome)
 "cAZ" = (
 /obj/machinery/flasher/portable,
@@ -6856,13 +6868,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"cGg" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
-/area/station/maintenance/radshelter/civil)
 "cGo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -7134,6 +7139,13 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"cKv" = (
+/obj/structure/stairs/wood,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/closed/wall/mineral/wood,
+/area/station/biodome)
 "cKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -7187,11 +7199,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"cLV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/reinforced,
-/area/station/maintenance/radshelter/civil)
 "cMg" = (
 /obj/structure/chair/sofa/bench/tram/right{
 	dir = 8
@@ -10932,13 +10939,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "enj" = (
-/obj/structure/stairs/wood{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/wood/stairs/left,
 /area/station/biodome/aft)
 "enk" = (
 /obj/machinery/door/airlock/research/glass{
@@ -17454,12 +17458,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "gNF" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/diagonal,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "gNZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -17553,13 +17553,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"gQa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/reinforced,
-/area/station/maintenance/radshelter/civil)
 "gQd" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/siding/green{
@@ -17743,13 +17736,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"gTA" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
-/area/station/maintenance/radshelter/civil)
 "gTD" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -18356,7 +18342,7 @@
 "hhr" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Medbay Delivery";
-	req_access = list("medbay")
+	req_access = list("medical")
 	},
 /turf/open/floor/iron/terracotta,
 /area/station/medical/storage)
@@ -21896,13 +21882,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"iGn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/reinforced,
-/area/station/maintenance/radshelter/civil)
 "iGo" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
@@ -22906,6 +22885,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"jdn" = (
+/obj/item/trash/can/food/pine_nuts,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "jdJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22970,11 +22953,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue{
-	pixel_x = -2;
-	pixel_y = -8
-	},
-/obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "jeM" = (
@@ -24977,6 +24957,12 @@
 "jVT" = (
 /turf/open/openspace,
 /area/station/hallway/primary/aft)
+"jVU" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/bronze,
+/area/station/service/library)
 "jVW" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -26866,11 +26852,8 @@
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "kEX" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 10
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/plating,
 /area/station/maintenance/radshelter/civil)
 "kEZ" = (
 /obj/structure/cable,
@@ -29521,11 +29504,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
-"lDA" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
-/area/station/maintenance/radshelter/civil)
 "lDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29917,8 +29895,7 @@
 /area/station/engineering/atmos)
 "lKQ" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/floor/plating,
 /area/station/service/kitchen/diner)
 "lKR" = (
 /obj/machinery/door/poddoor/shutters/window{
@@ -30475,6 +30452,15 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"lWF" = (
+/obj/structure/stairs/wood{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood/stairs/left,
+/area/station/biodome/aft)
 "lWG" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "cargowarehouse";
@@ -32016,14 +32002,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"mzQ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central)
 "mzW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
@@ -32255,6 +32233,10 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/water/jungle/biodome,
 /area/station/biodome)
+"mGf" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "mGi" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -34426,6 +34408,18 @@
 /obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"nyr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "nyw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -35844,13 +35838,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/wood/tile,
 /area/station/service/janitor)
-"oaY" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 9
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
-/area/station/maintenance/radshelter/civil)
 "obk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37309,6 +37296,13 @@
 "oEu" = (
 /turf/closed/wall,
 /area/station/science/xenobiology/hallway)
+"oEB" = (
+/obj/structure/stairs/wood{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/open/floor/wood/stairs/left,
+/area/station/biodome/aft)
 "oEC" = (
 /obj/structure/table,
 /obj/item/electronics/apc,
@@ -37503,6 +37497,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
+"oHW" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "oHY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -38390,9 +38388,6 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "pbm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 10
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/radshelter/civil)
@@ -39544,11 +39539,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "pAi" = (
-/obj/effect/turf_decal/trimline/blue{
-	pixel_x = -2;
-	pixel_y = -2
-	},
+/obj/effect/turf_decal/trimline/blue,
 /obj/structure/cable,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "pAm" = (
@@ -40369,10 +40362,6 @@
 "pSI" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"pSJ" = (
-/obj/item/grown/bananapeel/mimanapeel,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "pSM" = (
 /turf/open/floor/carpet/lone/star,
 /area/station/security/brig)
@@ -42157,11 +42146,8 @@
 /turf/open/openspace,
 /area/station/biodome)
 "qCm" = (
-/obj/structure/stairs/wood{
-	dir = 8
-	},
 /obj/structure/railing,
-/turf/open/floor/grass,
+/turf/open/floor/wood/stairs/left,
 /area/station/biodome/aft)
 "qCq" = (
 /obj/docking_port/stationary{
@@ -42752,10 +42738,6 @@
 /area/station/command/heads_quarters/captain/private)
 "qNG" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/machinery/light/cold/directional/east,
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44341,6 +44323,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"rqE" = (
+/obj/structure/holosign/barrier/atmos/leaf{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/primary/central)
 "rqX" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/medical_all,
@@ -45500,11 +45488,6 @@
 	dir = 4
 	},
 /area/station/commons/lounge)
-"rPU" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/spawner/structure/window,
-/turf/open/openspace,
-/area/station/service/kitchen/diner)
 "rQb" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/eighties,
@@ -51400,13 +51383,6 @@
 "ukj" = (
 /turf/open/floor/glass,
 /area/station/hallway/primary/starboard)
-"uks" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/textured_large,
-/area/station/maintenance/radshelter/civil)
 "ukO" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -54619,13 +54595,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"vBq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/reinforced,
-/area/station/maintenance/radshelter/civil)
 "vBr" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -54903,11 +54872,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vGA" = (
-/obj/structure/stairs/wood,
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/iron/stairs/left,
+/turf/open/floor/wood/stairs,
 /area/station/biodome)
 "vGC" = (
 /obj/machinery/door/airlock/virology{
@@ -56082,6 +56050,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"wfG" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "wfH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
@@ -57530,12 +57503,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"wEB" = (
-/obj/structure/railing,
-/obj/effect/spawner/structure/window,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/service/kitchen/diner)
 "wEE" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -59792,10 +59759,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue{
-	pixel_x = 2;
-	pixel_y = 2
-	},
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "xAa" = (
@@ -60719,12 +60684,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
-"xQI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/radshelter/civil)
 "xRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -89242,7 +89201,7 @@ dhk
 qMk
 asD
 asD
-aWc
+asD
 aWc
 aWc
 tlW
@@ -89255,8 +89214,8 @@ vfD
 kle
 kle
 jdP
+bVc
 xVa
-ota
 ota
 oAe
 ydb
@@ -89500,6 +89459,7 @@ tMS
 tMS
 tMS
 tMS
+aWc
 weR
 weR
 weR
@@ -89513,7 +89473,6 @@ weR
 weR
 weR
 vxS
-qda
 ota
 oAe
 ydb
@@ -89755,6 +89714,7 @@ ngd
 wju
 ngd
 asD
+asD
 bxm
 bxm
 weR
@@ -89770,7 +89730,6 @@ cZA
 iPO
 weR
 cDy
-kle
 xVa
 oAe
 ydb
@@ -90012,6 +89971,7 @@ asD
 wju
 ngd
 asD
+asD
 bxm
 bxm
 weR
@@ -90027,7 +89987,6 @@ kIm
 eRj
 weR
 yin
-ota
 vxS
 oAe
 cwg
@@ -90271,6 +90230,7 @@ ngd
 asD
 asD
 asD
+asD
 ilj
 oYq
 bjN
@@ -90283,7 +90243,6 @@ lRh
 fYP
 fzk
 weR
-ota
 ota
 vxS
 oAe
@@ -90528,6 +90487,7 @@ kco
 kco
 kco
 kco
+kco
 wnH
 bjN
 bjN
@@ -90541,7 +90501,6 @@ qYW
 weR
 weR
 mZS
-ota
 vxS
 oAe
 vnE
@@ -90785,6 +90744,7 @@ ngd
 asD
 asD
 asD
+asD
 weR
 cPm
 oYq
@@ -90798,7 +90758,6 @@ ylL
 bxk
 weR
 jTy
-ota
 icc
 oAe
 vnE
@@ -91042,6 +91001,7 @@ bIu
 bIu
 bIu
 bIu
+bIu
 eTQ
 bcA
 oYq
@@ -91054,7 +91014,6 @@ gjv
 ylL
 vyw
 weR
-ota
 ota
 kMD
 oAe
@@ -91299,6 +91258,7 @@ hLn
 gbE
 asD
 asD
+asD
 ilj
 pUk
 mpn
@@ -91312,7 +91272,6 @@ ylL
 kAN
 weR
 jTy
-ota
 oBg
 tIK
 aGk
@@ -91554,6 +91513,7 @@ ybG
 wju
 ngd
 vGA
+cKv
 bxm
 bxm
 weR
@@ -91569,7 +91529,6 @@ ctr
 unq
 weR
 qda
-ota
 aXf
 oAe
 nFE
@@ -91811,6 +91770,7 @@ bdP
 wju
 ngd
 cAW
+bLR
 bxm
 bxm
 weR
@@ -91825,7 +91785,6 @@ weR
 ilj
 weR
 weR
-ota
 miI
 rax
 oAe
@@ -92069,8 +92028,8 @@ wju
 gwP
 omC
 asD
-xti
 asD
+xti
 asD
 oAv
 ota
@@ -93111,7 +93070,7 @@ ota
 ota
 ota
 aiZ
-sAB
+aiZ
 ooS
 oAe
 nFE
@@ -93367,8 +93326,8 @@ ota
 ota
 ota
 ota
-soh
-soh
+lWF
+oEB
 ooS
 oAe
 nFE
@@ -145788,8 +145747,8 @@ eAU
 pSH
 pSH
 pSH
-pSH
 rpq
+pSH
 pSH
 pSH
 pSH
@@ -146042,11 +146001,11 @@ ikk
 xHJ
 vyS
 qUB
+ikk
 pSH
 pSH
 ikk
-ikk
-ikk
+jdn
 xdX
 kLb
 rle
@@ -146299,10 +146258,10 @@ eFk
 gfQ
 vkh
 vkh
+ikk
 kSv
 kxJ
 ikk
-pSJ
 nKV
 nKV
 nKV
@@ -148620,7 +148579,7 @@ sxi
 msS
 bQe
 ggb
-ggb
+nyr
 qNG
 pfn
 sUU
@@ -155036,7 +154995,8 @@ rAq
 rAq
 rAq
 rAq
-ctt
+rAq
+jVU
 weR
 weR
 qxk
@@ -155048,7 +155008,6 @@ qxk
 weR
 weR
 cZN
-fQs
 fQs
 fQs
 jpN
@@ -155291,6 +155250,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 vMh
 rsY
 weR
@@ -155305,7 +155265,6 @@ ilj
 weR
 weR
 weR
-fQs
 fQs
 fQs
 jpN
@@ -155548,6 +155507,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 bsz
 wUg
 weR
@@ -155562,7 +155522,6 @@ xEV
 bfl
 wBq
 weR
-fQs
 fQs
 fQs
 jpN
@@ -155807,6 +155766,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 ilj
 kKv
 ylL
@@ -155819,7 +155779,6 @@ nPT
 cgt
 bcB
 weR
-fQs
 fQs
 fQs
 jpN
@@ -156064,6 +156023,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 weR
 kKv
 ylL
@@ -156076,7 +156036,6 @@ lvI
 cgt
 bcB
 weR
-fQs
 fQs
 fQs
 jpN
@@ -156321,6 +156280,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 ilj
 sJN
 hYE
@@ -156333,7 +156293,6 @@ mgh
 mgh
 efa
 weR
-fQs
 fQs
 fQs
 sXp
@@ -156578,6 +156537,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 weR
 kKv
 ylL
@@ -156590,7 +156550,6 @@ oYq
 oYq
 eTx
 weR
-fQs
 fQs
 fQs
 sXp
@@ -156835,6 +156794,7 @@ rAq
 rAq
 rAq
 rAq
+rAq
 ilj
 lBf
 kBa
@@ -156847,7 +156807,6 @@ rBo
 iKU
 rMD
 weR
-fQs
 fQs
 fQs
 sXp
@@ -157090,6 +157049,7 @@ nuN
 rAq
 rAq
 rAq
+rAq
 sjl
 twp
 weR
@@ -157104,7 +157064,6 @@ ilj
 weR
 weR
 weR
-fQs
 fQs
 fQs
 jpN
@@ -157347,7 +157306,8 @@ nuN
 rAq
 rAq
 rAq
-kTd
+rAq
+pHy
 psK
 xfC
 weR
@@ -157361,7 +157321,6 @@ cZN
 weR
 weR
 ltx
-fQs
 fQs
 fQs
 jpN
@@ -157605,12 +157564,12 @@ opX
 opX
 opX
 gNF
+oHW
 uyN
-opX
 vXZ
-xly
-mzQ
-psK
+rqE
+vop
+cvl
 xly
 nxg
 nxg
@@ -157862,8 +157821,8 @@ qMz
 qMz
 qMz
 hYz
+uJB
 lEX
-qMz
 ioj
 qMz
 uJB
@@ -158646,8 +158605,8 @@ fQs
 fQs
 fQs
 soh
-bdu
-uyN
+mGf
+wfG
 hjh
 jpN
 fQl
@@ -158903,11 +158862,11 @@ nxg
 nxg
 nxg
 sKm
-vop
-psK
+fQs
+fQs
 fQs
 jpN
-neH
+gRQ
 iqp
 ikM
 mPs
@@ -161450,11 +161409,11 @@ rpC
 szR
 lKQ
 lKQ
-rPU
-rPU
-rPU
 lKQ
-wEB
+lKQ
+lKQ
+lKQ
+lKQ
 kmB
 tpc
 rAq
@@ -161946,11 +161905,11 @@ nfE
 qNA
 iGo
 ggF
-oaY
-cGg
-cGg
-cGg
-cGg
+kEX
+kEX
+kEX
+kEX
+kEX
 kEX
 sZD
 dbR
@@ -162203,12 +162162,12 @@ nfE
 ftO
 kfd
 ggF
-uks
+kEX
 sdG
 tCu
 sdG
 jaN
-lDA
+kEX
 sZD
 dbR
 sZD
@@ -162465,7 +162424,7 @@ vDY
 cSg
 vzK
 sdG
-lDA
+kEX
 sZD
 dbR
 sZD
@@ -162717,12 +162676,12 @@ nfE
 fsz
 kfd
 ggF
-uks
+kEX
 jft
 cpN
 cSg
 gHu
-lDA
+kEX
 ggF
 sxx
 ggF
@@ -162979,7 +162938,7 @@ mit
 bYs
 ihR
 dsO
-gTA
+kEX
 sZD
 dbR
 sZD
@@ -163231,7 +163190,7 @@ pGm
 pGm
 feT
 heF
-xQI
+fuu
 mJo
 otU
 bXh
@@ -163488,12 +163447,12 @@ ueU
 pGm
 iGo
 qwk
-gQa
+pbm
 hER
 bCk
 cSg
 nQW
-cLV
+pbm
 sZD
 dbR
 sZD
@@ -163750,7 +163709,7 @@ yif
 pqv
 cSg
 hER
-cLV
+pbm
 ggF
 gfH
 ggF
@@ -164002,12 +163961,12 @@ pGm
 pGm
 iGo
 sZD
-gQa
+pbm
 hER
 hER
 hER
 jho
-cLV
+pbm
 sZD
 wuM
 sZD
@@ -164259,12 +164218,12 @@ nfE
 ftO
 wuM
 sZD
-aAA
-iGn
-iGn
-iGn
-iGn
-vBq
+pbm
+pbm
+pbm
+pbm
+pbm
+pbm
 sZD
 sZD
 eAh

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1716,6 +1716,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"aFI" = (
+/obj/structure/chair/sofa/bamboo,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
 "aFM" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/neon/simple/yellow,
@@ -4471,7 +4476,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/closed/wall/mineral/wood,
+/turf/open/floor/wood/stairs/down,
 /area/station/biodome)
 "bLU" = (
 /obj/structure/disposalpipe/segment{
@@ -5966,6 +5971,7 @@
 "cqU" = (
 /obj/structure/sign/clock/directional/south,
 /obj/effect/landmark/start/hangover,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/noslip,
 /area/station/biodome/aft)
 "cqY" = (
@@ -6593,7 +6599,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/wood/stairs,
+/turf/open/floor/wood/stairs/down,
 /area/station/biodome)
 "cAZ" = (
 /obj/machinery/flasher/portable,
@@ -7168,7 +7174,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/closed/wall/mineral/wood,
+/turf/open/floor/wood/stairs/down,
 /area/station/biodome)
 "cKx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8826,6 +8832,7 @@
 /area/station/hallway/primary/central/aft)
 "dtP" = (
 /obj/item/chair/stool/bamboo,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/stone,
 /area/station/hallway/primary/starboard)
 "dud" = (
@@ -35174,6 +35181,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"nML" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Service - Botany Access Overlook"
+	},
+/turf/open/openspace,
+/area/station/biodome/fore)
 "nMZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -37123,6 +37136,12 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"ozx" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Biodome - Library Alley Overlook"
+	},
+/turf/open/openspace,
+/area/station/biodome)
 "ozE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38502,6 +38521,12 @@
 /obj/effect/spawner/random/trash/mopbucket,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
+"pbx" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "pbH" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/checker,
@@ -47392,6 +47417,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Service - Hall Access Overlook"
+	},
 /turf/open/floor/wood/parquet,
 /area/station/biodome/fore)
 "sBg" = (
@@ -54634,6 +54662,15 @@
 /obj/structure/beebox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"vzm" = (
+/obj/structure/holosign/barrier/atmos/leaf{
+	dir = 1
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Biodome - Starboard Passage Overlook"
+	},
+/turf/open/openspace,
+/area/station/biodome/fore)
 "vzt" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/tile,
@@ -55019,7 +55056,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/wood/stairs,
+/turf/open/floor/wood/stairs/down,
 /area/station/biodome)
 "vGC" = (
 /obj/machinery/door/airlock/virology{
@@ -55255,6 +55292,11 @@
 /obj/item/wallframe/firealarm,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"vLA" = (
+/obj/structure/chair/sofa/bamboo,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vLD" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -57474,6 +57516,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wBc" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
+/area/station/commons/dorms/laundry)
 "wBq" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/sign/painting/library{
@@ -61401,6 +61450,7 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "ybh" = (
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/noslip,
 /area/station/biodome/fore)
 "ybk" = (
@@ -149222,7 +149272,7 @@ jJi
 rps
 wuF
 oet
-lQH
+wBc
 cFs
 bLX
 wuF
@@ -150505,7 +150555,7 @@ irB
 irB
 rsP
 rsP
-rsP
+pbx
 skp
 ocT
 hUr
@@ -154912,7 +154962,7 @@ rAq
 rAq
 rAq
 rAq
-rAq
+ozx
 vel
 koU
 koU
@@ -156181,7 +156231,7 @@ sZD
 sZD
 sZD
 sZD
-iuL
+vzm
 bWE
 pHy
 aAO
@@ -157718,7 +157768,7 @@ dIi
 sZD
 sZD
 sZD
-sZD
+nML
 nzE
 nzE
 kLv
@@ -170593,7 +170643,7 @@ ybs
 ybs
 ybs
 jsf
-bsP
+vLA
 ukj
 svB
 syv
@@ -172150,7 +172200,7 @@ uJh
 svB
 syv
 dmf
-dmf
+aFI
 nzQ
 nUl
 nUl

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1425,6 +1425,13 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"aAt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
+/turf/open/misc/asteroid,
+/area/station/maintenance/central/greater)
 "aAx" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -3675,6 +3682,17 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"buI" = (
+/obj/effect/spawner/random/structure/table,
+/obj/item/food/monkeycube/chicken,
+/obj/item/kitchen/fork/plastic{
+	pixel_x = -8
+	},
+/obj/item/knife/plastic{
+	pixel_x = 10
+	},
+/turf/open/misc/asteroid,
+/area/station/maintenance/fore/greater)
 "buV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6040,6 +6058,14 @@
 /obj/item/paper/pamphlet/gateway,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"csT" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "csV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
@@ -6673,6 +6699,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"cCt" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "cCx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Quartermaster Office Maintenance"
@@ -6846,6 +6876,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"cFC" = (
+/obj/effect/spawner/random/trash/mess,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "cFK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/smooth_large,
@@ -6883,19 +6920,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
-"cGO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/button/elevator/directional/south{
-	id = "biodome_medbay_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "biodome_medbay_lift"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "cGX" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -9583,6 +9607,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"dIP" = (
+/obj/effect/spawner/random/decoration/showcase,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "dIT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -11436,10 +11464,6 @@
 /obj/effect/spawner/random/structure/crate_empty,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/greater)
-"exP" = (
-/obj/effect/spawner/random/food_or_drink/cups,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "exQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/industrial_lift/public,
@@ -12199,6 +12223,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/railing,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "eMc" = (
@@ -12312,6 +12337,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/lobby)
+"eNU" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/glass,
+/area/station/maintenance/department/science)
 "eOf" = (
 /obj/structure/railing{
 	dir = 8
@@ -12773,6 +12802,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"eWK" = (
+/turf/open/floor/glass,
+/area/station/maintenance/department/science)
 "eWQ" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/chem_pack,
@@ -15378,6 +15410,12 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
+"fWa" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/maintenance/port/greater)
 "fWb" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -15678,6 +15716,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
+"gbY" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "gcl" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/smooth_large,
@@ -16942,6 +16986,13 @@
 /obj/item/shovel/spade,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
+"gCY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "gDp" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -19790,6 +19841,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"hOj" = (
+/obj/structure/ladder,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/station/asteroid)
 "hOo" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Hut"
@@ -21544,6 +21599,13 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome/fore)
+"izy" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/item/clothing/suit/hazardvest,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "izA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -23344,7 +23406,7 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/station/cargo/lobby)
 "joP" = (
 /obj/machinery/airalarm/directional/south,
@@ -24359,6 +24421,12 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"jJc" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "jJi" = (
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -24957,12 +25025,6 @@
 "jVT" = (
 /turf/open/openspace,
 /area/station/hallway/primary/aft)
-"jVU" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/bronze,
-/area/station/service/library)
 "jVW" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -25807,10 +25869,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"klE" = (
-/obj/effect/spawner/random/structure/chair_flipped,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "klF" = (
 /obj/machinery/turretid{
 	icon_state = "control_stun";
@@ -26900,7 +26958,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/command/meeting_room)
 "kGO" = (
 /obj/machinery/door/firedoor,
@@ -27719,6 +27777,15 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"kTM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/xtracks{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "kTN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/rock/icy/style_random,
@@ -30441,6 +30508,11 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
+"lWl" = (
+/obj/effect/spawner/random/engineering/vending_restock,
+/obj/effect/spawner/random/engineering/vending_restock,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "lWz" = (
 /obj/structure/table,
 /obj/item/stack/medical/mesh,
@@ -35948,6 +36020,10 @@
 /obj/item/banner/science/mundane,
 /turf/open/floor/iron,
 /area/station/science/research)
+"odB" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "odJ" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -36677,6 +36753,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
+"orQ" = (
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "osb" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
@@ -36904,6 +36984,13 @@
 "owD" = (
 /turf/closed/wall,
 /area/station/science/research)
+"owW" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 10
+	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "oxa" = (
 /obj/structure/transit_tube,
 /turf/open/openspace,
@@ -37622,6 +37709,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
+"oKN" = (
+/turf/open/floor/carpet,
+/area/station/cargo/lobby)
 "oKR" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -38791,6 +38881,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/railing/corner,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "pil" = (
@@ -39494,6 +39585,12 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"pzr" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "pzs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -44992,6 +45089,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"rCY" = (
+/obj/effect/spawner/structure/window/hollow,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "rDd" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -45627,6 +45728,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"rSx" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "rSy" = (
 /obj/structure/holosign/barrier/atmos/leaf,
 /obj/structure/transit_tube/curved/flipped{
@@ -46164,6 +46273,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"sch" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/cargo/storage)
 "scl" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/spawner/random/maintenance,
@@ -46998,6 +47111,12 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"swl" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/maintenance/aft/upper)
 "swn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51721,6 +51840,13 @@
 	},
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
+"urn" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/machinery/light/small/red/dim/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "uro" = (
 /obj/item/shovel,
 /turf/open/misc/asteroid/airless,
@@ -52204,6 +52330,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
+"uCx" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/misc/asteroid,
+/area/station/maintenance/fore/greater)
 "uCA" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -53854,6 +53984,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/sorting)
+"vmg" = (
+/obj/machinery/button/elevator/directional/west{
+	id = "biodome_science_lift"
+	},
+/obj/machinery/lift_indicator/directional/west{
+	linked_elevator_id = "biodome_science_lift"
+	},
+/turf/open/floor/iron,
+/area/station/science/research)
 "vml" = (
 /obj/structure/marker_beacon/jade,
 /obj/structure/lattice,
@@ -53980,6 +54119,11 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
+"vnT" = (
+/obj/effect/spawner/random/food_or_drink/cups,
+/obj/effect/spawner/random/food_or_drink/cups,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "vnU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -56217,6 +56361,13 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"wiZ" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 6
+	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wjj" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/bamboo/tatami{
@@ -57064,6 +57215,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
+"wxN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "wxS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -57349,6 +57505,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"wBW" = (
+/turf/open/floor/glass,
+/area/station/cargo/lobby)
 "wCf" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
@@ -58064,6 +58223,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"wPL" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wPM" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
@@ -59826,7 +59989,7 @@
 /obj/item/paper/crumpled{
 	pixel_x = 7
 	},
-/turf/open/floor/wood,
+/turf/open/floor/glass,
 /area/station/cargo/lobby)
 "xBr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -60006,6 +60169,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
+"xEX" = (
+/obj/effect/decal/cleanable/blood/xtracks{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "xFa" = (
 /obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/machinery/holopad,
@@ -60684,6 +60853,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"xRa" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "xRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -84849,7 +85022,7 @@ pov
 lnK
 pov
 iQm
-cGO
+oso
 jHc
 oAe
 oAe
@@ -86151,7 +86324,7 @@ bib
 bwN
 tHc
 tHc
-tHc
+aAt
 tHc
 tHc
 tHc
@@ -86880,9 +87053,9 @@ cCZ
 cCZ
 cCZ
 rRv
-rRv
-rRv
-rRv
+pKF
+pKF
+pKF
 pKF
 fld
 dMM
@@ -87137,9 +87310,9 @@ cCZ
 cCZ
 cCZ
 hNy
-hNy
-hNy
-hNy
+pKF
+izy
+owW
 pKF
 cJU
 dMM
@@ -87394,10 +87567,10 @@ cCZ
 cCZ
 hNy
 hNy
-rRv
-rRv
-hNy
 pKF
+tUp
+wPL
+jJc
 cJU
 dMM
 lHf
@@ -87651,9 +87824,9 @@ cCZ
 rRv
 hNy
 hNy
-hNy
-hNy
-hNy
+pKF
+urn
+wiZ
 pKF
 cJU
 dMM
@@ -91723,9 +91896,9 @@ cCZ
 vtU
 hNy
 hNy
-hNy
-hNy
-hNy
+xRa
+dIP
+xRa
 hNy
 hNy
 hNy
@@ -91980,9 +92153,9 @@ sBz
 sBz
 sBz
 sBz
-sBz
-sBz
-sBz
+fRH
+rCY
+fRH
 sBz
 sBz
 sBz
@@ -92224,7 +92397,7 @@ rlY
 rlY
 rlY
 jlt
-dYQ
+orQ
 gbs
 gbs
 gbs
@@ -92481,7 +92654,7 @@ ixB
 rsj
 deH
 jlt
-dYQ
+xEX
 gbs
 jlt
 jlt
@@ -92495,7 +92668,7 @@ dYQ
 dYQ
 dYQ
 dYQ
-dYQ
+cCt
 dYQ
 dYQ
 dYQ
@@ -92738,7 +92911,7 @@ ixB
 oAp
 jGl
 jlt
-dYQ
+xEX
 gbs
 jlt
 wAH
@@ -92995,7 +93168,7 @@ ixB
 vMN
 xOJ
 jlt
-dYQ
+xEX
 gbs
 jlt
 rWl
@@ -93252,7 +93425,7 @@ ixB
 ryZ
 aAW
 uZM
-gbs
+kTM
 gbs
 jlt
 exQ
@@ -93770,7 +93943,7 @@ jpl
 jpl
 dJN
 xkG
-dCg
+vmg
 ifC
 lUf
 fMc
@@ -100980,7 +101153,7 @@ hNy
 hNy
 hNy
 xWW
-jPA
+uCx
 sBz
 sBz
 sBz
@@ -101233,7 +101406,7 @@ cCZ
 cCZ
 hNy
 hNy
-hNy
+uCx
 hNy
 hNy
 jPA
@@ -101489,10 +101662,10 @@ cCZ
 cCZ
 cCZ
 hNy
-hNy
-hNy
-hNy
-hNy
+buI
+jPA
+jPA
+jPA
 jPA
 hNy
 sBz
@@ -101746,7 +101919,7 @@ cCZ
 cCZ
 cCZ
 hNy
-rRv
+jPA
 sBz
 sBz
 sBz
@@ -102003,7 +102176,7 @@ cCZ
 cCZ
 cCZ
 hNy
-rRv
+uCx
 sBz
 krh
 anR
@@ -104634,7 +104807,7 @@ kPb
 cCZ
 cCZ
 hNy
-hNy
+hOj
 hNy
 hNy
 hNy
@@ -106659,7 +106832,7 @@ rdY
 wfX
 hNy
 hNy
-hNy
+tAz
 tAz
 hNy
 hNy
@@ -151430,9 +151603,9 @@ jpN
 blQ
 jpN
 vxC
-hNy
-hNy
-hNy
+vxC
+vxC
+vxC
 hNy
 hNy
 hNy
@@ -151687,8 +151860,8 @@ uFA
 ple
 pTn
 vxC
-vxC
-vxC
+swl
+swl
 vxC
 hNy
 hNy
@@ -152419,7 +152592,7 @@ ikk
 ikk
 ikk
 ikk
-epr
+gCY
 nRf
 sJW
 soo
@@ -152674,7 +152847,7 @@ xlT
 tms
 vOG
 epr
-epr
+gCY
 epr
 epr
 nRf
@@ -152931,7 +153104,7 @@ xlT
 ikk
 jmx
 wOd
-pSH
+odB
 ikk
 ikk
 nRf
@@ -153188,7 +153361,7 @@ xlT
 ikk
 jmx
 dce
-khI
+fWa
 ikk
 bbT
 qTg
@@ -154225,7 +154398,7 @@ neH
 neH
 dAJ
 neH
-neH
+awg
 neH
 atz
 atz
@@ -154996,7 +155169,7 @@ rAq
 rAq
 rAq
 rAq
-jVU
+ctt
 weR
 weR
 qxk
@@ -155191,7 +155364,7 @@ hHc
 hHc
 hHc
 rRv
-rRv
+vKY
 lvG
 hNy
 hHc
@@ -155705,9 +155878,9 @@ rKS
 rKS
 rKS
 oYs
-vKY
-lvG
-hNy
+ajw
+oFQ
+ajw
 rRv
 hNy
 hNy
@@ -155963,7 +156136,7 @@ rKS
 rKS
 oYs
 ajw
-oFQ
+bOc
 ajw
 rRv
 hNy
@@ -156218,11 +156391,11 @@ rKS
 rKS
 rKS
 rKS
-oYs
-ajw
-bOc
-ajw
-rRv
+lps
+lps
+pSV
+lps
+lps
 rRv
 dQH
 omP
@@ -156475,10 +156648,10 @@ tFo
 hNq
 tFo
 nfF
-oYs
 lps
-pSV
-lps
+rtu
+bOc
+kMg
 lps
 rRv
 dQH
@@ -156732,10 +156905,10 @@ rsj
 rsj
 rsj
 fTM
-oYs
-rtu
-bOc
-kMg
+lps
+glN
+nrV
+kPF
 lps
 rRv
 dQH
@@ -156989,10 +157162,10 @@ rlY
 rlY
 rlY
 jrc
-oYs
-glN
-nrV
-kPF
+lps
+mes
+bVI
+xqP
 lps
 rRv
 dQH
@@ -157246,10 +157419,10 @@ rlY
 rlY
 rlY
 gJx
-oYs
-mes
-bVI
-xqP
+lps
+lps
+xSH
+lps
 lps
 rRv
 rRv
@@ -157504,10 +157677,10 @@ rlY
 qMc
 dJN
 dJN
-dJN
-xSH
-dJN
-dJN
+lWl
+wxN
+vnT
+jpl
 jpl
 jpl
 tPv
@@ -157760,8 +157933,8 @@ plo
 rsj
 wch
 dJN
-hUb
-cLA
+eNU
+eWK
 eHu
 eHu
 eHu
@@ -158017,8 +158190,8 @@ sRV
 cwa
 yil
 dJN
-exP
-cLA
+eWK
+eWK
 dJN
 dJN
 dJN
@@ -158274,8 +158447,8 @@ eGS
 vCD
 rKS
 dJN
-klE
-cLA
+eNU
+eWK
 dJN
 wAH
 xhn
@@ -166768,8 +166941,8 @@ aXw
 khm
 aXw
 phX
-aXw
-aXw
+csT
+rSx
 aXw
 bzj
 dJN
@@ -167025,7 +167198,7 @@ eYb
 wDy
 wDy
 eLP
-cLA
+aqd
 jpl
 kwe
 aXw
@@ -167281,9 +167454,9 @@ tnj
 ydO
 tyv
 cLA
-jqK
-cLA
-cLA
+cFC
+pzr
+gbY
 cLA
 rFM
 dJN
@@ -171681,8 +171854,8 @@ rAn
 dbk
 wlo
 qRD
-wlo
-wlo
+wBW
+wBW
 tNi
 bwa
 dGD
@@ -171939,7 +172112,7 @@ lNN
 wlo
 wlo
 xBp
-wlo
+oKN
 wlg
 fky
 kDX
@@ -172195,7 +172368,7 @@ rAn
 rAn
 hKx
 nMj
-wlo
+wBW
 jnX
 tNi
 kkm
@@ -172475,7 +172648,7 @@ gTp
 ups
 xuP
 hKD
-hHc
+tsu
 dUQ
 hHc
 lLK
@@ -172970,7 +173143,7 @@ izR
 dod
 bjl
 qcQ
-krs
+sch
 krs
 tDm
 jGu


### PR DESCRIPTION
 - the medbay mulebot delivery window now requires an access that exists
 - adjusted lights
 - tweaks some stray decals and platings under windows
 - pushed the library back by one tile to make the wooden stairs be in line with the other ones
 - fixes a nightmare trap
 - added a few more overlooks and ladders in maintenance, along with a single museum showcase! Can you find them all?
 - lower research elevator has buttons, and lower medbay has only one elevator button
 - added some more assistant spawn points
 - cleared some AI blindspots