### PR TITLE
Enables Limb Augmentation surgery on non organic limbs

### DIFF
--- a/orbstation/code/jobs/medical/surgery/misc.dm
+++ b/orbstation/code/jobs/medical/surgery/misc.dm
@@ -1,2 +1,2 @@
 /datum/surgery/augmentation
-	var/requires_bodypart_type = NONE
+	requires_bodypart_type = NONE

--- a/orbstation/code/jobs/medical/surgery/misc.dm
+++ b/orbstation/code/jobs/medical/surgery/misc.dm
@@ -1,0 +1,2 @@
+/datum/surgery/augmentation
+	var/requires_bodypart_type = NONE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5250,6 +5250,7 @@
 #include "orbstation\code\jobs\medical\brain_trauma.dm"
 #include "orbstation\code\jobs\medical\surgery\height_manipulation.dm"
 #include "orbstation\code\jobs\medical\surgery\lobotomy.dm"
+#include "orbstation\code\jobs\medical\surgery\misc.dm"
 #include "orbstation\code\jobs\medical\surgery\pacification.dm"
 #include "orbstation\code\jobs\medical\virology\red_eyes.dm"
 #include "orbstation\code\jobs\mining\chasm_rescue.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so you can do limb augmentation on non organic limbs. This means that you know longer have to do amputate then prosthetic replacement surgeries to replace a surplus prosthetic with robotic limb. 


## Why It's Good For The Game

It doesn't make sense that you can augment a fleshly limb not not a surplus prosthetic. Having to do two surgeries to replace a surplus prosthetic with a robotic limb sucks and takes a lot of time. This PR fixes that. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Balance: You can now do limb augmentation surgery on non organic limbs. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
