### PR TITLE
Department security locker changes

### DIFF
--- a/orbstation/code/jobs/department_security.dm
+++ b/orbstation/code/jobs/department_security.dm
@@ -66,8 +66,9 @@
 	new /obj/item/gun/energy/disabler/departmental(src)
 	new /obj/item/storage/belt/security/departmental(src)
 	new /obj/item/clothing/accessory/armband/cargo(src)
-	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/clothing/accessory/armband/cargo(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
+	new /obj/item/storage/box/zipties(src)
 
 /obj/structure/closet/secure_closet/security/engine
 	req_access = list()
@@ -81,8 +82,9 @@
 	new /obj/item/gun/energy/disabler/departmental(src)
 	new /obj/item/storage/belt/security/departmental(src)
 	new /obj/item/clothing/accessory/armband/engine(src)
-	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/clothing/accessory/armband/engine(src)
 	new /obj/item/encryptionkey/headset_eng(src)
+	new /obj/item/storage/box/zipties(src)
 
 /obj/structure/closet/secure_closet/security/science
 	req_access = list()
@@ -96,8 +98,9 @@
 	new /obj/item/gun/energy/disabler/departmental(src)
 	new /obj/item/storage/belt/security/departmental(src)
 	new /obj/item/clothing/accessory/armband/science(src)
-	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/clothing/accessory/armband/science(src)
 	new /obj/item/encryptionkey/headset_sci(src)
+	new /obj/item/storage/box/zipties(src)
 
 /obj/structure/closet/secure_closet/security/med
 	req_access = list()
@@ -111,8 +114,9 @@
 	new /obj/item/gun/energy/disabler/departmental(src)
 	new /obj/item/storage/belt/security/departmental(src)
 	new /obj/item/clothing/accessory/armband/medblue(src)
-	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/clothing/accessory/armband/medblue(src)
 	new /obj/item/encryptionkey/headset_med(src)
+	new /obj/item/storage/box/zipties(src)
 
 // Mapping access helpers
 /obj/effect/mapping_helpers/airlock/access/any/security/cargo/get_access()

--- a/orbstation/code/jobs/department_security.dm
+++ b/orbstation/code/jobs/department_security.dm
@@ -27,7 +27,6 @@
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/restraints/handcuffs(src)
-	new /obj/item/restraints/handcuffs(src)
 	update_appearance()
 
 // Adds capability of closet to talk on radio when unlocked


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR implements a few suggestions regarding departmental security items:

- Department sec lockers each contain one box of zipties.
- Departmental secbelts only contain one set of handcuffs, not two.
- Department sec lockers contain two department-colored armbands rather than one departmental and one red.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One of the problem that comes with our departmental sec changes is, while it gives a disabler to the department, departments have limited options for what you actually do after catching one. This does not especially _solve_ that (you still can't brig people), but giving each department one box of zipties should be useful for pulling citizen's arrests on troublemakers. Plus, they're less potent items than handcuffs, so it doesn't feel as bad if they get handed out to other department members.

I reduced the amount of actual handcuffs that come with the departmental secbelt in the meantime, because I feel zipties are more appropriate for self-deputized department members.

Finally, many people (myself included) have expressed discomfort with the deputy armbands, given that they're, you know, bright red armbands. I replaced these with a second copy of the department-color armband instead.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: added a box of zipties to each departmental sec locker
balance: reduced the number of handcuffs in each departmental sec belt
qol: replaced the unpleasant red armbands in departmental sec lockers with department-colored ones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
