### PR TITLE
Biodome: Wires and Wires Update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -308,10 +308,10 @@
 /area/station/science/genetics)
 "afK" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "afP" = (
@@ -2063,6 +2063,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"aMv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "aMx" = (
 /turf/open/floor/noslip,
 /area/station/service/janitor)
@@ -2305,7 +2310,6 @@
 /turf/open/floor/grass,
 /area/station/biodome/fore)
 "aQu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -2561,6 +2565,7 @@
 "aVA" = (
 /obj/structure/toilet,
 /obj/structure/barricade/wooden,
+/obj/structure/mirror/directional/west,
 /turf/open/floor/plating,
 /area/station/science/research)
 "aVD" = (
@@ -2718,6 +2723,10 @@
 /obj/machinery/grill,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"aZn" = (
+/obj/structure/cable,
+/turf/open/floor/glass/reinforced,
+/area/station/maintenance/starboard/lesser)
 "aZt" = (
 /obj/structure/railing{
 	dir = 8
@@ -3781,9 +3790,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "bwz" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -5205,6 +5214,15 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/grass,
 /area/station/biodome)
+"cab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "caf" = (
 /obj/effect/spawner/structure/window/hollow/middle{
 	dir = 4
@@ -5238,6 +5256,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "caT" = (
@@ -6488,6 +6507,14 @@
 "cyq" = (
 /turf/open/floor/eighties/red,
 /area/station/hallway/secondary/exit/departure_lounge)
+"cyy" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "cyC" = (
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/carpet,
@@ -7560,12 +7587,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"cSL" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "cTv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/north,
@@ -8377,6 +8398,7 @@
 "dju" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/full,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "djE" = (
@@ -8407,11 +8429,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "djQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
 "dka" = (
@@ -9673,7 +9697,6 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/white,
@@ -9720,6 +9743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
 "dKJ" = (
@@ -10594,6 +10618,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"ebT" = (
+/obj/item/stack/sheet/iron/five,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "ebY" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/disposalpipe/segment{
@@ -10620,6 +10649,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"ecr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/cargo/storage)
 "ecB" = (
 /obj/machinery/computer/shuttle/mining{
 	req_access = null
@@ -10712,6 +10747,13 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"eez" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "eeG" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -11151,7 +11193,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
@@ -11811,6 +11852,9 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
 "eET" = (
@@ -12371,6 +12415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
 "eNx" = (
@@ -14519,6 +14564,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
 "fEW" = (
@@ -14588,7 +14634,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "fGu" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -14719,13 +14764,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"fKs" = (
-/obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "fKy" = (
 /obj/machinery/duct,
 /turf/open/misc/asteroid,
@@ -14841,6 +14879,16 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"fMu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome)
 "fMx" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -14912,6 +14960,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "fNw" = (
@@ -14942,6 +14991,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fNU" = (
@@ -15383,7 +15433,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -15572,6 +15621,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fYo" = (
@@ -16182,7 +16232,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "gld" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -16399,6 +16448,7 @@
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "gqF" = (
@@ -18664,6 +18714,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/circuit,
 /area/station/science/robotics/mechbay)
+"hlw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "hlC" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/two,
@@ -18852,6 +18910,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"hpw" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/lesser)
 "hpD" = (
 /obj/structure/sign/warning/test_chamber/directional/south,
 /obj/machinery/firealarm/directional/east,
@@ -18928,6 +18990,7 @@
 /obj/effect/mob_spawn/corpse/human/assistant,
 /obj/item/clothing/head/utility/hardhat/welding,
 /obj/item/clothing/suit/hazardvest,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "hrn" = (
@@ -21755,9 +21818,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -22020,6 +22080,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"iGO" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "iGQ" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/misc/asteroid,
@@ -22725,9 +22793,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iYr" = (
@@ -22871,7 +22936,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/radshelter/civil)
 "jaT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -23339,6 +23403,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"jko" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/lesser)
 "jks" = (
 /obj/docking_port/stationary/laborcamp_home{
 	dir = 2
@@ -24042,6 +24109,7 @@
 "jzR" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "jzX" = (
@@ -24453,24 +24521,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
-"jHO" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "jHS" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/terracotta/small,
@@ -24694,6 +24744,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "jNb" = (
@@ -25581,6 +25632,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "kfw" = (
@@ -27940,6 +27992,9 @@
 /area/station/service/theater)
 "kUT" = (
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
 "kUY" = (
@@ -28631,7 +28686,6 @@
 "lkJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -29078,10 +29132,6 @@
 "lty" = (
 /turf/open/floor/plating/plasma,
 /area/station/maintenance/space_hut/plasmaman)
-"ltI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ltW" = (
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
@@ -29860,6 +29910,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"lGA" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/lesser)
 "lGB" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -30166,6 +30221,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "lOc" = (
@@ -30571,6 +30627,7 @@
 /area/station/service/hydroponics/garden)
 "lVh" = (
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "lVx" = (
@@ -30663,6 +30720,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "lXk" = (
 /obj/structure/fluff/broken_flooring,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "lXm" = (
@@ -33095,15 +33153,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mUg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "mUl" = (
@@ -33208,7 +33266,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -33237,6 +33294,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mYa" = (
@@ -34529,11 +34587,11 @@
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
 "nxo" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nxu" = (
@@ -34734,7 +34792,6 @@
 /area/station/command/heads_quarters/hop)
 "nBa" = (
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -35449,6 +35506,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"nPF" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/lesser)
 "nPH" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -35741,6 +35803,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nVa" = (
@@ -35791,7 +35854,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/white,
@@ -36046,7 +36108,6 @@
 /turf/open/floor/wood/tile,
 /area/station/service/janitor)
 "obk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
@@ -36904,6 +36965,7 @@
 /area/station/hallway/primary/central/fore)
 "osg" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "osi" = (
@@ -39317,7 +39379,6 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "pod" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -40049,12 +40110,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "pGw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pGx" = (
@@ -40405,6 +40466,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"pNK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pNM" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light/directional/west,
@@ -40506,6 +40573,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"pPN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "pQc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40535,9 +40610,6 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
 "pQw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/delivery,
@@ -41027,7 +41099,6 @@
 "qbL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -41623,6 +41694,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "qml" = (
@@ -41717,6 +41789,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qnB" = (
@@ -42786,6 +42859,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
+"qJa" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qJl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43425,7 +43502,6 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/white,
 /area/station/medical/medbay/lobby)
@@ -45218,6 +45294,7 @@
 "rBF" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "rBO" = (
@@ -45910,6 +45987,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"rSu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/cargo/lobby)
 "rSx" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -46403,7 +46488,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -47398,7 +47482,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "syv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -50049,6 +50132,7 @@
 "tyM" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/food_or_drink,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "tyU" = (
@@ -50369,6 +50453,7 @@
 "tFi" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "tFm" = (
@@ -50431,6 +50516,7 @@
 "tFY" = (
 /obj/structure/lattice/catwalk,
 /obj/item/storage/fancy/pickles_jar,
+/obj/effect/landmark/blobstart,
 /turf/open/openspace,
 /area/station/maintenance/port/central)
 "tFZ" = (
@@ -51292,15 +51378,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"tZH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tZU" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison)
@@ -51853,7 +51930,6 @@
 /turf/open/floor/grass,
 /area/station/biodome/aft)
 "unD" = (
-/obj/structure/mirror/directional/east,
 /obj/structure/stairs/east,
 /turf/open/floor/iron/stairs/left{
 	dir = 8
@@ -52649,9 +52725,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "uFc" = (
-/obj/machinery/disposal/bin,
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/effect/turf_decal/bot,
+/obj/machinery/computer/order_console/cook{
+	dir = 8
+	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
 "uFA" = (
@@ -54013,6 +54090,14 @@
 /obj/effect/turf_decal/tile/dark_red/half,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"viz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "viF" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
@@ -54311,9 +54396,9 @@
 /obj/structure/sign/painting/library{
 	pixel_x = -32
 	},
-/obj/machinery/computer/order_console/cook{
-	dir = 4
-	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
 "vnT" = (
@@ -54511,6 +54596,10 @@
 "vrU" = (
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"vrY" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/grass,
+/area/station/hallway/primary/starboard)
 "vsb" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
@@ -56377,6 +56466,10 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/white,
 /area/station/medical/treatment_center)
+"weY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/port/central)
 "wfm" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
@@ -58463,7 +58556,6 @@
 "wQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Genetics)"
@@ -59210,6 +59302,11 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
+"xfs" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "xft" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -59248,12 +59345,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"xgK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/station/hallway/secondary/service)
 "xgT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -59607,7 +59698,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/white,
@@ -60425,18 +60515,6 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"xFk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "xFv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -60490,6 +60568,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"xGt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/fore)
 "xGv" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
 	name = "Burn Chamber Exterior Airlock"
@@ -61296,6 +61385,7 @@
 "xUr" = (
 /obj/effect/mob_spawn/corpse/human/assistant,
 /obj/item/spear,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "xUF" = (
@@ -61834,6 +61924,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
 "yeN" = (
@@ -61967,7 +62058,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "yhZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -86238,12 +86328,12 @@ kuQ
 cgO
 rXz
 ase
-cJU
-cJU
+aMv
+ugH
 lVh
 xUr
 hrj
-ase
+cyy
 pKF
 kAo
 cJU
@@ -87269,7 +87359,7 @@ pKF
 pKF
 mkq
 dBC
-hgp
+weY
 gqA
 lXk
 pKF
@@ -87526,7 +87616,7 @@ cJU
 pKF
 pxz
 dBC
-cJU
+ugH
 cJU
 bZB
 pKF
@@ -87783,7 +87873,7 @@ pKF
 pKF
 pKF
 pKF
-rXz
+iGO
 pKF
 pKF
 pKF
@@ -88040,9 +88130,9 @@ cJU
 cJU
 cJU
 cJU
-cJU
-cJU
-cJU
+ugH
+ugH
+ugH
 pKF
 kAo
 cJU
@@ -88299,7 +88389,7 @@ rNa
 rNa
 rNa
 cJU
-hgp
+weY
 pKF
 kAo
 oTM
@@ -88556,7 +88646,7 @@ kjj
 ktg
 rNa
 hgp
-agM
+ebT
 pKF
 arC
 oTM
@@ -88813,7 +88903,7 @@ jhl
 mil
 rNa
 jwU
-cJU
+ugH
 kdk
 bmC
 bmC
@@ -92167,7 +92257,7 @@ xkX
 aqC
 vxL
 bdP
-wju
+fMu
 ngd
 cAW
 bLR
@@ -92659,7 +92749,7 @@ kFI
 qef
 mnM
 kRr
-mnM
+xnt
 kRr
 kkE
 keR
@@ -93429,7 +93519,7 @@ jvC
 kFI
 yfs
 mnM
-xnt
+mnM
 mnM
 uWr
 omi
@@ -95229,7 +95319,7 @@ aWb
 hdU
 pxZ
 niz
-xgK
+aza
 luN
 mMH
 aWb
@@ -98061,7 +98151,7 @@ fuu
 eyl
 uXm
 iMr
-fWl
+xGt
 aLk
 aLk
 ubG
@@ -99633,7 +99723,7 @@ yjs
 xnc
 xFA
 xFA
-xFA
+hlw
 xFA
 xFA
 xFA
@@ -102985,7 +103075,7 @@ ktR
 ruE
 oAe
 hYU
-ltI
+gRN
 hEa
 cAe
 oAe
@@ -106317,7 +106407,7 @@ jYS
 kND
 kND
 kND
-kND
+vrY
 lnY
 kND
 kND
@@ -146371,7 +146461,7 @@ dka
 wZS
 wBS
 fmZ
-txv
+qJa
 vLR
 qgp
 fwY
@@ -151547,7 +151637,7 @@ acV
 oLd
 aZD
 gxh
-oLd
+eez
 mXw
 oLd
 dVr
@@ -151804,7 +151894,7 @@ hbg
 hbg
 qDO
 kUH
-cSL
+kqT
 ejP
 jUz
 pxl
@@ -152320,7 +152410,7 @@ uCO
 bIP
 eyw
 bIP
-jHO
+uCO
 eyw
 ahq
 lRH
@@ -152577,7 +152667,7 @@ fkk
 kCx
 fUE
 kCx
-xFk
+fkk
 chZ
 ahq
 xeC
@@ -166402,7 +166492,7 @@ elY
 ckg
 kAs
 ckg
-ckg
+viz
 cAS
 wQl
 sbd
@@ -166410,7 +166500,7 @@ qbL
 lkJ
 lkJ
 mXf
-nAm
+pNK
 nqu
 jzd
 pGm
@@ -170331,7 +170421,7 @@ hHc
 dUQ
 hHc
 eZB
-avN
+ups
 pUs
 cEV
 uEl
@@ -170566,7 +170656,7 @@ jsf
 bsP
 ukj
 svB
-syv
+cab
 lbS
 hHc
 hHc
@@ -170588,7 +170678,7 @@ hHc
 dUQ
 hHc
 eZB
-avN
+ups
 ulQ
 cEV
 cEV
@@ -170823,7 +170913,7 @@ jsf
 vLA
 ukj
 svB
-syv
+cab
 jsf
 hHc
 hHc
@@ -170845,7 +170935,7 @@ rRv
 rRv
 rRv
 eZB
-avN
+ups
 eZB
 eZB
 cEV
@@ -171080,7 +171170,7 @@ kPb
 lrg
 ukj
 svB
-syv
+cab
 kPb
 dUQ
 dUQ
@@ -171102,7 +171192,7 @@ kcg
 eZB
 eZB
 eZB
-avN
+ups
 eZB
 lzy
 cEV
@@ -171337,7 +171427,7 @@ jsf
 bsP
 nGD
 svB
-syv
+cab
 kPb
 kPb
 kPb
@@ -171359,7 +171449,7 @@ kPb
 eZB
 iKA
 ulg
-ulg
+aZn
 isa
 ulg
 ulg
@@ -171594,7 +171684,7 @@ jsf
 bsP
 nGD
 svB
-tZH
+tjp
 nxo
 afK
 jaT
@@ -171616,7 +171706,7 @@ nUl
 eZB
 aku
 ulg
-ulg
+aZn
 eZB
 ulg
 voY
@@ -171824,7 +171914,7 @@ rAn
 wmS
 wlo
 xHE
-eNx
+rSu
 aQu
 wmO
 wGE
@@ -171873,7 +171963,7 @@ nUl
 eZB
 eZB
 eZB
-avN
+ups
 eZB
 eZB
 eZB
@@ -172387,7 +172477,7 @@ nUl
 kPb
 rRv
 eZB
-avN
+ups
 eZB
 rRv
 rRv
@@ -172644,7 +172734,7 @@ vSj
 kPb
 rRv
 eZB
-avN
+ups
 eZB
 vij
 rRv
@@ -172901,7 +172991,7 @@ nUl
 kPb
 rRv
 eZB
-avN
+ups
 ouU
 hNy
 hNy
@@ -173158,7 +173248,7 @@ nUl
 kPb
 rRv
 eZB
-avN
+ups
 ouU
 cBY
 ouU
@@ -173415,9 +173505,9 @@ nUl
 kPb
 rRv
 eZB
-avN
-avN
-avN
+ups
+ups
+ups
 aEn
 ouU
 rRv
@@ -173674,7 +173764,7 @@ rRv
 eZB
 avN
 avN
-fRI
+xfs
 avN
 ouU
 rRv
@@ -173931,8 +174021,8 @@ wLS
 wLS
 eZB
 rsW
-avN
-avN
+ups
+ups
 ouU
 rRv
 rRv
@@ -174148,7 +174238,7 @@ tlL
 jZy
 aoJ
 jGu
-jZy
+ecr
 klA
 kmi
 rYs
@@ -174174,7 +174264,7 @@ pzj
 yjd
 yjd
 svB
-tjp
+pPN
 obk
 iXY
 wkW
@@ -174189,7 +174279,7 @@ nvv
 eZB
 ihI
 avN
-avN
+ups
 ouU
 hHc
 hHc
@@ -174405,8 +174495,8 @@ tlL
 jZy
 aoJ
 mqD
-jZy
-jZy
+ecr
+ecr
 cMq
 rYs
 qzJ
@@ -174433,7 +174523,7 @@ qUA
 dTo
 edm
 bwz
-fKs
+jva
 ezH
 hud
 ayK
@@ -174446,7 +174536,7 @@ qcV
 eZB
 jgZ
 qzY
-avN
+ups
 ouU
 hHc
 hHc
@@ -174663,7 +174753,7 @@ jZy
 aoJ
 jGu
 cMq
-jZy
+ecr
 hVE
 tFU
 dTv
@@ -174703,7 +174793,7 @@ npX
 eZB
 ulQ
 qzY
-avN
+ups
 ouU
 hHc
 hHc
@@ -174920,8 +175010,8 @@ jZy
 aoJ
 jGu
 cMq
-jZy
-jZy
+ecr
+ecr
 eNs
 dKn
 meJ
@@ -174959,8 +175049,8 @@ eZB
 eZB
 eZB
 ePj
-avN
-avN
+hpw
+hpw
 ouU
 hHc
 hHc
@@ -175216,7 +175306,7 @@ aXd
 aXd
 avN
 rsW
-avN
+hpw
 rsW
 ouU
 hHc
@@ -175473,8 +175563,8 @@ ePj
 wCf
 avN
 rsW
-avN
-avN
+hpw
+jko
 ouU
 hHc
 hHc
@@ -175719,19 +175809,19 @@ eWG
 dGl
 sFY
 dGl
-avN
-avN
-jgZ
-avN
-osg
-avN
-avN
-avN
-avN
-avN
-avN
-jgZ
-avN
+hpw
+hpw
+lGA
+hpw
+nPF
+hpw
+hpw
+hpw
+hpw
+hpw
+hpw
+lGA
+jko
 ouU
 hHc
 hHc

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -57516,6 +57516,10 @@
 "wxi" = (
 /turf/open/floor/glass,
 /area/station/biodome)
+"wxw" = (
+/obj/item/grown/bananapeel/mimanapeel,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wxH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -87612,7 +87616,7 @@ pKF
 pKF
 cJU
 pKF
-cJU
+wxw
 pKF
 pxz
 dBC


### PR DESCRIPTION
- hooked up detective disposals to the system
- detective APC goes through maint, added catwalks where the hobos live so they don't get shocked....
- swaps service disposal bin with the produce order console, and actually hooks it up
- moved hydroponics holopad to the center of the room
- adds one more xeno and blob spawn
- science, medbay and cargo fully powered from maintenance, instead of from a main corridor
- abandoned airlock in the science elevator requires science access to open
- moved the science toilet mirror from the stairs onto the abandoned toilet
- added a few more event spawners
- found a place for the secret mimana peel