### PR TITLE
Disables holiday station names entirely.

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST(holidays)
 	if(GLOB.holidays.len)
 		shuffle_inplace(GLOB.holidays)
 		// regenerate station name because holiday prefixes.
-		set_station_name(new_station_name())
+		// set_station_name(new_station_name()) //ORBSTATION REMOVAL
 		world.update_status()
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The incentive for this PR is realizing that the station prefixes for the Ramadan holiday are _incredibly_ fucking Islamaphobic. Like, Bush-era shit. Originally, I was just going to disable those, but honestly... we already have random station names enabled. None of the holiday station prefixes are particularly funny, and with some of them being shitty like this, it's easiest to just disable them completely.

If preferred, though, I can just disable specific objectionable ones.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Disabled holiday station names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
