### PR TITLE
No Skinheads Except Anti-Racists

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,15 +25,6 @@
 			"label": "Build All"
 		},
 		{
-			"type": "dreammaker",
-			"dme": "tgstation.dme",
-			"problemMatcher": [
-				"$dreammaker"
-			],
-			"group": "build",
-			"label": "dm: build - tgstation.dme"
-		},
-		{
 			"command": "${command:dreammaker.reparse}",
 			"group": "build",
 			"label": "dm: reparse"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,15 @@
 			"label": "Build All"
 		},
 		{
+			"type": "dreammaker",
+			"dme": "tgstation.dme",
+			"problemMatcher": [
+				"$dreammaker"
+			],
+			"group": "build",
+			"label": "dm: build - tgstation.dme"
+		},
+		{
 			"command": "${command:dreammaker.reparse}",
 			"group": "build",
 			"label": "dm: reparse"

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -44,7 +44,7 @@
 	//It's still called Jade, but theres no HTML color for jade, so we use lime.
 	name = "jade lipstick"
 	colour = "lime"
-	
+
 /obj/item/lipstick/blue
 	name = "blue lipstick"
 	colour = "blue"
@@ -151,7 +151,7 @@
 	if(location == BODY_ZONE_PRECISE_MOUTH)
 		H.facial_hairstyle = "Shaved"
 	else
-		H.hairstyle = "Skinhead"
+		H.hairstyle = "S.H.A.R.P." // ORBSTATION EDIT TO REMOVE SKINHEAD
 
 	H.update_body_parts()
 	playsound(loc, 'sound/items/welder2.ogg', 20, TRUE)

--- a/orbstation/code/customisation/hair.dm
+++ b/orbstation/code/customisation/hair.dm
@@ -131,4 +131,3 @@
 
 /datum/sprite_accessory/hair/skinhead
 	name = "S.H.A.R.P."
-	icon_state = "hair_skinhead"

--- a/orbstation/code/customisation/hair.dm
+++ b/orbstation/code/customisation/hair.dm
@@ -128,3 +128,7 @@
 	name = "tulip"
 	icon_state = "tulip"
 	icon = 'orbstation/icons/mob/species/podperson/podperson_hair.dmi'
+
+/datum/sprite_accessory/hair/skinhead
+	name = "S.H.A.R.P."
+	icon_state = "hair_skinhead"


### PR DESCRIPTION
## About The Pull Request

Renames "Skinhead" haircut to "S.H.A.R.P." Also touches the cosmetics.dm in order to ensure that the name shows up correctly when accessed through an electric razor.

## Why It's Good For The Game

People have a justifiable worry/discomfort around "skinhead" being used blankly. So instead we've changed it to a name that's more in line with orbstation's political leanings:
![image](https://user-images.githubusercontent.com/77178736/228159022-1e450e17-f6bd-48bc-b6c0-daa0a0561422.png)


## Changelog

:cl:
fix: renamed the haircut to better match the vibes/politics of the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
