### PR TITLE
You will not be scared by hooded void cloaks

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -479,7 +479,6 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/effect/heretic_rune,
 		/obj/effect/rune,
 		/obj/effect/visible_heretic_influence,
-		/obj/item/clothing/head/hooded/cult_hoodie,
 		/obj/item/clothing/mask/madness_mask,
 		/obj/item/clothing/neck/heretic_focus,
 		/obj/item/clothing/neck/eldritch_amulet,

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -48,13 +48,13 @@
 	var/list/seen_atoms = view(7, owner)
 	if(LAZYLEN(trigger_objs))
 		for(var/obj/O in seen_atoms)
-			if(is_type_in_typecache(O, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(O)))
+			if(valid_atom(O)) // ORBSTATION: filter out some items based on state
 				freak_out(O)
 				return
 		for(var/mob/living/carbon/human/HU in seen_atoms) //check equipment for trigger items
 			for(var/X in HU.get_all_worn_items() | HU.held_items)
 				var/obj/I = X
-				if(!QDELETED(I) && (is_type_in_typecache(I, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(I))))
+				if(!QDELETED(I) && valid_atom(I)) // ORBSTATION: filter out some items based on state
 					freak_out(I)
 					return
 
@@ -76,6 +76,10 @@
 				if(LAZYLEN(trigger_species) && H.dna && H.dna.species && is_type_in_typecache(H.dna.species, trigger_species))
 					freak_out(H)
 					return
+
+/// ORBSTATION: returns true if an object triggers a phobia
+/datum/brain_trauma/mild/phobia/proc/valid_atom(atom/checked)
+	return is_type_in_typecache(checked, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(checked))
 
 /datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
 	if(!owner.can_hear() || owner == hearing_args[HEARING_SPEAKER] || !owner.has_language(hearing_args[HEARING_LANGUAGE])) 	//words can't trigger you if you can't hear them *taps head*

--- a/orbstation/code/antagonists/heretic/heretic_phobia.dm
+++ b/orbstation/code/antagonists/heretic/heretic_phobia.dm
@@ -23,3 +23,11 @@
 	lose_text = "<span class='notice'>The hands are a distant memory now. You're not sure what you were afraid of...</span>"
 	scan_desc = "phobia of "
 	scan_desc += pick(garbage_text)
+
+// Don't get spooked by invisible robes
+/datum/brain_trauma/mild/phobia/mansus/valid_atom(atom/checked)
+	. = ..()
+	if (!. || !istype(checked, /obj/item/clothing/suit/hooded/cultrobes/void))
+		return .
+	var/obj/item/clothing/suit/hooded/cultrobes/void/void_robes = checked
+	return !void_robes.hood_up


### PR DESCRIPTION
## About The Pull Request

Adds an additional validation check into phobia items before they spook you.
The heretic phobia won't trigger on invisible (hooded) void cloaks.

Ultimately we should probably:
- Replace this with something which isn't a phobia (a trait which causes heretic abilities to be extra-effective on you?)
- Send it upstream
But this will do as a stopgap

## Why It's Good For The Game

This is unintuitive and confusing.

## Changelog

:cl:
fix: The curse of the Mansus no longer grants victims a supernatural ability to sense invisible void cloaks in order to be frightened of them.
/:cl:
