### PR TITLE
Corrects debug values

### DIFF
--- a/orbstation/code/modules/station_traits/sensitive_equipment.dm
+++ b/orbstation/code/modules/station_traits/sensitive_equipment.dm
@@ -1,5 +1,5 @@
-#define FALSE_ALARM_COOLDOWN_LENGTH_MIN (30 SECONDS)
-#define FALSE_ALARM_COOLDOWN_LENGTH_MAX (1 MINUTES)
+#define FALSE_ALARM_COOLDOWN_LENGTH_MIN (20 MINUTES)
+#define FALSE_ALARM_COOLDOWN_LENGTH_MAX (30 MINUTES)
 #define SENSOR_TYPE_PROBABILITY 50
 #define INTRUDER_ANNOUNCE_PROBABILITY 5
 
@@ -18,7 +18,7 @@
 	force = TRUE // TURN THIS OFF
 
 /datum/station_trait/sensitive_equipment/New()
-	trait_processes = prob(100) // when this triggers, the false alarm version of this trait will activate
+	trait_processes = prob(30) // when this triggers, the false alarm version of this trait will activate
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request

An earlier PR was merged with debug values enabled.

## Why It's Good For The Game

We don't want to receive a false alarm every 30-60 seconds.

## Changelog

technically not player facing because this has never been in a round before