### PR TITLE
Resurrecting inside a Legion/Bileworm will remove stasis

### DIFF
--- a/orbstation/code/jobs/mining/safer_stomach.dm
+++ b/orbstation/code/jobs/mining/safer_stomach.dm
@@ -29,6 +29,7 @@
 	if (regenerative_stomach)
 		victim.fully_heal(HEAL_DAMAGE)
 	RegisterSignal(victim, COMSIG_MOVABLE_MOVED, PROC_REF(on_rescued))
+	RegisterSignal(victim, COMSIG_LIVING_REVIVE, PROC_REF(on_rescued))
 
 /datum/element/safe_stomach/Detach(mob/living/source, ...)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

If you come back to life while still inside a Legion or Bileworm it will remove the stasis effect.

## Why It's Good For The Game

Recently someone returned to life as a changeling inside a worm but had to yell for aid over the radio, which is silly.

## Changelog

:cl:
fix: Reviving yourself (such as via changeling revival) inside a Bileworm or Legion will remove the Stasis effect.
/:cl:
