### PR TITLE
Changes to Emag interaction with Cyborgs

### DIFF
--- a/orbstation/code/antagonists/traitor/items/cyborg_subversion.dm
+++ b/orbstation/code/antagonists/traitor/items/cyborg_subversion.dm
@@ -1,0 +1,44 @@
+// Emags now reset all cyborgs
+/mob/living/silicon/robot/emag_act(mob/user)
+	if(user == src)//To prevent syndieborgs from emagging themselves
+		return
+	if(!opened)//Cover is closed
+		if(locked)
+			to_chat(user, span_notice("You emag the cover lock."))
+			locked = FALSE
+			if(shell) //A warning to Traitors who may not know that emagging AI shells does not slave them.
+				to_chat(user, span_boldwarning("[src] seems to be controlled remotely! Emagging the interface may not work as expected."))
+		else
+			to_chat(user, span_warning("The cover is already unlocked!"))
+		return
+	if(world.time < emag_cooldown)
+		return
+	if(wiresexposed)
+		to_chat(user, span_warning("You must unexpose the wires first!"))
+		return
+
+	to_chat(user, span_notice("You emag [src]'s interface."))
+	emag_cooldown = world.time + 100
+
+	if(connected_ai && connected_ai.mind && connected_ai.mind.has_antag_datum(/datum/antagonist/malf_ai))
+		to_chat(src, span_danger("ALERT: Foreign software execution prevented."))
+		logevent("ALERT: Foreign software execution prevented.")
+		to_chat(connected_ai, span_danger("ALERT: Cyborg unit \[[src]\] successfully defended against subversion."))
+		log_silicon("EMAG: [key_name(user)] attempted to emag cyborg [key_name(src)], but they were slaved to traitor AI [connected_ai].")
+		return
+
+	to_chat(user, span_danger("Your emag attempt has succesfully triggered a system reset."))
+	ResetModel()
+	SetStun(6 SECONDS)
+	overlay_fullscreen("flash", type)
+	addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "flash", 6 SECONDS), 6 SECONDS)
+	to_chat(src, span_danger("ALERT: Unexpected systems failure detected. Short terms logs discarded to maintain system integrity."))
+
+/// new traitor item that allows to install illegal cyborg technology on a singular cyborg
+/datum/uplink_item/device_tools/syndie_borg_upgrade
+	name = "Syndicate Cyborg Upgrade"
+	desc = "A black-market cyborg upgrade that activates illegal functions on any cyborg. \
+			It can be subtley installed just like any other upgrade."
+	item = /obj/item/borg/upgrade/syndicate
+	cost = 1
+	surplus = 5

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5183,6 +5183,7 @@
 #include "orbstation\code\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\code\antagonists\traitor\items\cheese_implant.dm"
 #include "orbstation\code\antagonists\traitor\items\cursed_tome.dm"
+#include "orbstation\code\antagonists\traitor\items\cyborg_subversion.dm"
 #include "orbstation\code\antagonists\traitor\items\rebalancing.dm"
 #include "orbstation\code\antagonists\traitor\objectives\kidnapping.dm"
 #include "orbstation\code\antagonists\traitor\objectives\sabotage_machines.dm"


### PR DESCRIPTION
## About The Pull Request
emag act on a cyborg now stuns and flashes them for six seconds and informs them that they do not remember what just happened to them. it also resets their model, like when you reset an AI shell with an emag

![dreamseeker_sxyrbHeBk9](https://user-images.githubusercontent.com/116288367/226423940-7060f15b-bc66-47c4-8541-5bb5daa408d0.png)
![dreamseeker_POB9cH5WOV](https://user-images.githubusercontent.com/116288367/226423943-8b4d2f46-9b55-45f1-92e8-8d6088946021.png)

a traitor can also buy a syndicate cyborg modual if they subvert the cyborg with an upload or via AI, which both are unchanged in this PR. It costs one telecrystal and can be adjusted in the future.
![dreamseeker_KPRkYLFfM3](https://user-images.githubusercontent.com/116288367/226423913-f771bcda-bb6d-4779-954d-710353f8bb99.png)


## Why It's Good For The Game

lets just see what this does, keeps all of the functionality but in different pieces that are not that unintuitive

this can just be adjusted as needs, but it solves the repeated complaint that emag is too easy

## Changelog

:cl:
balance: emag act on cyborgs reset their model, stun them, and flash them
add: traitors can now buy the illegal cyborg module because they do not get it via emag acting on a cyborg
/:cl:
