### PR TITLE
HERETIC CONTRACT RENEGOTIATION

### DIFF
--- a/orbstation/code/antagonists/heretic/heretic_knowledge.dm
+++ b/orbstation/code/antagonists/heretic/heretic_knowledge.dm
@@ -1,7 +1,65 @@
+/// Proc to remove a specific knowledge path from a heretic
+/datum/antagonist/heretic/proc/remove_knowledge(knowledge_path)
+	var/datum/heretic_knowledge/to_unlearn = locate(knowledge_path) in researched_knowledge
+	if(!to_unlearn)
+		return
+	researched_knowledge -= to_unlearn
+	to_unlearn.on_lose(owner.current, src)
+
 // GENERAL
 
 /datum/heretic_knowledge/limited_amount/starting
 	cost = 0
 
+/// make more clear which knowledge is your sacrifice
 /datum/heretic_knowledge/hunt_and_sacrifice
 	name = "Heartbeat of the Mansus (Sacrifice)"
+
+// heretic contract renegotiation concept
+
+/// overwrite on proc to remove scheme of prometheus upon sacrificing someone
+/datum/heretic_knowledge/hunt_and_sacrifice/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	if(our_heretic.total_sacrifices > 1)
+		return
+	our_heretic.remove_knowledge(/datum/heretic_knowledge/prometheus_scheme)
+	to_chat(user, span_hypnophrase(span_big("THE PACT OF BLOOD AND FLESH IS SEALED.")))
+
+
+/// ritual that gives you knowledge and removes all of your objectives, similar to contract renegotiation
+/datum/heretic_knowledge/prometheus_scheme
+	name = "Scheme of Prometheus (No Objectives)"
+	desc = "Allows you to use a candle to reject the desires of your masters and steal their power for yourself. \
+		You will instantly gain 10 knowledge. You will no longer be able to sacrifice or ascend. \
+		You can still gain knowledge from rifts and the Ritual of Knowledge."
+	required_atoms = list(/obj/item/flashlight/flare/candle = 1)
+	priority = MAX_KNOWLEDGE_PRIORITY
+	route = PATH_START
+	/// Whether we've done the ritual. Only doable once.
+	var/was_completed = FALSE
+
+/datum/heretic_knowledge/prometheus_scheme/can_be_invoked(datum/antagonist/heretic/invoker)
+	return !was_completed
+
+/datum/heretic_knowledge/prometheus_scheme/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
+	return !was_completed
+
+/datum/heretic_knowledge/prometheus_scheme/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.knowledge_points += 10
+	was_completed = TRUE
+
+	to_chat(user, span_boldnotice("[name] completed!"))
+	to_chat(user, span_hypnophrase("You have grasped for the stars themselves and gained immense power!"))
+	desc += " (Completed!)"
+	reject_mansus(our_heretic, user)
+	log_heretic_knowledge("[key_name(user)] completed a [name] at [worldtime2text()].")
+	return TRUE
+
+/// Proc that runs when you complete this ritual in order to cancel sacrifice objectives and remove the heartbeat of mansus knowledge
+/datum/heretic_knowledge/prometheus_scheme/proc/reject_mansus(datum/antagonist/heretic/our_heretic, mob/living/user)
+	our_heretic.remove_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
+	to_chat(user, span_hypnophrase(span_big("THE MANSUS REJECTS YOU. YOU CAN NO LONGER SACRIFICE TARGETS NOR ASCEND.")))


### PR DESCRIPTION
## About The Pull Request

This PR adds in a new ritual that every heretic starts with, one that is only for those who are brave enough to conspire against their masters and **steal power for themselves**!

THE SCHEME OF PROMETHEUS 

To steal fire from the gods is something to be praised and to follow in the path of the first defiant one is to claim yourself to be an equal to the very powers that of the unknown!

![dreamseeker_CkVMi6C3Qr](https://user-images.githubusercontent.com/116288367/224516785-014774e5-e3e0-403f-b6fb-5f593c0db285.png)


This ritual will give you 10 Knowledge upon completion and is done by using one candle, to represent the profane and stolen fire, on your heretic rune. This is essentially the amount of knowledge you would get for sacrificing two normal crewmates and 2 heads of staff over the course of a round, but all at once. It completely **removes your ability to sacrifice which means _you will not be able to ascend_**.

Additionally, to prevent this from being abused, the scheme will be removed the first time that you perform the sacrifice ritual.
![dreamseeker_XUEDm1Bbpk](https://user-images.githubusercontent.com/116288367/224516862-8291508c-fec0-41b9-abdc-54067d2d75dd.png)


You can still use the ritual of knowledge and you can still open rifts to gain knowledge. 
If this ends up being too fucked up I can figure out how to turn it into a passive gain instead.
We have whitetext, so I did not also have this ritual give you greentext, but I will do so if we need it later.

## Why It's Good For The Game

People who play heretic generally only play heretic to complete objectives, some people just want to play with the toys and not go through the objective stuff so this will help facilitate this. 

Additionally, if someone gets latejoin heretic, they will have an easy 10 knowledge in addition to their latejoin delay knowledge which means that they can just Do Threatening Things instead of having to hunt down and do in like, 15 minutes, what roundstart heretic has 70 to do.

Finally, we do just generally want to give players on orbstation more freedom and ability to play how they want, making heretic more open and allowing you to mechanically reject your objectives is better than just saying "you dont have to sac anyone," which ignores how juicy it is, especially with the heretic phobia.

## Changelog



:cl:
add: Heretics now start with a new ritual that allows them to reject the heartbeat of manusus and steal power for themselves
/:cl:
