### PR TITLE
Chainsaw man

### DIFF
--- a/orbstation/code/antagonists/traitor/items/intergrated_chainsaw.dm
+++ b/orbstation/code/antagonists/traitor/items/intergrated_chainsaw.dm
@@ -1,0 +1,59 @@
+/obj/item/autosurgeon/syndicate/chainsaw
+	desc = "A single use autosurgeon that contains a combat arms-up chainsaw augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/internal/cyberimp/arm/melee/chainsaw
+
+/obj/item/organ/internal/cyberimp/arm/melee/chainsaw/l
+	zone = BODY_ZONE_L_ARM
+
+/obj/item/organ/internal/cyberimp/arm/melee/chainsaw
+	name = "arm-mounted chainsaw implant"
+	desc = "A chainsaw hand implanted inside the arm. The chainsaw emerges from the subject's arm and remains inside when not in use."
+	icon = 'icons/obj/weapons/items_and_weapons.dmi'
+	icon_state = "chainsaw_off"
+	items_to_create = list(/obj/item/chainsaw/mounted_chainsaw/implanted)
+
+/datum/uplink_item/role_restricted/intergrated_chainsaw
+	name = "Intergrated Chainsaw"
+	desc = "A chainsaw hand implanted inside the arm. The chainsaw emerges from the subject's arm and remains inside when not in use."
+	item = /obj/item/autosurgeon/syndicate/chainsaw
+	cost = 12
+	restricted_roles = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER, JOB_BOTANIST, JOB_ASSISTANT, JOB_ASSISTANT_ENG)
+	surplus = 15
+	progression_minimum = 30 MINUTES
+
+/obj/item/chainsaw/mounted_chainsaw/implanted
+	name = "mounted chainsaw"
+	desc = "A chainsaw that has replaced your arm."
+	icon_state = "chainsaw_on"
+	inhand_icon_state = "mounted_chainsaw"
+	lefthand_file = 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+	item_flags = ABSTRACT
+	w_class = WEIGHT_CLASS_HUGE
+	force = 24
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	sharpness = SHARP_EDGED
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1
+
+/obj/item/chainsaw/mounted_chainsaw/implanted/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+
+/obj/item/chainsaw/mounted_chainsaw/implanted/Destroy()
+	var/obj/item/bodypart/part
+	new /obj/item/chainsaw(get_turf(src))
+	if(iscarbon(loc))
+		var/mob/living/carbon/holder = loc
+		var/index = holder.get_held_index_of_item(src)
+		if(index)
+			part = holder.hand_bodyparts[index]
+	. = ..()
+	if(part)
+		part.drop_limb()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5187,6 +5187,7 @@
 #include "orbstation\code\antagonists\traitor\items\cheese_implant.dm"
 #include "orbstation\code\antagonists\traitor\items\cursed_tome.dm"
 #include "orbstation\code\antagonists\traitor\items\cyborg_subversion.dm"
+#include "orbstation\code\antagonists\traitor\items\intergrated_chainsaw.dm"
 #include "orbstation\code\antagonists\traitor\items\rebalancing.dm"
 #include "orbstation\code\antagonists\traitor\objectives\kidnapping.dm"
 #include "orbstation\code\antagonists\traitor\objectives\sabotage_machines.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

It's CHAINSAW TIME!! Adds a new traitor item, the chainsaw implant. It functions like the laser arm implant, but instead of a hidden laser in your arm you can take out, it's a one handed chainsaw. 
![image](https://user-images.githubusercontent.com/76571156/227403042-ceec7fbf-9b76-4a39-a76c-21ddb6cc79d2.png)
The chainsaw implant is exclusive to Engineer, Chief Engineer, Botanist, Assistant, and Tech Support. It costs 12 tc and requires 300 rep to purchase. You can use a screw driver to take the implant out of the autosurgeon, then screwdriver it again to swap arms. 

## Why It's Good For The Game
YOU CAN BECOME CHAINSAW MAN FROM FAMOUS ANIME CHAINSAW MAN.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Chainsaw arm implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
