### PR TITLE
Biodome: some wires and the Modular Zoo update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -11197,6 +11197,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Law Sat"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eqS" = (
@@ -34651,7 +34652,6 @@
 /area/station/maintenance/disposal/incinerator)
 "nyU" = (
 /obj/structure/cable/multilayer/multiz,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "nzd" = (
@@ -175723,7 +175723,7 @@ eZB
 afv
 eZB
 eZB
-avN
+eZB
 avN
 rnO
 rnO

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -178,11 +178,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
-"adN" = (
-/obj/structure/flora/bush/leafy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "adP" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -1261,10 +1256,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"awH" = (
-/obj/structure/flora/bush/leavy/style_random,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "axh" = (
 /obj/structure/cable,
 /obj/structure/falsewall,
@@ -2145,10 +2136,6 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"aNq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "aNr" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Locker Room"
@@ -3052,11 +3039,6 @@
 "bgp" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/cargo/warehouse)
-"bgK" = (
-/mob/living/basic/cockroach,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "bgQ" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north,
@@ -7707,11 +7689,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"cVU" = (
-/obj/structure/flora/bush/leavy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "cVX" = (
 /turf/open/misc/beach/coastline_t,
 /area/station/ai_monitored/command/nuke_storage)
@@ -10815,11 +10792,6 @@
 "egm" = (
 /turf/closed/wall,
 /area/station/security/office)
-"ego" = (
-/obj/machinery/light/warm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "egs" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access"
@@ -12609,12 +12581,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"eQl" = (
-/obj/structure/flora/bush/pointy/style_random,
-/mob/living/basic/cockroach,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "eQu" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
@@ -17041,12 +17007,6 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
-"gBb" = (
-/obj/structure/flora/bush/leafy,
-/mob/living/basic/cockroach,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "gBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19736,9 +19696,6 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
-"hIZ" = (
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "hJb" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/cobweb,
@@ -22137,11 +22094,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
-"iIC" = (
-/mob/living/basic/axolotl,
-/obj/structure/flora/bush/leavy/style_random,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "iIH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24295,10 +24247,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jDw" = (
-/mob/living/basic/amoung,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "jDR" = (
 /obj/structure/ladder,
 /turf/open/floor/stone,
@@ -25159,12 +25107,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"jVX" = (
-/mob/living/basic/axolotl,
-/obj/structure/flora/bush/leavy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "jWb" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -25193,11 +25135,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"jWu" = (
-/mob/living/basic/rabbit,
-/obj/structure/flora/bush/leavy/style_random,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "jWH" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -27296,11 +27233,6 @@
 /obj/structure/sign/gym/mirrored/right,
 /turf/closed/wall,
 /area/station/commons/fitness)
-"kJH" = (
-/mob/living/basic/rabbit,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "kJT" = (
 /obj/item/paper_bin/bundlenatural,
 /turf/open/misc/asteroid/airless,
@@ -28695,10 +28627,6 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
-"lld" = (
-/obj/structure/flora/bush/leafy,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "lli" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters"
@@ -31338,6 +31266,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"mhT" = (
+/obj/modular_map_root/biodome{
+	key = "cage_2";
+	name = "cage_2"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mhX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32161,11 +32096,6 @@
 "mzc" = (
 /turf/closed/wall,
 /area/station/medical/chemistry)
-"mzg" = (
-/mob/living/basic/amoung,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "mzh" = (
 /obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/fakebasalt,
@@ -35049,9 +34979,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "nGY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
+/obj/modular_map_root/biodome{
+	key = "cage_1";
+	name = "cage_1"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "nHe" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -37379,6 +37311,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"oAz" = (
+/obj/modular_map_root/biodome{
+	key = "cage_3";
+	name = "cage_3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "oAD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39362,10 +39301,6 @@
 "pov" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
-"poE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "ppl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -42030,11 +41965,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"qtL" = (
-/obj/structure/flora/bush/leavy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "quo" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/machinery/light/directional/east,
@@ -42843,11 +42773,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"qJQ" = (
-/mob/living/basic/axolotl,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "qJS" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
@@ -43070,16 +42995,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/orange,
 /area/station/security/prison)
-"qOJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
-"qON" = (
-/mob/living/basic/amoung/pequeno,
-/obj/structure/flora/bush/leafy,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "qOT" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -45587,11 +45502,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/security/medical)
-"rKr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/south,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "rKN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45738,12 +45648,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"rOK" = (
-/obj/machinery/light/warm/directional/south,
-/obj/structure/flora/bush/pointy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "rOP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -48625,11 +48529,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"sWU" = (
-/obj/structure/flora/bush/leafy,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "sWX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -49494,12 +49393,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
-"tmR" = (
-/obj/machinery/light/warm/directional/south,
-/mob/living/basic/rabbit,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "tmW" = (
 /obj/structure/sign/warning/chem_diamond/directional/south,
 /obj/effect/turf_decal/tile/blue/half,
@@ -50591,10 +50484,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
-"tIM" = (
-/obj/structure/flora/bush/pointy/style_random,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "tIP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52376,11 +52265,6 @@
 	},
 /turf/open/openspace,
 /area/station/biodome/aft)
-"uzj" = (
-/obj/structure/flora/bush/pointy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/maintenance/aft/upper)
 "uzo" = (
 /turf/open/floor/engine,
 /area/station/science/explab)
@@ -56737,10 +56621,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "wlv" = (
-/obj/structure/flora/bush/leavy/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
+/obj/modular_map_root/biodome{
+	key = "cage_4";
+	name = "cage_4"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "wlw" = (
 /obj/structure/disposalpipe/segment,
@@ -154133,9 +154018,9 @@ hcy
 nSu
 pLT
 dST
-poE
-jVX
-ego
+fJC
+fJC
+fJC
 vxC
 xsO
 fJC
@@ -154390,8 +154275,8 @@ aWD
 ljH
 pLT
 dST
-lld
-hIZ
+fJC
+fJC
 nGY
 wum
 xsO
@@ -154647,9 +154532,9 @@ neH
 swn
 neH
 dST
-hIZ
-iIC
-uzj
+fJC
+fJC
+fJC
 vxC
 xsO
 fJC
@@ -154904,9 +154789,9 @@ cqe
 sJr
 cqe
 dST
-qJQ
-qOJ
-cVU
+fJC
+fJC
+fJC
 vxC
 xsO
 uKI
@@ -155418,9 +155303,9 @@ neH
 swn
 neH
 dST
-qON
-qtL
-rOK
+fJC
+fJC
+fJC
 vxC
 xsO
 fJC
@@ -155675,9 +155560,9 @@ euf
 swn
 neH
 dST
-hIZ
-jDw
-nGY
+fJC
+fJC
+mhT
 mqM
 xsO
 vxC
@@ -155932,9 +155817,9 @@ neH
 swn
 ngn
 dST
-awH
-hIZ
-qOJ
+fJC
+fJC
+fJC
 vxC
 xsO
 vxC
@@ -156189,9 +156074,9 @@ neH
 swn
 neH
 dST
-mzg
-qOJ
-cVU
+fJC
+fJC
+fJC
 vxC
 xsO
 vxC
@@ -156703,9 +156588,9 @@ neH
 swn
 neH
 dST
-poE
-aNq
-tmR
+fJC
+fJC
+fJC
 vxC
 xsO
 fJC
@@ -156960,9 +156845,9 @@ neH
 swn
 neH
 dST
-tIM
-jWu
-nGY
+fJC
+fJC
+oAz
 bJS
 xsO
 fJC
@@ -157217,9 +157102,9 @@ neH
 swn
 neH
 dST
-awH
-hIZ
-qOJ
+fJC
+fJC
+fJC
 vxC
 xsO
 kSk
@@ -157474,9 +157359,9 @@ neH
 swn
 neH
 dST
-kJH
-adN
-cVU
+fJC
+fJC
+fJC
 vxC
 xsO
 fJC
@@ -157988,9 +157873,9 @@ neH
 wWM
 oHa
 dST
-sWU
-eQl
-rKr
+fJC
+fJC
+fJC
 vxC
 pLV
 fJC
@@ -158245,8 +158130,8 @@ neH
 wWM
 qzF
 dST
-tIM
-hIZ
+fJC
+fJC
 wlv
 aUx
 xsO
@@ -158502,9 +158387,9 @@ neH
 tCM
 neH
 dST
-hIZ
-lld
-bgK
+fJC
+fJC
+fJC
 vxC
 vxC
 tsS
@@ -158759,9 +158644,9 @@ neH
 wWM
 neH
 dST
-gBb
-qOJ
-cVU
+fJC
+fJC
+fJC
 vxC
 uIF
 fJC

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -38297,10 +38297,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "oUo" = (
-/mob/living/simple_animal/hostile/skeleton{
-	faction = list("neutral");
-	name = "disco skeleton"
-	},
+/mob/living/simple_animal/hostile/skeleton/jim,
 /turf/open/floor/light/colour_cycle,
 /area/station/maintenance/starboard/central)
 "oUu" = (
@@ -39414,11 +39411,7 @@
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
 "pqv" = (
-/mob/living/basic/carp{
-	faction = list("neutral");
-	desc = "A ferocious, fang-bearing creature that resembles a fish. This has been tamed to serve as decoration.";
-	name = "Fun-Fun"
-	},
+/mob/living/basic/carp/pet/biodome/fangfang,
 /turf/open/misc/beach/coastline_b,
 /area/station/maintenance/radshelter/civil)
 "pqA" = (
@@ -54868,11 +54861,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vzK" = (
-/mob/living/basic/carp{
-	faction = list("neutral");
-	desc = "A ferocious, fang-bearing creature that resembles a fish. This has been tamed to serve as decoration.";
-	name = "Fang-Fang"
-	},
+/mob/living/basic/carp/pet/biodome/funfun,
 /turf/open/misc/beach/coastline_b,
 /area/station/maintenance/radshelter/civil)
 "vzP" = (
@@ -58252,8 +58241,8 @@
 "wMf" = (
 /obj/structure/table,
 /obj/item/clothing/head/hats/tophat,
-/mob/living/basic/rabbit,
 /obj/item/gun/magic/wand/nothing,
+/mob/living/basic/rabbit/trefoil,
 /turf/open/floor/plating,
 /area/station/science/breakroom)
 "wMo" = (

--- a/_maps/map_files/biodome/modules/cage_1_axolotl.dmm
+++ b/_maps/map_files/biodome/modules/cage_1_axolotl.dmm
@@ -1,0 +1,67 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/mob/living/basic/axolotl,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/aft/upper)
+"f" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/aft/upper)
+"i" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+"n" = (
+/mob/living/basic/axolotl,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+"p" = (
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/aft/upper)
+"y" = (
+/mob/living/basic/axolotl,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+"D" = (
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/aft/upper)
+"J" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+"P" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+"X" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+X
+n
+P
+"}
+(2,1,1) = {"
+p
+D
+i
+"}
+(3,1,1) = {"
+D
+a
+J
+"}
+(4,1,1) = {"
+y
+f
+J
+"}

--- a/_maps/map_files/biodome/modules/cage_2_amoung.dmm
+++ b/_maps/map_files/biodome/modules/cage_2_amoung.dmm
@@ -1,0 +1,72 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"g" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"h" = (
+/mob/living/basic/amoung/pequeno,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+"m" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+"n" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/hollow/survival_pod,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"u" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/fakespace,
+/area/station/maintenance/aft/upper)
+"v" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+"E" = (
+/mob/living/basic/amoung,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+"F" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+"S" = (
+/mob/living/basic/amoung,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/fakespace,
+/area/station/maintenance/aft/upper)
+"W" = (
+/obj/item/toy/redbutton,
+/turf/open/floor/iron/textured,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+h
+F
+v
+"}
+(2,1,1) = {"
+W
+E
+m
+"}
+(3,1,1) = {"
+a
+g
+n
+"}
+(4,1,1) = {"
+S
+u
+u
+"}

--- a/_maps/map_files/biodome/modules/cage_3_rabbit.dmm
+++ b/_maps/map_files/biodome/modules/cage_3_rabbit.dmm
@@ -1,0 +1,78 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/warm/directional/south,
+/mob/living/basic/rabbit,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"e" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"i" = (
+/obj/structure/flora/bush/leavy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"j" = (
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"n" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/storage/basket/easter,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"u" = (
+/mob/living/basic/rabbit,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"v" = (
+/obj/structure/flora/bush/leafy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"w" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"R" = (
+/mob/living/basic/rabbit,
+/obj/structure/flora/bush/leavy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"S" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"W" = (
+/obj/structure/flora/bush/leavy/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"X" = (
+/obj/structure/flora/bush/pointy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+n
+e
+a
+"}
+(2,1,1) = {"
+X
+R
+w
+"}
+(3,1,1) = {"
+i
+j
+S
+"}
+(4,1,1) = {"
+u
+v
+W
+"}

--- a/_maps/map_files/biodome/modules/cage_4_cockroach.dmm
+++ b/_maps/map_files/biodome/modules/cage_4_cockroach.dmm
@@ -1,0 +1,70 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"c" = (
+/mob/living/basic/cockroach,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"g" = (
+/mob/living/basic/cockroach,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"p" = (
+/mob/living/basic/cockroach,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"w" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"x" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/clothing/mask/cigarette/rollie,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"z" = (
+/obj/item/cigbutt/roach,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"E" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/warm/directional/south,
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"T" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"Z" = (
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+x
+p
+E
+"}
+(2,1,1) = {"
+Z
+z
+a
+"}
+(3,1,1) = {"
+Z
+Z
+g
+"}
+(4,1,1) = {"
+c
+T
+w
+"}

--- a/_maps/map_files/biodome/modules/map legend.txt
+++ b/_maps/map_files/biodome/modules/map legend.txt
@@ -1,0 +1,19 @@
+[rooms.arrivalsecupper]
+modules = ["arrivalsecupper_1.dmm", "arrivalsecupper_2.dmm", "arrivalsecupper_3.dmm"]
+# 1. Small S connection that connects Arrivals, EVA and Security. Has a simple side room with misc maintenance gear.
+
+[rooms.cage_1]
+modules = ["cage_axolotl.dmm"]
+# 1. A cage containing axolotls.
+
+[rooms.cage_2]
+modules = ["cage_amoung.dmm"]
+# 1. A cage containing amoungs.
+
+[rooms.cage_3]
+modules = ["cage_cockroach.dmm"]
+# 1. A cage containing cockroaches.
+
+[rooms.cage_4]
+modules = ["cage_rabbit.dmm"]
+# 1. A cage containing rabbits.

--- a/orbstation/code/map/biodome/mobs.dm
+++ b/orbstation/code/map/biodome/mobs.dm
@@ -1,0 +1,21 @@
+/mob/living/basic/carp/pet/biodome
+	gender = MALE
+	faction = list(FACTION_NEUTRAL)
+
+/mob/living/basic/carp/pet/biodome/funfun
+	name = "Fun-Fun"
+	desc = "This carp has been created as a decoration in the biodome. You feel you should love him and believe him."
+
+/mob/living/basic/carp/pet/biodome/fangfang
+	name = "Fang-Fang"
+	desc = "This carp has been created as a decoration in the biodome. You feel you should come and see him."
+
+/mob/living/basic/rabbit/trefoil
+	name = "Trefoil"
+	desc = "This rabbit is always planning elaborate set pieces for their newest act."
+
+/mob/living/simple_animal/hostile/skeleton/jim
+	name = "Jim"
+	faction = list(FACTION_NEUTRAL)
+	desc = "Your friendly maintenance skeleton, Jim."
+

--- a/orbstation/code/map/biodome/modular_map.dm
+++ b/orbstation/code/map/biodome/modular_map.dm
@@ -1,0 +1,2 @@
+/obj/modular_map_root/biodome
+	config_file = "strings/modular_maps/biodome.toml"

--- a/strings/modular_maps/biodome.toml
+++ b/strings/modular_maps/biodome.toml
@@ -1,0 +1,13 @@
+directory = "_maps/map_files/biodome/modules/"
+
+[rooms.cage_1]
+modules = ["cage_1_axolotl.dmm"]
+
+[rooms.cage_2]
+modules = ["cage_2_amoung.dmm"]
+
+[rooms.cage_3]
+modules = ["cage_3_rabbit.dmm"]
+
+[rooms.cage_4]
+modules = ["cage_4_cockroach.dmm"]

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5290,6 +5290,7 @@
 #include "orbstation\code\map\biodome\area.dm"
 #include "orbstation\code\map\biodome\decoration.dm"
 #include "orbstation\code\map\biodome\mobs.dm"
+#include "orbstation\code\map\biodome\modular_map.dm"
 #include "orbstation\code\map\biodome\power.dm"
 #include "orbstation\code\map\biodome\shuttles.dm"
 #include "orbstation\code\map\biodome\turfs.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5289,6 +5289,7 @@
 #include "orbstation\code\map\shuttles.dm"
 #include "orbstation\code\map\biodome\area.dm"
 #include "orbstation\code\map\biodome\decoration.dm"
+#include "orbstation\code\map\biodome\mobs.dm"
 #include "orbstation\code\map\biodome\power.dm"
 #include "orbstation\code\map\biodome\shuttles.dm"
 #include "orbstation\code\map\biodome\turfs.dm"


### PR DESCRIPTION
- Fixes a case when there was an extra wire on a cable multilayer hub
- Fixes a case when there was no wire under the upper lawsat door
- Fixes two walls touching diagonally in the abandoned gambling den, allowing light to leak
- The rabbit in the science breakroom has a name and description, and is a subtype
- Jim the maintenance skeleton now has a subtype
- Fun-Fun and Fang-Fang have subtypes
- The zoo cages are now modularly loaded! There is only one possible content per cage, but the framework has been implemented.

![image](https://user-images.githubusercontent.com/2676196/227795247-a8cc5b4b-8a1c-4eb4-a243-675160a78fff.png)

