### PR TITLE
Wound tending is less slow on the dead.

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -84,12 +84,10 @@
 	var/target_msg = "[user] fixes some of [target]'s wounds" //see above
 	var/brute_healed = brutehealing
 	var/burn_healed = burnhealing
-	if(target.stat == DEAD) //dead patients get way less additional heal from the damage they have.
-		brute_healed += round((target.getBruteLoss() * (brute_multiplier * 0.2)),0.1)
-		burn_healed += round((target.getFireLoss() * (burn_multiplier * 0.2)),0.1)
-	else
-		brute_healed += round((target.getBruteLoss() * brute_multiplier),0.1)
-		burn_healed += round((target.getFireLoss() * burn_multiplier),0.1)
+	//ORBSTATION REMOVAL: death no longer affects healing speed
+	//Instead, damage amounts higher than 200 are healed as if they were 200
+	brute_healed += round((min(target.getBruteLoss(), 200) * brute_multiplier),0.1)
+	burn_healed += round((min(target.getFireLoss(), 200) * burn_multiplier),0.1)
 	if(!get_location_accessible(target, target_zone))
 		brute_healed *= 0.55
 		burn_healed *= 0.55


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the multiplier on wound tending surgery that makes it only 20% as effective on corpses. Instead, healing rate via wound tending is absolutely capped at the speed that comes with 200 of a damage type (enough to kill on its own). Thus, healing above 200 brute or burn will not be _incredibly_ fast.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wound tending is, by far, the most boring part of medical's job - you have to stand still watching a progress bar fill up over and over while a number slowly ticks down to zero. It is also the main way to remove wounds from a corpse, so if someone is dead from massive blunt force trauma you have little choice but to stand there for several minutes tending wounds. This is neither engaging nor interesting, nor _fun_. Allegedly, the purpose of this slowdown is to incentivize getting people back on their feet without bothering to heal all their damage, but even getting to _that_ point takes a long while. And given that medicine is usually just fine for removing damage from living people, tend wounds is _mostly_ used on the dead.

This does nothing to speed up the harder parts of revival, anyway - repairing and replacing organs, fixing husking, and so on. It just noticeably speeds up the least interesting part and lets medical players do something other than stand around waiting.

If this turns out to be _too_ powerful, and people are coming back to life too fast, we can look for another solution, but more often than not if someone's only ailment is that they took enough damage to die, they're an easy fix anyway.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Tend wounds speed is no longer affected by death, but it does not speed up further past 200 damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
