### PR TITLE
Biodome: Boats And Trams Update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -21141,6 +21141,12 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"iox" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/warehouse)
 "ioC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -108437,7 +108443,7 @@ avu
 dAF
 dAF
 dAF
-hNy
+dAF
 hNy
 hNy
 hNy
@@ -108693,7 +108699,7 @@ pLH
 euM
 nAp
 gcl
-dAF
+nkq
 dAF
 dAF
 dAF
@@ -108951,7 +108957,7 @@ fUq
 lcn
 qoX
 jSN
-nkq
+iox
 ibh
 dxy
 vuK

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -7641,7 +7641,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cUz" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/table,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/vacant_room/commissary)
@@ -16774,15 +16773,8 @@
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium"
 	},
-/obj/machinery/computer/tram_controls{
-	specific_lift_id = "tram_boat";
-	dir = 8
-	},
-/obj/effect/landmark/tram{
-	name = "Aft Boat Dock";
-	specific_lift_id = "tram_boat";
-	platform_code = "aft_boat_dock"
-	},
+/obj/effect/landmark/tram/boat/aft,
+/obj/machinery/computer/tram_controls/boat,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
 "gxh" = (
@@ -17712,10 +17704,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gQD" = (
-/obj/machinery/button/tram{
-	id = "fore_boat_dock";
-	lift_id = "tram_boat"
-	},
+/obj/machinery/button/tram/boat/fore,
 /turf/closed/wall/mineral/wood,
 /area/station/biodome/fore)
 "gQU" = (
@@ -19287,10 +19276,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"hzL" = (
-/obj/effect/fishing_lure,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/greater)
 "hAi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21667,11 +21652,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/kitchen/diner)
 "izf" = (
-/obj/effect/landmark/tram{
-	name = "Fore Boat Dock";
-	specific_lift_id = "tram_boat";
-	platform_code = "fore_boat_dock"
-	},
+/obj/effect/landmark/tram/boat/fore,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/fore)
 "izy" = (
@@ -22698,11 +22679,7 @@
 	},
 /area/station/command/heads_quarters/cmo)
 "iXz" = (
-/obj/effect/landmark/tram{
-	name = "Central Boat Dock";
-	specific_lift_id = "tram_boat";
-	platform_code = "central_boat_dock"
-	},
+/obj/effect/landmark/tram/boat/middle,
 /turf/open/water/jungle/biodome,
 /area/station/biodome)
 "iXJ" = (
@@ -28691,10 +28668,7 @@
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
 "lmO" = (
-/obj/structure/sign/collision_counter{
-	sign_change_name = "Indicator board- Boating incidents";
-	name = "boating incident counter"
-	},
+/obj/structure/sign/collision_counter/boat,
 /turf/closed/wall,
 /area/station/medical/treatment_center)
 "lmY" = (
@@ -30408,6 +30382,7 @@
 /area/station/tcommsat/server)
 "lTG" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/vacant_room/commissary)
 "lTK" = (
@@ -30623,13 +30598,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "lXm" = (
-/obj/structure/sign/collision_counter{
-	sign_change_name = "Indicator board- Boating incidents";
-	name = "boating incident counter";
-	desc = "A display that indicates how many boat related incidents have occured today.";
-	pixel_y = -1;
-	pixel_x = -1
-	},
+/obj/structure/sign/collision_counter/boat,
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
 "lXp" = (
@@ -42050,10 +42019,7 @@
 /area/station/medical/medbay/central)
 "qvR" = (
 /obj/structure/girder,
-/obj/machinery/button/tram{
-	id = "central_boat_dock";
-	lift_id = "tram_boat"
-	},
+/obj/machinery/button/tram/boat/middle,
 /turf/open/water/jungle/biodome,
 /area/station/biodome)
 "qvT" = (
@@ -42202,10 +42168,7 @@
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
 "qzf" = (
-/obj/machinery/button/tram{
-	id = "aft_boat_dock";
-	lift_id = "tram_boat"
-	},
+/obj/machinery/button/tram/boat/aft,
 /turf/closed/wall/mineral/wood,
 /area/station/biodome/aft)
 "qzw" = (
@@ -52225,7 +52188,6 @@
 /area/station/engineering/atmos/hfr_room)
 "uyA" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/vacant_room/commissary)
 "uyB" = (
@@ -57754,9 +57716,7 @@
 	icon_state = "titanium"
 	},
 /obj/structure/chair/comfy/shuttle,
-/obj/effect/landmark/lift_id{
-	specific_lift_id = "tram_boat"
-	},
+/obj/effect/landmark/lift_id/boat,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
 "wEe" = (
@@ -98448,7 +98408,7 @@ hNy
 hNy
 sBz
 rcP
-hzL
+dYQ
 uiF
 dYQ
 sBz

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -26936,7 +26936,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/science,
-/obj/structure/filingcabinet,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "kEG" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -4538,7 +4538,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "bNa" = (
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/chair/sofa/bench/solo{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -10507,14 +10507,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"dZQ" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/dark_red/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron,
-/area/station/command/bridge)
 "dZR" = (
 /obj/machinery/mass_driver/chapelgun,
 /obj/structure/sign/warning/vacuum/external/directional/north,
@@ -27005,6 +26997,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/meeting_room)
 "kGO" = (
@@ -36644,7 +36637,7 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "onM" = (
-/obj/structure/chair/sofa/bench/left{
+/obj/structure/chair/sofa/bench/solo{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -52930,14 +52923,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/carpet/executive,
 /area/station/security/prison)
-"uOL" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/green/half,
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/command/bridge)
 "uPi" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
@@ -166025,23 +166010,23 @@ meU
 meU
 meU
 meU
-mcO
-mcO
-mcO
-lTv
-mcO
-mcO
-rAq
-rAq
-rAq
-rAq
 rAq
 mcO
 mcO
 lTv
 mcO
 mcO
+rAq
+rAq
+rAq
+rAq
+rAq
 mcO
+mcO
+lTv
+mcO
+mcO
+lTv
 lTv
 fQs
 fQs
@@ -166282,8 +166267,8 @@ cFv
 cFv
 cFv
 cFv
-lTv
-uOL
+mcO
+mcO
 sig
 lHg
 mZX
@@ -166297,7 +166282,7 @@ mcO
 mTv
 ttG
 sLV
-dZQ
+mcO
 mcO
 mcO
 fQs

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -28683,6 +28683,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "lnK" = (

--- a/orbstation/code/map/biodome/tram.dm
+++ b/orbstation/code/map/biodome/tram.dm
@@ -1,0 +1,50 @@
+#define TRAM_BOAT "tram_boat"
+#define TRAM_BOAT_FORE "tram_boat_fore"
+#define TRAM_BOAT_CENTRAL "tram_boat_central"
+#define TRAM_BOAT_AFT "tram_boat_aft"
+
+/obj/effect/landmark/lift_id/boat
+	specific_lift_id = TRAM_BOAT
+
+/obj/machinery/computer/tram_controls/boat
+	specific_lift_id = TRAM_BOAT
+
+/obj/effect/landmark/tram/boat/fore
+	name = "Fore Boat Dock"
+	specific_lift_id = TRAM_BOAT
+	platform_code = TRAM_BOAT_FORE
+	tgui_icons = list("Departures" = "plane-departure", "Science" = "flask")
+
+/obj/effect/landmark/tram/boat/middle
+	name = "Central Boat Dock"
+	specific_lift_id = TRAM_BOAT
+	platform_code = TRAM_BOAT_CENTRAL
+	tgui_icons = list("Cargo" = "box")
+
+/obj/effect/landmark/tram/boat/aft
+	name = "Aft Boat Dock"
+	specific_lift_id = TRAM_BOAT
+	platform_code = TRAM_BOAT_AFT
+	tgui_icons = list("Command" = "bullhorn")
+
+/obj/structure/sign/collision_counter/boat
+	name = "boating incident counter"
+	desc = "A display that indicates how many boat related incidents have occured today."
+	sign_change_name = "Indicator board- Boating incidents"
+
+/obj/machinery/button/tram/boat/fore
+	id = TRAM_BOAT_FORE
+	lift_id = TRAM_BOAT
+
+/obj/machinery/button/tram/boat/middle
+	id = TRAM_BOAT_CENTRAL
+	lift_id = TRAM_BOAT
+
+/obj/machinery/button/tram/boat/aft
+	id = TRAM_BOAT_AFT
+	lift_id = TRAM_BOAT
+
+#undef TRAM_BOAT
+#undef TRAM_BOAT_AFT
+#undef TRAM_BOAT_CENTRAL
+#undef TRAM_BOAT_FORE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5312,6 +5312,7 @@
 #include "orbstation\code\map\biodome\modular_map.dm"
 #include "orbstation\code\map\biodome\power.dm"
 #include "orbstation\code\map\biodome\shuttles.dm"
+#include "orbstation\code\map\biodome\tram.dm"
 #include "orbstation\code\map\biodome\turfs.dm"
 #include "orbstation\code\mob\death_memory.dm"
 #include "orbstation\code\mob\eye_closing.dm"


### PR DESCRIPTION
- Every tram machinery (except for crossing signs which the tram doesn't have) related to the tram boat is now a subtype. Code: improved...
- Removed an unremovable fishing lure from the maint bar
- Wired the vacant commissary
- Wired the head meeting room
- Removed the trap corners on the bridge
- Tweaked two benches to be solo benches
- Chemistry Maintenance Door now requires chemistry access instead of nothing
- Adds a microwave and a donk pocket to the cargo warehouse, as a treat
- Removes the extra science sec point cabinet that blocked entrance