### PR TITLE
Fixes the eye trauma x-card.

### DIFF
--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -74,7 +74,7 @@
 		if(!possible_target.assigned_role)
 			continue
 
-		if(HAS_TRAIT(possible_target, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
+		if(HAS_TRAIT(possible_target.current, TRAIT_XCARD_EYE_TRAUMA)) //ORBSTATION
 			continue
 
 		if(heads_of_staff)


### PR DESCRIPTION
A bug with the eye trauma x-card was making traitors draft people with the x-card for eyesnatching, softlocking the objective. This is because it was checking for the trait on the _mind_ instead of the mob. This fixes that.

Whoops.