### PR TITLE
Removes Cybernetic Implants from the medical lathe

### DIFF
--- a/orbstation/code/jobs/research/medical_designs.dm
+++ b/orbstation/code/jobs/research/medical_designs.dm
@@ -1,0 +1,39 @@
+/datum/design/cyberimp_breather
+	departmental_flags = NONE
+
+/datum/design/cyberimp_surgical
+	departmental_flags = NONE
+
+/datum/design/cyberimp_toolset
+	departmental_flags = NONE
+
+/datum/design/cyberimp_security_hud
+	departmental_flags = NONE
+
+/datum/design/cyberimp_diagnostic_hud
+	departmental_flags = NONE
+
+/datum/design/cyberimp_xray
+	departmental_flags = NONE
+
+/datum/design/cyberimp_thermals
+	departmental_flags = NONE
+
+/datum/design/cyberimp_antidrop
+	departmental_flags = NONE
+
+/datum/design/cyberimp_antistun
+	departmental_flags = NONE
+
+/datum/design/cyberimp_nutriment
+	departmental_flags = NONE
+
+/datum/design/cyberimp_nutriment_plus
+	departmental_flags = NONE
+
+/datum/design/cyberimp_reviver
+	departmental_flags = NONE
+
+/datum/design/cyberimp_thrusters
+	departmental_flags = NONE
+	

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5259,6 +5259,7 @@
 #include "orbstation\code\jobs\mining\tendril.dm"
 #include "orbstation\code\jobs\mining\voucher_sets.dm"
 #include "orbstation\code\jobs\research\digitgrade_legs.dm"
+#include "orbstation\code\jobs\research\medical_designs.dm"
 #include "orbstation\code\jobs\research\orb_limbgrower_designs.dm"
 #include "orbstation\code\jobs\research\orb_techweb.dm"
 #include "orbstation\code\map\shuttles.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This Pr removes all implants from the medical lathe. You can now only print them in robotics. 

This PR doesn't touch cybernetic organs or the medical hud. These are important for medical and it make sense for medical to have access to them. 

## Why It's Good For The Game

Putting cool implants in people is part of robotics niche. Medical already does a lot and they shouldn't be able to just print the implants and go around research. We've had robotics more often than not, and at least 1 person in science the vast majority of rounds for a couple months now so i'm comfortable making this change knowing that in the vast majority of rounds it won't be cutting the station off from a subsystem. We don't always have a roboticist and while augments are requested more than genetic powers, they're still not used often enough that on the of chance there's no one to print augments in science, it'll be very missed. In that case, they wouldn't be researched anyway so it doesn't matter that medical can't print them. 

This PR is the first in a series of PRs i'm making that will be fleshing out implants and cybernetics and making it a larger part of Robotic's job. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Medical can no longer print cybernetic implants.
:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
