### PR TITLE
Advanced Sensory Equipment (New Station Trait)

### DIFF
--- a/code/__DEFINES/orb/signals.dm
+++ b/code/__DEFINES/orb/signals.dm
@@ -1,2 +1,8 @@
+/// signal for when uplinks purchase an item
+#define COMSIG_GLOB_UPLINK_PURCHASE "!uplink_purchase"
+
+/// signal for blood brother steal objective completion
+#define COMSIG_GLOB_BB_PAD_COMPLETE "!bb_pad_complete"
+
 /// signal for when you add quirks
 #define COMSIG_QUIRK_ADDED "quirk_added"

--- a/orbstation/code/antagonists/blood_brothers.dm
+++ b/orbstation/code/antagonists/blood_brothers.dm
@@ -97,6 +97,8 @@
 			continue
 		qdel(possible_implant)
 		to_chat(brother.current, span_notice("Your implant fizzles away! Objective Complete."))
+	if(CONFIG_GET(flag/log_traitor))
+		WRITE_LOG(GLOB.world_game_log, "BLOOD BROTHER: [name] delivered a [steal_objective.steal_target] at [worldtime2text()].")
 
 /// generates a light steal objective if there are no objectives and then from then on generates murder or heist objectives
 /datum/team/brother_team/forge_single_objective()
@@ -160,6 +162,8 @@
 /obj/item/implant/holo_pad_projector/proc/pad_completion()
 	SIGNAL_HANDLER
 	SEND_SIGNAL(src, COMSIG_BB_BOUNTY_SUCCESS)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_BB_PAD_COMPLETE)
+
 
 /// syndicate holo bounty pad capable of sending items to the syndicate in exchange for some gear.
 /obj/effect/holo_pad

--- a/orbstation/code/antagonists/rulesets_midround.dm
+++ b/orbstation/code/antagonists/rulesets_midround.dm
@@ -186,3 +186,7 @@
 	if(!spawn_locs.len)
 		return MAP_ERROR
 	new_character.forceMove(pick(spawn_locs))
+	addtimer(CALLBACK(src, PROC_REF(delay_announce)), 2 MINUTES)
+
+/datum/dynamic_ruleset/midround/from_ghosts/lone_operative/proc/delay_announce()
+	priority_announce("Encrypted communications intercepted in the vicinity of [station_name()]. There is an unknown threat aboard.", "Security Alert", ANNOUNCER_INTERCEPT)

--- a/orbstation/code/antagonists/wizard_journeyman/journeyman_outfit.dm
+++ b/orbstation/code/antagonists/wizard_journeyman/journeyman_outfit.dm
@@ -12,7 +12,7 @@
 		/obj/item/wizard_diploma = 1, )
 	ears = /obj/item/radio/headset
 	shoes = /obj/item/clothing/shoes/sandal/magic
-	r_pocket = /obj/item/teleportation_scroll/apprentice // You just get to the station, then you're on your own
+	r_pocket = /obj/item/teleportation_scroll/apprentice/announcement // You just get to the station, then you're on your own
 	r_hand = /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty
 
 /// Randomise outfit
@@ -40,3 +40,10 @@
 	var/obj/item/wizard_diploma/diploma = locate() in wizard.back
 	if(diploma)
 		diploma.owner = wizard.mind
+
+/// Special scroll that announces the wizard's teleporting
+/obj/item/teleportation_scroll/apprentice/announcement
+
+/obj/item/teleportation_scroll/apprentice/announcement/on_spell_cast(datum/action/cooldown/spell/cast_spell, mob/living/cast_on)
+	priority_announce("Encrypted communications intercepted in the vicinity of [station_name()]. There is an unknown threat aboard.", "Security Alert", ANNOUNCER_INTERCEPT)
+	return ..()

--- a/orbstation/code/modules/station_traits/sensitive_equipment.dm
+++ b/orbstation/code/modules/station_traits/sensitive_equipment.dm
@@ -1,26 +1,85 @@
-/// Station trait that gives the station information on syndicate activity on the station, but also fires false positives
+#define FALSE_ALARM_COOLDOWN_LENGTH_MIN (30 SECONDS)
+#define FALSE_ALARM_COOLDOWN_LENGTH_MAX (1 MINUTES)
+#define SENSOR_TYPE_PROBABILITY 50
+#define INTRUDER_ANNOUNCE_PROBABILITY 5
+
+/// Station trait that gives the station information on syndicate activity on the station, but sometimes fires false positives
 /datum/station_trait/sensitive_equipment
 	name =  "Advanced Sensory Equipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
 	show_in_report = TRUE
 	report_message = "We have installed advanced sensors, we will alert you to all syndicate activity on the station."
-	trait_processes = TRUE
+	/// allows for cooldown of false alarms when it is active.
+	COOLDOWN_DECLARE(false_alarm_cooldown)
+	COOLDOWN_DECLARE(objective_announcement_cooldown)
+	COOLDOWN_DECLARE(purchase_announcement_cooldown)
 
 	force = TRUE // TURN THIS OFF
 
+/datum/station_trait/sensitive_equipment/New()
+	trait_processes = prob(100) // when this triggers, the false alarm version of this trait will activate
+	return ..()
+
+
 /datum/station_trait/sensitive_equipment/on_round_start()
 	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED, PROC_REF(activate_objective_announcement))
+	RegisterSignal(SSdcs, COMSIG_GLOB_BB_PAD_COMPLETE, PROC_REF(activate_objective_announcement))
+	RegisterSignal(SSdcs, COMSIG_GLOB_UPLINK_PURCHASE, PROC_REF(activate_purchase_announcement))
+	COOLDOWN_START(src, false_alarm_cooldown, rand(FALSE_ALARM_COOLDOWN_LENGTH_MIN, FALSE_ALARM_COOLDOWN_LENGTH_MAX))
+
+/datum/station_trait/sensitive_equipment/process(delta_time)
+	if(!COOLDOWN_FINISHED(src, false_alarm_cooldown))
+		return
+
+	COOLDOWN_START(src, false_alarm_cooldown, rand(FALSE_ALARM_COOLDOWN_LENGTH_MIN, FALSE_ALARM_COOLDOWN_LENGTH_MAX))
+
+	if(prob(INTRUDER_ANNOUNCE_PROBABILITY))
+		priority_announce("Encrypted communications intercepted in the vicinity of [station_name()]. There is an unknown threat aboard.", "Security Alert", ANNOUNCER_INTERCEPT)
+		return
+	if(prob(SENSOR_TYPE_PROBABILITY))
+		activate_objective_announcement()
+		return
+	activate_purchase_announcement()
+
+/// proc that finds the announcement system to call the objective announcement proc
+/datum/station_trait/sensitive_equipment/proc/activate_objective_announcement()
+	if(!COOLDOWN_FINISHED(src, objective_announcement_cooldown))
+		return
+	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
+	announcer.announce_uplink_objective()
+	COOLDOWN_START(src, objective_announcement_cooldown, 2 MINUTES)
+
+///  proc that finds the announcement system to call the uplink purchase announcement proc
+/datum/station_trait/sensitive_equipment/proc/activate_purchase_announcement()
+	if(!COOLDOWN_FINISHED(src, purchase_announcement_cooldown))
+		return
+	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
+	announcer.announce_uplink_purchase()
+	COOLDOWN_START(src, purchase_announcement_cooldown, 2 MINUTES)
+
+//allows for a global signal to be sent when any purcahse is made for the purposes of this station trait
+/datum/uplink_handler/purchase_item(mob/user, datum/uplink_item/to_purchase, atom/movable/source)
+	. = ..()
+	if(!.)
+		return FALSE
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_UPLINK_PURCHASE, to_purchase)
 
 
 /// Accuratly reads signals to alert the crew that a traitor secondary objective has been turned in
 /obj/machinery/announcement_system/proc/announce_uplink_objective()
 	if (!is_operational)
 		return
