### PR TITLE
Alternate Biodome Beasts

### DIFF
--- a/_maps/map_files/biodome/modules/cage_1_creature.dmm
+++ b/_maps/map_files/biodome/modules/cage_1_creature.dmm
@@ -65,6 +65,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/mob/living/basic/creature/docile,
 /turf/open/floor/wood/stairs/down,
 /area/station/maintenance/aft/upper)
 

--- a/_maps/map_files/biodome/modules/cage_1_creature.dmm
+++ b/_maps/map_files/biodome/modules/cage_1_creature.dmm
@@ -1,0 +1,90 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/large,
+/area/station/maintenance/aft/upper)
+"d" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/maintenance/aft/upper)
+"i" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/aft/upper)
+"p" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/large,
+/area/station/maintenance/aft/upper)
+"q" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/aft/upper)
+"s" = (
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/aft/upper)
+"v" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/railing,
+/turf/open/floor/wood,
+/area/station/maintenance/aft/upper)
+"w" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/maintenance/aft/upper)
+"z" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/wood/stairs/down,
+/area/station/maintenance/aft/upper)
+"R" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/large,
+/area/station/maintenance/aft/upper)
+"S" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/wood/stairs/down,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+v
+p
+w
+"}
+(2,1,1) = {"
+q
+z
+R
+"}
+(3,1,1) = {"
+s
+S
+d
+"}
+(4,1,1) = {"
+i
+a
+d
+"}

--- a/_maps/map_files/biodome/modules/cage_2_ghost.dmm
+++ b/_maps/map_files/biodome/modules/cage_2_ghost.dmm
@@ -33,6 +33,7 @@
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "J" = (
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "M" = (

--- a/_maps/map_files/biodome/modules/cage_2_ghost.dmm
+++ b/_maps/map_files/biodome/modules/cage_2_ghost.dmm
@@ -1,0 +1,76 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/remains/human/grave,
+/mob/living/basic/ghost,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"c" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/remains/human,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"e" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"u" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"A" = (
+/obj/effect/decal/remains/human/grave,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"D" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"H" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"J" = (
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"M" = (
+/obj/effect/decal/cleanable/grand_remains,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/mapping_helpers/burnt_floor,
+/mob/living/basic/ghost,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"V" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+"W" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+u
+W
+c
+"}
+(2,1,1) = {"
+A
+M
+V
+"}
+(3,1,1) = {"
+J
+a
+H
+"}
+(4,1,1) = {"
+e
+D
+H
+"}

--- a/_maps/map_files/biodome/modules/cage_2_ghost.dmm
+++ b/_maps/map_files/biodome/modules/cage_2_ghost.dmm
@@ -1,6 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/effect/decal/remains/human/grave,
 /mob/living/basic/ghost,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
@@ -20,11 +19,11 @@
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "A" = (
-/obj/effect/decal/remains/human/grave,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "D" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/remains/human,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "H" = (
@@ -39,7 +38,6 @@
 "M" = (
 /obj/effect/decal/cleanable/grand_remains,
 /obj/effect/decal/cleanable/ash/large,
-/obj/effect/mapping_helpers/burnt_floor,
 /mob/living/basic/ghost,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)

--- a/_maps/map_files/biodome/modules/cage_3_gnome.dmm
+++ b/_maps/map_files/biodome/modules/cage_3_gnome.dmm
@@ -1,0 +1,88 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/flora/bush/leavy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"d" = (
+/obj/effect/turf_decal/siding/thinplating/terracotta{
+	dir = 6
+	},
+/obj/item/fishing_rod,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/station/maintenance/aft/upper)
+"i" = (
+/obj/effect/turf_decal/siding/thinplating/terracotta{
+	dir = 6
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/station/maintenance/aft/upper)
+"j" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"k" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"n" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/garden_gnome,
+/obj/structure/flora/bush/pointy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"q" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/station/maintenance/aft/upper)
+"H" = (
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"N" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/flora/bush/leavy/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"R" = (
+/obj/structure/flora/bush/leafy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/maintenance/aft/upper)
+"T" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating/terracotta,
+/mob/living/basic/garden_gnome,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/station/maintenance/aft/upper)
+"W" = (
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner,
+/mob/living/basic/garden_gnome,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+q
+T
+a
+"}
+(2,1,1) = {"
+W
+d
+j
+"}
+(3,1,1) = {"
+i
+H
+N
+"}
+(4,1,1) = {"
+k
+R
+n
+"}

--- a/_maps/map_files/biodome/modules/cage_4_spider.dmm
+++ b/_maps/map_files/biodome/modules/cage_4_spider.dmm
@@ -1,0 +1,73 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/fake_eggs,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"e" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"f" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/modular_map_connector,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"i" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/warm/directional/south,
+/obj/structure/fake_eggs,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"j" = (
+/mob/living/basic/giant_spider/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"y" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"B" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/spider/cocoon,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"I" = (
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"M" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/giant_spider/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"O" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/basic/giant_spider/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"X" = (
+/obj/structure/spider/cocoon,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+
+(1,1,1) = {"
+y
+O
+i
+"}
+(2,1,1) = {"
+X
+I
+f
+"}
+(3,1,1) = {"
+j
+I
+M
+"}
+(4,1,1) = {"
+e
+a
+B
+"}

--- a/_maps/map_files/biodome/modules/map legend.txt
+++ b/_maps/map_files/biodome/modules/map legend.txt
@@ -1,15 +1,15 @@
 [rooms.cage_1]
-modules = ["cage_axolotl.dmm"]
-# 1. A cage containing axolotls.
+modules = ["cage_1_axolotl.dmm", "cage_1_creature.dmm"]
+# 1. A cage containing damp beasts.
 
 [rooms.cage_2]
-modules = ["cage_amoung.dmm"]
-# 1. A cage containing amoungs.
+modules = ["cage_2_amoung.dmm", "cage_2_ghost.dmm"]
+# 1. A cage containing humanoid anomalies.
 
 [rooms.cage_3]
-modules = ["cage_cockroach.dmm"]
-# 1. A cage containing cockroaches.
+modules = ["cage_3_rabbit.dmm", "cage_3_gnome.dmm"]
+# 1. A cage containing garden creatures.
 
 [rooms.cage_4]
-modules = ["cage_rabbit.dmm"]
-# 1. A cage containing rabbits.
+modules = ["cage_4_cockroach.dmm", "cage_4_spider.dmm"]
+# 1. A cage containing insects.

--- a/orbstation/code/map/biodome/decoration.dm
+++ b/orbstation/code/map/biodome/decoration.dm
@@ -6,3 +6,11 @@
 
 /obj/structure/plaque/static_plaque/golden/commission/biodome
 	desc = "Spinward Sector Station SS-13\n'Biodome' Class Outpost \nCommissioned 18/02/2563\n'Walk In The Park'"
+
+/obj/structure/fake_eggs
+	name = "egg cluster"
+	desc = "These imitation eggs put the pen inhabitants at ease."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "eggs"
+	anchored = TRUE
+	density = FALSE

--- a/orbstation/code/map/biodome/mobs.dm
+++ b/orbstation/code/map/biodome/mobs.dm
@@ -15,3 +15,12 @@
 	desc = "This rabbit is always planning elaborate set pieces for their newest act."
 
 /mob/living/basic/creature/docile
+	desc = "A moving lump of animated viscera which current science cannot yet explain."
+	ai_controller = /datum/ai_controller/basic_controller/creature/docile
+
+/mob/living/basic/creature/docile/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sedated_mob, /datum/ai_controller/basic_controller/creature)
+
+/datum/ai_controller/basic_controller/creature/docile
+	planning_subtrees = list()

--- a/orbstation/code/map/biodome/mobs.dm
+++ b/orbstation/code/map/biodome/mobs.dm
@@ -13,3 +13,5 @@
 /mob/living/basic/rabbit/trefoil
 	name = "Trefoil"
 	desc = "This rabbit is always planning elaborate set pieces for their newest act."
+
+/mob/living/basic/creature/docile

--- a/orbstation/code/map/biodome/sedated_mob.dm
+++ b/orbstation/code/map/biodome/sedated_mob.dm
@@ -1,0 +1,31 @@
+/**
+ * Attached to a mob with an AI controller, if this mob is attacked then it will replace the AI controller.
+ */
+/datum/element/sedated_mob
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// The AI controller used when we wake up
+	var/awake_controller
+
+/datum/element/sedated_mob/Attach(datum/target, awake_controller)
+	. = ..()
+	if(!ismob(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.awake_controller = awake_controller
+	target.AddElement(/datum/element/relay_attackers)
+	RegisterSignal(target, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(on_attacked))
+
+/datum/element/sedated_mob/Detach(datum/source, ...)
+	. = ..()
+	UnregisterSignal(source, COMSIG_ATOM_WAS_ATTACKED)
+
+/// Add an attacking atom to a blackboard list of things which attacked us
+/datum/element/sedated_mob/proc/on_attacked(mob/victim, atom/attacker)
+	SIGNAL_HANDLER
+
+	if (!victim.ai_controller)
+		return
+	victim.balloon_alert_to_viewers("looks upset")
+	victim.ai_controller = new awake_controller(victim)
+	victim.RemoveElement(/datum/element/sedated_mob)

--- a/orbstation/code/map/biodome/sedated_mob.dm
+++ b/orbstation/code/map/biodome/sedated_mob.dm
@@ -24,8 +24,8 @@
 /datum/element/sedated_mob/proc/on_attacked(mob/victim, atom/attacker)
 	SIGNAL_HANDLER
 
-	if (!victim.ai_controller)
+	if (!victim.ai_controller || victim.stat == DEAD)
 		return
 	victim.balloon_alert_to_viewers("looks upset")
 	victim.ai_controller = new awake_controller(victim)
-	victim.RemoveElement(/datum/element/sedated_mob)
+	victim.RemoveElement(/datum/element/sedated_mob, awake_controller)

--- a/strings/modular_maps/biodome.toml
+++ b/strings/modular_maps/biodome.toml
@@ -1,13 +1,13 @@
 directory = "_maps/map_files/biodome/modules/"
 
 [rooms.cage_1]
-modules = ["cage_1_axolotl.dmm"]
+modules = ["cage_1_axolotl.dmm", "cage_1_creature.dmm"]
 
 [rooms.cage_2]
-modules = ["cage_2_amoung.dmm"]
+modules = ["cage_2_amoung.dmm", "cage_2_ghost.dmm"]
 
 [rooms.cage_3]
-modules = ["cage_3_rabbit.dmm"]
+modules = ["cage_3_rabbit.dmm", "cage_3_gnome.dmm"]
 
 [rooms.cage_4]
-modules = ["cage_4_cockroach.dmm"]
+modules = ["cage_4_cockroach.dmm", "cage_4_spider.dmm"]

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5311,6 +5311,7 @@
 #include "orbstation\code\map\biodome\mobs.dm"
 #include "orbstation\code\map\biodome\modular_map.dm"
 #include "orbstation\code\map\biodome\power.dm"
+#include "orbstation\code\map\biodome\sedated_mob.dm"
 #include "orbstation\code\map\biodome\shuttles.dm"
 #include "orbstation\code\map\biodome\turfs.dm"
 #include "orbstation\code\mob\death_memory.dm"


### PR DESCRIPTION
## About The Pull Request

Begins filling in biodome's modular zoo enclosures with alternate versions, drawing on our somewhat limited stock of basic mobs (although I am sure passive simplemobs, or even retaliate ones, would be fine).

![image](https://user-images.githubusercontent.com/7483112/229262919-ee38b596-b653-482e-8959-2c9c2e7727e6.png)
![image](https://user-images.githubusercontent.com/7483112/229262922-d0cc33d5-b8d6-4f3d-aa02-6962fd5f3ae9.png)
![image](https://user-images.githubusercontent.com/7483112/229262925-b0386ddf-4ff4-4ce9-8a83-6164201eef71.png)
![image](https://user-images.githubusercontent.com/7483112/229262928-089694da-5f25-49e3-ac27-358f969bb0d5.png)

This also adds a new element we may make use of for other zoo beasts in the future, which gives a creature different AI... until it is attacked.

## Why It's Good For The Game

A little bit of visual variety for our favourite homegrown map. Maybe you can even think of a use for some of these creatures?

## Changelog

:cl:
add: Nanotrasen has began rotating the contents of the biodome pens on a per-shift basis.
/:cl:
