### PR TITLE
makes dna syringe gun not purchasable

### DIFF
--- a/orbstation/code/antagonists/traitor/items/rebalancing.dm
+++ b/orbstation/code/antagonists/traitor/items/rebalancing.dm
@@ -25,6 +25,10 @@
 /datum/uplink_item/device_tools/hypnotic_grenade
 	purchasable_from = NONE
 
+// While this item has uses that are not inherently against the nature of orbstation, the most effective ones all are so until a transformation x-card exists this should not be enabled
+/datum/uplink_item/role_restricted/modified_syringe_gun
+	purchasable_from = NONE
+
 /datum/uplink_item/stealthy_tools/randomize
 	name = "Trigger Unfortunate Occurence"
 	desc = "When purchased, syndicate probabilty matrixes will cause a random event to occur on the station."


### PR DESCRIPTION
## About The Pull Request

removes dna syringe gun from geneticist and RD traitor uplinks

## Why It's Good For The Game

as per discussion last night on discord while this item has uses that could be funny and wider than turning everyone into monkeys or changing other peoples dna, the risk of those combined with them being the most effective uses of such an item makes it not function on orbstation. 

if there is a tf x card perhaps it could return.

## Changelog

:cl:
del: Removed dna syringe gun
/:cl:
