### PR TITLE
Fix Blood Brothers deliveries

### DIFF
--- a/orbstation/code/antagonists/blood_brothers.dm
+++ b/orbstation/code/antagonists/blood_brothers.dm
@@ -31,6 +31,36 @@
 /datum/objective/steal/brothers
 	/// Where the objective is to be delivered to
 	var/delivery_site
+	/// Don't try to deliver these items
+	var/static/list/brothers_blacklist = list(
+		/datum/objective_item/steal/blackbox,
+		/datum/objective_item/steal/blueprints,
+		/datum/objective_item/steal/documents,
+		/datum/objective_item/steal/functionalai,
+		/datum/objective_item/steal/hdd_extraction,
+		/datum/objective_item/steal/nukedisc,
+		/datum/objective_item/steal/nuke_core,
+		/datum/objective_item/steal/supermatter,
+	)
+
+/datum/objective/steal/brothers/find_target(dupe_search_range, list/blacklist)
+	var/list/datum/mind/owners = get_owners()
+	if(!dupe_search_range)
+		dupe_search_range = get_owners()
+	var/approved_targets = list()
+	for(var/datum/objective_item/possible_item in GLOB.possible_items)
+		if(!possible_item.valid_objective_for(owners, require_owner = FALSE))
+			continue
+		if(possible_item.objective_type != OBJECTIVE_ITEM_TYPE_NORMAL)
+			continue
+		if(is_type_in_list(possible_item, brothers_blacklist))
+			continue
+		if(!is_unique_objective(possible_item.targetitem,dupe_search_range))
+			continue
+		approved_targets += possible_item
+	if (length(approved_targets))
+		return set_target(pick(approved_targets))
+	return set_target(null)
 
 /datum/objective/steal/brothers/set_target(datum/objective_item/item)
 	. = ..()
@@ -45,6 +75,7 @@
 		/datum/objective_item/steal/supermatter,
 		/datum/objective_item/steal/nuke_core,
 		/datum/objective_item/steal/functionalai,
+		/datum/objective_item/steal/hdd_extraction,
 	)
 
 /datum/objective/steal/heist_bros/find_target(dupe_search_range, list/blacklist)


### PR DESCRIPTION
## About The Pull Request

Recent upstream merge broke our Blood Brothers mechanics because it added every item to the potential pool.
This now limits it down again into the kind of items we want them to deliver to the Syndicate, so for instance no sapient AIs who would be deleted upon delivery.

Also I added stealing the R&D hard drive to the secondary heist list because that one is kind of cool.

## Why It's Good For The Game

Fixes bugs and undesirable situations.

## Changelog

:cl:
fix: Blood brothers should only be asked to deliver theft items which work
/:cl:
