### PR TITLE
Randomly-spawned humans have random hairstyles again.

### DIFF
--- a/orbstation/code/mob/species/tiziran/hair.dm
+++ b/orbstation/code/mob/species/tiziran/hair.dm
@@ -8,8 +8,9 @@
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	..()
-	human_mob.hairstyle = "Bald"
-	human_mob.facial_hair_color = "#F0E0C0" // for the colored snout option
+	if(istype(human_mob.dna.species, /datum/species/lizard))
+		human_mob.hairstyle = "Bald"
+		human_mob.facial_hair_color = "#F0E0C0" // for the colored snout option
 
 /datum/species/lizard/silverscale
 	/// Stored facial hair color for when the species is removed.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to some _bizarre_ code related to randomizing humans, #218 inadvertently made all randomly-spawned humans (regardless of species; not actual humans) completely bald. This includes both humans spawned by admins and cadavers purchased via cargo - and possibly others, too.

This PR simply makes the modified randomize_features() for lizards only run if the target is actually a lizard. This restores everyone's hair, except for lizards, who are still naturally bald.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/105025397/228418456-308276f6-5e1e-4a41-b181-dfb685286fa7.png)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed hairstyles always getting set to Bald for randomly-spawned humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
