### PR TITLE
Fixes a missing wire in Biodome Research.

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -25387,6 +25387,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "jZy" = (


### PR DESCRIPTION
There's a wire missing after #535 that means the entire research department is unpowered. This fixes that.