### PR TITLE
Don't dismember jellies from woundless damage

### DIFF
--- a/orbstation/code/mob/species/jelly/dismemberment.dm
+++ b/orbstation/code/mob/species/jelly/dismemberment.dm
@@ -7,7 +7,8 @@
 		return
 	if (biological_state != BIO_SLIME) // Everything else is handled in super
 		return // We can turn this into a switch if we ever expand it
-
+	if (wound_bonus == CANT_WOUND)
+		return // Don't dismember on woundless damage
 	// If we're easy to dismember we don't reduce wounding damage from varying type
 	if (!HAS_TRAIT(owner, TRAIT_EASYDISMEMBER))
 		if (wounding_type == WOUND_SLASH)


### PR DESCRIPTION
## About The Pull Request

This change ensures that damage which is marked "cannot wound" will not cause jellyperson limbs to fly off.

## Why It's Good For The Game

If damage is not meant to be able to wound you then it also should not be able to disembowel you.

## Changelog

:cl:
fix: Jellypeople won't occasionally lose limbs to goliaths, or be gibbed by legions or chasms.
/:cl:
