### PR TITLE
Adds required tools to overriden surgery steps.

### DIFF
--- a/orbstation/code/jobs/medical/surgery/lobotomy.dm
+++ b/orbstation/code/jobs/medical/surgery/lobotomy.dm
@@ -2,7 +2,7 @@
 	name = "Experimental Neural Bypass"
 
 /datum/surgery_step/lobotomize
-	name = "perform neural bypass"
+	name = "perform neural bypass (scalpel)"
 
 /datum/surgery_step/lobotomize/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to rearrange the nerves in [target]'s brain..."),

--- a/orbstation/code/jobs/medical/surgery/pacification.dm
+++ b/orbstation/code/jobs/medical/surgery/pacification.dm
@@ -3,7 +3,7 @@
 		This chip can only be terminated by CentCom officials following an official investigation."
 
 /datum/surgery_step/pacify
-	name = "attach chip"
+	name = "attach chip (hemostat)"
 
 /datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to carefully insert the chip into [target]..."),


### PR DESCRIPTION
Our overrides to pacification and lobotomy renamed the key surgery steps, but this was before surgery steps included the tool you need to use. This is now fixed.