-	broadcast("We have detected encrypted communications that indicate a succesful enemy operation.", list(RADIO_CHANNEL_COMMON, RADIO_CHANNEL_SECURITY))
+	broadcast("We have detected encrypted communications that indicate a succesful enemy operation.", list(null, RADIO_CHANNEL_SECURITY))
 
 /// Accuratly reads signals to alert the crew that an item has been bought or an objective has been turned in
 /obj/machinery/announcement_system/proc/announce_uplink_purchase()
 	if (!is_operational)
 		return
-	broadcast("We have detected illicit market activity on the station.", list(RADIO_CHANNEL_COMMON, RADIO_CHANNEL_SECURITY))
+	broadcast("We have detected illicit market activity on the station.", list(null, RADIO_CHANNEL_SECURITY))
+
+#undef FALSE_ALARM_COOLDOWN_LENGTH_MIN
+#undef FALSE_ALARM_COOLDOWN_LENGTH_MAX
+#undef SENSOR_TYPE_PROBABILITY
+#undef INTRUDER_ANNOUNCE_PROBABILITY

--- a/orbstation/code/modules/station_traits/sensitive_equipment.dm
+++ b/orbstation/code/modules/station_traits/sensitive_equipment.dm
@@ -1,0 +1,26 @@
+/// Station trait that gives the station information on syndicate activity on the station, but also fires false positives
+/datum/station_trait/sensitive_equipment
+	name =  "Advanced Sensory Equipment"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 5
+	show_in_report = TRUE
+	report_message = "We have installed advanced sensors, we will alert you to all syndicate activity on the station."
+	trait_processes = TRUE
+
+	force = TRUE // TURN THIS OFF
+
+/datum/station_trait/sensitive_equipment/on_round_start()
+	. = ..()
+
+
+/// Accuratly reads signals to alert the crew that a traitor secondary objective has been turned in
+/obj/machinery/announcement_system/proc/announce_uplink_objective()
+	if (!is_operational)
+		return
+	broadcast("We have detected encrypted communications that indicate a succesful enemy operation.", list(RADIO_CHANNEL_COMMON, RADIO_CHANNEL_SECURITY))
+
+/// Accuratly reads signals to alert the crew that an item has been bought or an objective has been turned in
+/obj/machinery/announcement_system/proc/announce_uplink_purchase()
+	if (!is_operational)
+		return
+	broadcast("We have detected illicit market activity on the station.", list(RADIO_CHANNEL_COMMON, RADIO_CHANNEL_SECURITY))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5298,6 +5298,7 @@
 #include "orbstation\code\modules\events\scrubber_clog.dm"
 #include "orbstation\code\modules\looc\looc.dm"
 #include "orbstation\code\modules\looc\looc_indicators.dm"
+#include "orbstation\code\modules\station_traits\sensitive_equipment.dm"
 #include "orbstation\code\modules\station_traits\ytp_announcer.dm"
 #include "orbstation\code\modules\table_shuffle\item_decay.dm"
 #include "orbstation\code\modules\table_shuffle\report_item.dm"


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_IXzYB10Ccu](https://user-images.githubusercontent.com/116288367/224568283-f9cb487b-2137-4a56-b988-3a7ac157a2dd.png)

this is part of why i did #524, merge that first

This new, neutral station trait makes use of NEW and EXPERIMENTAL technology to more accurately read encrypted messages from the syndicate. Finally, we have information on when they smuggle items to their operatives and when they complete their missions.*

*(As long as they don't do more than one in a 2 minute span)
(And maybe also sometimes the equipment isn't set up right and it's too sensitive)
(That's a user error not out fault)

also this logs BB steal objectives to the game log when they get their syndicrate. we want that logged i think

## Why It's Good For The Game

more funny station traits, this one might be weird but it doesn't give any specific information other than "traitor is doing stuff sort of" and it can't even fully be trusted due to the misfire chance? So maybe it balances out. If two different traitors complete their objectives close to each other you don't get to know about one, it isn't really actionable information ultimately, so i think its fine enough.

## Changelog


:cl:
add: some stations in the sector may occasionally have advanced sensory equipment, which allows the crew to get updates on syndicate activity on the station, assuming that it was set up correctly, that is.
/:cl:


