### PR TITLE
More Station Side Alerts

### DIFF
--- a/orbstation/code/antagonists/rulesets_midround.dm
+++ b/orbstation/code/antagonists/rulesets_midround.dm
@@ -186,3 +186,7 @@
 	if(!spawn_locs.len)
 		return MAP_ERROR
 	new_character.forceMove(pick(spawn_locs))
+	addtimer(CALLBACK(src, PROC_REF(delay_announce)), 2 MINUTES)
+
+/datum/dynamic_ruleset/midround/from_ghosts/lone_operative/proc/delay_announce()
+	priority_announce("Encrypted communications intercepted in the vicinity of [station_name()]. There is an unknown threat aboard.", "Security Alert", ANNOUNCER_INTERCEPT)

--- a/orbstation/code/antagonists/wizard_journeyman/journeyman_outfit.dm
+++ b/orbstation/code/antagonists/wizard_journeyman/journeyman_outfit.dm
@@ -12,7 +12,7 @@
 		/obj/item/wizard_diploma = 1, )
 	ears = /obj/item/radio/headset
 	shoes = /obj/item/clothing/shoes/sandal/magic
-	r_pocket = /obj/item/teleportation_scroll/apprentice // You just get to the station, then you're on your own
+	r_pocket = /obj/item/teleportation_scroll/apprentice/announcement // You just get to the station, then you're on your own
 	r_hand = /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty
 
 /// Randomise outfit
@@ -40,3 +40,10 @@
 	var/obj/item/wizard_diploma/diploma = locate() in wizard.back
 	if(diploma)
 		diploma.owner = wizard.mind
+
+/// Special scroll that announces the wizard's teleporting
+/obj/item/teleportation_scroll/apprentice/announcement
+
+/obj/item/teleportation_scroll/apprentice/announcement/on_spell_cast(datum/action/cooldown/spell/cast_spell, mob/living/cast_on)
+	priority_announce("Encrypted communications intercepted in the vicinity of [station_name()]. There is an unknown threat aboard.", "Security Alert", ANNOUNCER_INTERCEPT)
+	return ..()


### PR DESCRIPTION
## About The Pull Request
Journeyman Wizards and Lone Ops now give out a priority alert to the crew when they spawn.

Journeyman Wiz's do it when they teleport in.
Lone Ops have a two minute head start before they get caught, to actually give them time to use their uplink.

## Why It's Good For The Game

something we wanted to have, the two of them sharing the same non-specific message is good for a few things, it can be extended to other stuff if we feel like it needs to be

## Changelog


:cl:
balance: NanoTrasen have increased the ability of their sensors and can now detect the arrival of two antagonists that they could not before.
/:cl:
