### PR TITLE
Biodome: Kitchens And Roofs Update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2282,7 +2282,9 @@
 /area/station/maintenance/central/greater)
 "aPY" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/door/airlock/wood,
+/obj/machinery/door/airlock/wood{
+	name = "Diner Canopy"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
 /turf/open/openspace,
@@ -3173,7 +3175,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "biW" = (
-/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/dark_green/full,
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "bjh" = (
@@ -7726,11 +7729,11 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "cWc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "cWe" = (
@@ -9853,8 +9856,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dNn" = (
-/obj/machinery/grill,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
+/obj/machinery/oven,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "dNw" = (
@@ -13942,6 +13946,7 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "frG" = (
+/obj/effect/landmark/event_spawn,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
@@ -14798,8 +14803,9 @@
 /area/station/ai_monitored/command/storage/eva)
 "fKW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "fLl" = (
@@ -16973,6 +16979,7 @@
 /area/station/hallway/primary/central)
 "gzM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "gzN" = (
@@ -17513,6 +17520,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"gKW" = (
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_y = 12
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen)
 "gLc" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -26158,6 +26172,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"knO" = (
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen)
 "knY" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -28638,11 +28657,7 @@
 /area/station/engineering/atmos/storage/gas)
 "ljV" = (
 /obj/effect/turf_decal/tile/dark_green/full,
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "ljW" = (
@@ -29042,14 +29057,12 @@
 "lra" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/machinery/holopad,
 /obj/machinery/requests_console/directional/west{
 	department = "Kitchen";
 	name = "Kitchen Requests Console";
 	pixel_x = 30;
 	supplies_requestable = 1
 	},
-/obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "lrb" = (
@@ -29109,6 +29122,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
+"lsD" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen)
 "lsO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_empty,
@@ -34437,13 +34454,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"nuQ" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/dark_green/full,
-/obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/kitchen)
 "nuT" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutter";
@@ -35165,14 +35175,14 @@
 /area/station/science/server)
 "nJj" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/button/door/directional/north{
 	id = "kitchencounter";
 	name = "Kitchen Lockdown";
 	pixel_x = -25;
 	req_access = list("kitchen")
 	},
-/obj/machinery/deepfryer,
+/obj/machinery/griddle,
+/obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "nJl" = (
@@ -35949,7 +35959,6 @@
 /obj/machinery/oven,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/structure/sign/clock/directional/west,
-/obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "nYc" = (
@@ -36042,10 +36051,8 @@
 /area/station/engineering/lobby)
 "oae" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/machinery/processor{
-	pixel_y = 12
-	},
-/obj/structure/table,
+/obj/machinery/deepfryer,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "oaf" = (
@@ -37872,11 +37879,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
-"oJB" = (
-/obj/machinery/vending/dinnerware,
-/obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/kitchen)
 "oJI" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/structure/window{
@@ -39278,12 +39280,16 @@
 /turf/open/water/jungle/biodome,
 /area/station/maintenance/starboard/central)
 "plL" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Kitchen"
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "plW" = (
@@ -39953,7 +39959,6 @@
 /area/station/medical/morgue)
 "pCn" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "pCv" = (
@@ -43375,12 +43380,12 @@
 	},
 /area/station/commons/storage/art)
 "qSx" = (
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap,
+/obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "qTg" = (
@@ -47438,6 +47443,11 @@
 	dir = 8
 	},
 /area/station/science/robotics/lab)
+"sxh" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen)
 "sxi" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
@@ -51172,6 +51182,12 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tUf" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/tile/dark_green/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen)
 "tUj" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -52679,6 +52695,14 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/electrical)
+"uDH" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/wood{
+	name = "Diner Canopy"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
+/area/station/service/kitchen/diner)
 "uDQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -54593,8 +54617,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/cargo/sorting)
 "vrS" = (
-/obj/machinery/chem_master/condimaster,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "vrU" = (
@@ -94045,7 +94069,7 @@ bSG
 haP
 mov
 dit
-eBC
+syw
 syw
 syw
 syw
@@ -94302,8 +94326,8 @@ eTO
 aWb
 eVG
 dit
-eBC
 syw
+knO
 oae
 dNn
 nXY
@@ -94560,7 +94584,7 @@ aWb
 eBC
 dit
 syw
-syw
+gKW
 pCn
 ndg
 tbF
@@ -94819,7 +94843,7 @@ dit
 lpd
 ljV
 vrS
-dHv
+sxh
 frG
 rMy
 pWk
@@ -95331,9 +95355,9 @@ aWb
 lUu
 vHU
 qvE
-ebK
-nuQ
-dHv
+tUf
+glT
+biW
 cHh
 xkU
 pWk
@@ -95588,8 +95612,8 @@ aWb
 eBC
 vHU
 syw
-syw
-oJB
+ebK
+pCn
 dHv
 jfn
 dFr
@@ -95844,8 +95868,8 @@ aWb
 aWb
 jgn
 vHU
-eBC
 syw
+lsD
 ctH
 dHv
 cFK
@@ -96101,7 +96125,7 @@ rnX
 aki
 aLk
 vHU
-eBC
+syw
 syw
 qSx
 plL
@@ -159581,7 +159605,7 @@ dIi
 dIi
 sZD
 sZD
-sZD
+ggF
 wYO
 uAr
 xJc
@@ -159838,7 +159862,7 @@ fkg
 hQz
 sZD
 sZD
-sZD
+ggF
 ugn
 snd
 snd
@@ -159850,7 +159874,7 @@ fbD
 qBL
 lKQ
 aPY
-lKQ
+uDH
 lKQ
 lKQ
 lKQ

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2285,8 +2285,8 @@
 /obj/machinery/door/airlock/wood{
 	name = "Diner Canopy"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
 "aQb" = (
@@ -2531,8 +2531,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/bar)
 "aUR" = (
@@ -16114,13 +16115,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "gig" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/wood{
 	name = "Bar Maintenance Hatch"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
 "giE" = (
@@ -22552,10 +22554,11 @@
 /area/station/science/cytology)
 "iRE" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/airlock/wood{
 	name = "Bar Maintenance Hatch"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
 "iSu" = (
@@ -36862,6 +36865,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"opw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "opC" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -52696,11 +52704,11 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/electrical)
 "uDH" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/airlock/wood{
 	name = "Diner Canopy"
 	},
 /obj/structure/lattice/catwalk,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
 "uDQ" = (
@@ -157803,7 +157811,7 @@ kKU
 kKU
 kKU
 kKU
-dIi
+opw
 sZD
 sZD
 sZD


### PR DESCRIPTION
- Reorganized the kitchen. It now has two of every cooking machines, and two more tables.
- The diner's canopy door is now two doors, and they are actually called diner's canopy
- Diner's canopy requires maintenance access, instead of general engineering access
- The bar's cable/pipe layer maintenance room now requires bar access OR engineering access on all three of its doors, instead of solely engineering access.