### PR TITLE
Biodome Cameras And Calls Update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -615,11 +615,11 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/lesser)
 "als" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "alG" = (
@@ -1198,6 +1198,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"avJ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "avL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1548,6 +1552,9 @@
 	name = "Engineering Lockdown";
 	pixel_x = 6;
 	req_access = list("engineering")
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_y = 36
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
@@ -5188,6 +5195,9 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"bZQ" = (
+/turf/open/floor/iron/goonplaque,
+/area/station/hallway/secondary/entry)
 "bZT" = (
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
@@ -5314,6 +5324,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"cdt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cdD" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6239,9 +6253,11 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
 "cvl" = (
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "cvI" = (
@@ -7095,6 +7111,7 @@
 /area/station/hallway/secondary/entry)
 "cJd" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/bamboo,
 /area/station/command/heads_quarters/qm)
 "cJf" = (
@@ -8065,6 +8082,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/supply)
 "dey" = (
@@ -8458,10 +8476,10 @@
 	},
 /area/station/maintenance/department/science)
 "dlF" = (
-/obj/structure/railing{
-	dir = 5
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
 	},
-/turf/open/openspace,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/service/hydroponics)
 "dlT" = (
 /obj/effect/turf_decal/siding/dark,
@@ -8935,6 +8953,7 @@
 /area/station/engineering/gravity_generator)
 "dvs" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "dvD" = (
@@ -9105,6 +9124,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dzB" = (
@@ -9857,6 +9877,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "dOs" = (
@@ -12017,6 +12038,7 @@
 "eIf" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "eIi" = (
@@ -12348,6 +12370,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
 "eNx" = (
@@ -14749,13 +14772,16 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "fLr" = (
-/obj/machinery/disposal/delivery_chute{
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "fLO" = (
@@ -16288,6 +16314,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
+"gnV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "gnX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -16690,6 +16720,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "gwt" = (
@@ -17167,6 +17198,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "gFQ" = (
@@ -18452,6 +18484,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "hip" = (
@@ -19983,6 +20016,11 @@
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"hQL" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "hRc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -21290,10 +21328,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "isd" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "isp" = (
@@ -21803,6 +21841,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"iDg" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "iDh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/dark_blue/anticorner,
@@ -27437,6 +27481,13 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"kNc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/holosign/barrier/atmos/leaf{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/primary/central)
 "kNf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -27982,6 +28033,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/green,
 /area/station/commons/dorms)
+"kXD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/fore)
 "kYa" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -28559,10 +28618,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"lkt" = (
-/obj/structure/railing/corner,
-/turf/open/floor/iron/diagonal,
-/area/station/service/library)
 "lky" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/royalblue,
@@ -29139,6 +29194,10 @@
 /obj/structure/stairs/south,
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
+"lwi" = (
+/obj/structure/shipping_container,
+/turf/open/floor/wood/parquet,
+/area/station/cargo/storage)
 "lwn" = (
 /obj/effect/spawner/random/mod/maint,
 /obj/structure/cable,
@@ -31585,6 +31644,16 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
+"moV" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "moX" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32200,6 +32269,7 @@
 /area/station/commons/dorms)
 "mBS" = (
 /obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "mBT" = (
@@ -33092,6 +33162,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/circuit/green,
 /area/station/engineering/storage/tech)
+"mVY" = (
+/obj/structure/sign/departments/science/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "mWd" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
@@ -33309,6 +33384,10 @@
 /obj/structure/cable/multilayer/multiz/cable_2,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"naG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "naK" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -33780,6 +33859,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
+"niK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/fore)
 "niN" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
@@ -33913,6 +33996,7 @@
 "nnp" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "nnC" = (
@@ -34118,10 +34202,9 @@
 /area/station/service/kitchen/diner)
 "nqN" = (
 /obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
+	stack_amt = 10;
+	output_dir = 2
 	},
-/obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
@@ -34316,6 +34399,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
+"nvk" = (
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "nvv" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/medical/surgery_tool,
@@ -38839,6 +38926,10 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"pgD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "pgM" = (
 /obj/item/stack/ore/glass/basalt,
 /turf/open/misc/asteroid/airless,
@@ -39540,6 +39631,10 @@
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/eighties/red,
 /area/station/hallway/secondary/exit/departure_lounge)
+"pwQ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/fakepit,
+/area/station/hallway/primary/aft)
 "pwU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40401,6 +40496,10 @@
 /obj/item/gun/syringe,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"pPw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pPI" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Storage Entrance"
@@ -40683,6 +40782,7 @@
 	req_access = list("ordnance")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "pVE" = (
@@ -41516,6 +41616,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/catwalk_floor,
 /area/station/command/gateway)
+"qmd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "qml" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -42077,6 +42186,11 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/bronze,
 /area/station/service/library)
+"qxo" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "qxr" = (
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/large,
@@ -43274,6 +43388,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "qUA" = (
@@ -44142,7 +44257,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/diagonal,
-/area/station/service/library)
+/area/station/hallway/primary/central)
 "rkF" = (
 /obj/structure/railing{
 	dir = 4
@@ -44790,6 +44905,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/security/engine,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "rvQ" = (
@@ -50306,7 +50422,7 @@
 "tFL" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
-/turf/open/floor/fakebasalt,
+/turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
 "tFU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50351,6 +50467,9 @@
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_y = 32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "tGC" = (
@@ -50362,6 +50481,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "tGF" = (
@@ -50372,6 +50492,7 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tGI" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "tGP" = (
@@ -51164,7 +51285,6 @@
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "tZE" = (
@@ -53664,6 +53784,10 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/carpet,
 /area/station/security/warden)
+"vdw" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "vdE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
@@ -56343,6 +56467,14 @@
 "wgo" = (
 /turf/closed/wall,
 /area/station/maintenance/fore/lesser)
+"wgq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "wgz" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -56528,6 +56660,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "wkD" = (
@@ -57398,6 +57531,9 @@
 /area/station/biodome/aft)
 "wyE" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wyF" = (
@@ -58735,6 +58871,7 @@
 	name = "Mining Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
 "wYN" = (
@@ -61300,7 +61437,7 @@
 "xXi" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker,
-/turf/open/floor/fakebasalt,
+/turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
 "xXo" = (
 /obj/machinery/light/directional/east,
@@ -61984,6 +62121,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
+"yjN" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/hydroponics)
 "yjR" = (
 /obj/structure/closet{
 	name = "Evidence Closet 5"
@@ -88654,7 +88798,7 @@ pKF
 qdW
 cJU
 cJU
-cJU
+avJ
 cJU
 cJU
 agH
@@ -93294,7 +93438,7 @@ mov
 bCN
 fdL
 fdL
-hyE
+kXD
 hyE
 aUM
 qqO
@@ -94611,7 +94755,7 @@ ePT
 bAL
 ota
 fPs
-frW
+pgD
 ota
 oAe
 fsn
@@ -94877,13 +95021,13 @@ gyq
 gzb
 xTY
 qDk
-nTx
+gnV
 eEW
 uMM
 nnp
-nTx
+nvk
 fAP
-nTx
+naG
 jUJ
 nTx
 nTx
@@ -95132,12 +95276,12 @@ iYy
 oAe
 vcb
 gzb
-xTY
+qxo
 kOT
 lJl
 lJl
-lJl
-lJl
+iDg
+iDg
 oca
 vDf
 vDf
@@ -95396,7 +95540,7 @@ lxd
 lxd
 lxd
 vOY
-nTx
+gnV
 kcZ
 vWz
 nTx
@@ -96369,7 +96513,7 @@ eBC
 eBC
 aLk
 aLk
-aLk
+niK
 xXo
 aLk
 aLk
@@ -97395,7 +97539,7 @@ dZv
 sBz
 rwj
 gwG
-aLk
+niK
 cYR
 wXD
 dTs
@@ -99194,7 +99338,7 @@ kct
 sBz
 eBC
 eBC
-aLk
+niK
 eBC
 jZe
 dBO
@@ -141865,7 +142009,7 @@ ycq
 hgs
 fDn
 fDn
-fDn
+bZQ
 fDn
 fDn
 hoj
@@ -156252,8 +156396,8 @@ dIi
 vzf
 fRK
 fEG
+yjN
 ydh
-kKU
 kKU
 dIi
 sZD
@@ -156510,7 +156654,7 @@ aJa
 dpE
 pAz
 dlF
-pvw
+ydh
 kKU
 dIi
 sZD
@@ -157569,7 +157713,7 @@ xfC
 weR
 weR
 rkx
-lkt
+ajB
 weR
 weR
 cZN
@@ -157824,10 +157968,10 @@ oHW
 uyN
 vXZ
 rqE
-vop
+kNc
 cvl
+psK
 xly
-nxg
 nxg
 xly
 nxg
@@ -158081,9 +158225,9 @@ uJB
 lEX
 ioj
 qMz
-uJB
+qmd
 als
-gux
+wgq
 gux
 gux
 gux
@@ -158283,7 +158427,7 @@ dJN
 pLp
 jXN
 rII
-jXN
+mVY
 fjt
 sAN
 vmQ
@@ -158788,7 +158932,7 @@ kqB
 rKS
 dJN
 cLA
-cLA
+qfG
 dJN
 vUU
 vUU
@@ -158853,7 +158997,7 @@ rAq
 xBf
 vop
 uJB
-psK
+hQL
 rYO
 fQs
 fQs
@@ -159301,7 +159445,7 @@ hoP
 gRK
 rKS
 dJN
-cLA
+qfG
 cLA
 dJN
 czJ
@@ -166853,7 +166997,7 @@ gbr
 vos
 dQF
 dyz
-nTy
+pwQ
 mpH
 xzy
 lqj
@@ -167111,7 +167255,7 @@ lqj
 whu
 xzy
 rut
-lqj
+vdw
 xzy
 qRp
 xLQ
@@ -171922,7 +172066,7 @@ tWy
 qxL
 sBt
 sGo
-sBt
+cdt
 jCy
 ovE
 ovE
@@ -172179,7 +172323,7 @@ bJR
 euh
 sBt
 sGo
-sBt
+pPw
 lTT
 mAB
 ovE
@@ -172435,7 +172579,7 @@ xdO
 iXN
 qLq
 sBt
-sGo
+moV
 sBt
 jCy
 ovE
@@ -172693,7 +172837,7 @@ bUG
 vEr
 sBt
 sGo
-sBt
+cdt
 jCy
 ovE
 ovE
@@ -174762,7 +174906,7 @@ rRv
 rRv
 rRv
 rRv
-rRv
+xvk
 xvk
 xvk
 xvk
@@ -175019,9 +175163,9 @@ rRv
 rRv
 hNy
 rRv
-rRv
 xvk
-tHt
+cMq
+lwi
 tHt
 tHt
 kWo
@@ -175276,9 +175420,9 @@ rRv
 hNy
 hNy
 hNy
-rRv
 xvk
-tHt
+cMq
+cMq
 tHt
 tHt
 kWo
@@ -175533,9 +175677,9 @@ hNy
 hNy
 hNy
 hNy
-hNy
 xvk
-tHt
+cMq
+cMq
 tHt
 fGW
 kWo
@@ -175790,7 +175934,7 @@ rRv
 hNy
 hNy
 hNy
-rRv
+xvk
 xvk
 xvk
 xvk

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1691,6 +1691,11 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
+"aFg" = (
+/obj/structure/cable/layer1,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aFm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -1895,6 +1900,7 @@
 	location = "Bridge"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aJI" = (
@@ -4530,7 +4536,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "bNa" = (
-/obj/structure/chair/sofa/bench{
+/obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -5790,6 +5796,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/donk,
 /area/station/hallway/secondary/service)
+"cnx" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "cnA" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -5902,6 +5914,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "cqe" = (
@@ -10417,13 +10430,11 @@
 /turf/open/floor/stone,
 /area/station/service/bar)
 "dYS" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
 /obj/structure/cable,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dYX" = (
@@ -10695,7 +10706,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/sofa/bench,
+/obj/structure/chair/sofa/bench/solo,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "efa" = (
@@ -11756,6 +11767,10 @@
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Xenobiology Pals  Pen";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
@@ -22044,6 +22059,11 @@
 /obj/effect/landmark/navigate_destination/dockesc,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"iJi" = (
+/obj/structure/cable,
+/obj/machinery/holopad/secure,
+/turf/open/floor/catwalk_floor/titanium,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "iJt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -23926,6 +23946,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jyN" = (
@@ -24272,6 +24295,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"jGa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Port RD Entrance"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "jGd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -26822,11 +26855,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
 "kDg" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Research Division Starboard";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "kDp" = (
@@ -29714,7 +29749,7 @@
 /area/station/security/execution/education)
 "lFQ" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Science - Genetics Ape Pit"
+	c_tag = "Research - Genetics Ape Pit"
 	},
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -30801,11 +30836,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mba" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "mbe" = (
@@ -31194,6 +31229,12 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"mhm" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "mhJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube{
@@ -31989,13 +32030,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"myB" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/fakebasalt,
-/area/station/hallway/primary/aft)
 "myL" = (
 /obj/machinery/computer/atmos_control/air_tank{
 	dir = 1
@@ -32860,12 +32894,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
-"mQZ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/service/kitchen/diner)
 "mRe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -34420,6 +34448,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"nxu" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "nxA" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment{
@@ -36612,7 +36646,7 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "onM" = (
-/obj/structure/chair/sofa/bench{
+/obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -37724,6 +37758,16 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"oKk" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Server Room Access";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron,
+/area/station/science/research)
 "oKs" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/smooth_half,
@@ -38772,7 +38816,7 @@
 "pfS" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/camera/directional/north{
-	c_tag = "Science - Entrance"
+	c_tag = "Research - Entrance"
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -39141,12 +39185,6 @@
 "pnf" = (
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
-"pnh" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science)
 "pnj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40312,6 +40350,11 @@
 /obj/effect/decal/cleanable/grand_remains,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"pOT" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/science/research)
 "pPe" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -41568,10 +41611,10 @@
 /area/station/medical/medbay/central)
 "qnB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qnI" = (
@@ -42721,19 +42764,13 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "qKL" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
-"qKT" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/fakebasalt,
-/area/station/hallway/primary/aft)
 "qKY" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/gambling,
@@ -42998,9 +43035,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "qQg" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Starboard RD Entrance";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -46518,7 +46558,7 @@
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 1
 	},
-/obj/structure/chair/sofa/bench,
+/obj/structure/chair/sofa/bench/solo,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "shL" = (
@@ -47516,9 +47556,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sDl" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/holopad/secure,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "sDq" = (
@@ -51123,6 +51163,7 @@
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "tZE" = (
@@ -52350,8 +52391,11 @@
 /turf/open/openspace,
 /area/station/biodome/fore)
 "uCq" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Robotics Access";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "uCt" = (
@@ -55002,7 +55046,6 @@
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -3
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "vFK" = (
@@ -58380,10 +58423,10 @@
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
 "wSn" = (
-/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "wSu" = (
@@ -58959,13 +59002,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"xdS" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/fakebasalt,
-/area/station/hallway/primary/aft)
 "xdT" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
@@ -59059,10 +59095,6 @@
 /obj/item/book/random,
 /turf/open/floor/bronze,
 /area/station/service/library)
-"xfJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/closed/wall,
-/area/station/security/processing)
 "xfO" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -61085,7 +61117,7 @@
 	name = "test subject's closet"
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Science - Genetics"
+	c_tag = "Research - Genetics"
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
@@ -82660,7 +82692,7 @@ kuz
 bJr
 nhR
 mqX
-wxc
+aFg
 mdC
 rhL
 xuo
@@ -92499,7 +92531,7 @@ lCm
 kbF
 kbF
 kbF
-cTA
+lUJ
 cTA
 kZi
 vQj
@@ -93013,7 +93045,7 @@ vxL
 tIw
 cTA
 jGz
-lUJ
+cTA
 dCX
 etY
 vxL
@@ -95840,7 +95872,7 @@ xTN
 rIz
 tCU
 nAq
-mQZ
+fOK
 dMK
 fOK
 fOK
@@ -148197,7 +148229,7 @@ lHJ
 nhR
 sSm
 sSm
-sSm
+iJi
 xMJ
 lWa
 xKr
@@ -159535,7 +159567,7 @@ qva
 qva
 dnM
 byj
-hqB
+jGa
 hqB
 hqB
 hqB
@@ -160825,7 +160857,7 @@ rfB
 uES
 dCg
 xUK
-kAO
+pOT
 chi
 ljn
 xDw
@@ -162097,7 +162129,7 @@ vcN
 dJN
 aqd
 aqd
-pnh
+dJN
 cwe
 tcQ
 dCg
@@ -162697,11 +162729,11 @@ lqj
 lqj
 psp
 fRR
-lqj
 jyW
 tqk
 tqk
-xdS
+mhm
+whu
 lqj
 lqj
 lqj
@@ -162874,7 +162906,7 @@ eZh
 eZh
 iMY
 eZh
-eZh
+ghd
 qQg
 wyo
 wEE
@@ -162954,11 +162986,11 @@ nTy
 lqj
 nTy
 nTy
-nTy
 vSJ
 qwf
 rVm
-myB
+nxu
+whu
 nTy
 nTy
 lqj
@@ -163211,11 +163243,11 @@ nTy
 lqj
 nTy
 nTy
-nTy
 vSJ
 tFL
 xXi
-myB
+nxu
+whu
 nTy
 nTy
 lqj
@@ -163468,11 +163500,11 @@ nTy
 lqj
 nTy
 nTy
-yjM
 xXP
 wkD
 wkD
-qKT
+cnx
+whu
 nTy
 nTy
 lqj
@@ -163904,7 +163936,7 @@ iFE
 gsf
 fOF
 kFW
-qCr
+oKk
 bTC
 kAO
 qfx
@@ -166475,7 +166507,7 @@ cLA
 dJN
 vaY
 eZh
-eZh
+iMY
 ghd
 jtN
 rXN
@@ -166581,7 +166613,7 @@ ePm
 ePm
 aWy
 aYB
-xfJ
+rRy
 lul
 vFF
 arN
@@ -173717,7 +173749,7 @@ lsx
 yeE
 vJH
 ceH
-ceH
+vJH
 tLm
 ceH
 vJH

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -21720,6 +21720,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iBA" = (


### PR DESCRIPTION
- remove a stray decals and a pipe
- moves the coffee and emergency enclosure in the grotto by one tile
- three science cameras renamed to research cameras and fixes camera blindspots in the research division
- gave a fire extinguisher to cargo bay
- tweaked some of the diner benches
- removes a window from the QM office, as it smoothes uglily with the mining dock access windows
- moved the bar and diner holopads a bit
- updates the AI Sat, Captain's Office and HoS Office holopads to be Secure Holopads (heads of staff can't autoconnect)
- fixes a missing wire, detective's office is no longer depowered
- realigns upper library exit
- adds more dirt
- makes disposals use the proper outlet, fixes stacker directions
- adds the goon plaque
- adds missing fire alarms to various places
- adds a decorative shipping container to cargo
- adds a third botanist closet