### PR TITLE
Biodome: The papercutters and events update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -40,6 +40,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"abi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "abs" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Garden"
@@ -615,6 +620,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "alG" = (
@@ -755,7 +761,7 @@
 	spawn_loot_chance = 50
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "aoa" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -867,13 +873,13 @@
 /turf/open/openspace,
 /area/station/biodome/aft)
 "apz" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
 "apE" = (
@@ -2203,6 +2209,7 @@
 /area/station/commons/toilet/auxiliary)
 "aPi" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "aPl" = (
@@ -2852,11 +2859,10 @@
 /area/station/hallway/primary/central/aft)
 "bcq" = (
 /obj/structure/table/reinforced,
-/obj/item/multitool,
-/obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "bcv" = (
@@ -2877,7 +2883,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "bcG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth_half,
@@ -3020,7 +3026,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "bfC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -3875,6 +3881,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "bys" = (
@@ -4426,15 +4433,16 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "bKh" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
+	},
+/obj/item/multitool{
+	pixel_x = -10
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 10
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -4785,12 +4793,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/breakroom)
-"bRu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark_green,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
-/area/station/service/kitchen/diner)
 "bRw" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/industrial_lift/public,
@@ -5498,7 +5500,7 @@
 "cgt" = (
 /obj/structure/table/bronze,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "cgx" = (
 /obj/item/assembly/signaler{
 	pixel_x = 5;
@@ -5787,6 +5789,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
+"cmh" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass/reinforced,
+/area/station/security/lockers)
 "cms" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/misc/asteroid/airless,
@@ -5837,6 +5843,7 @@
 /area/station/security/warden)
 "cnF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "cnW" = (
@@ -6140,7 +6147,7 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "ctv" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs/right{
@@ -6265,6 +6272,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "cvI" = (
@@ -6846,6 +6854,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
+"cEw" = (
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "cEC" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -7137,6 +7148,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain)
+"cJg" = (
+/turf/open/floor/carpet/royalblack,
+/area/station/service/library/lounge)
 "cJl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
@@ -7848,7 +7862,7 @@
 "cZN" = (
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "cZT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -7929,7 +7943,7 @@
 /area/station/medical/surgery/aft)
 "dba" = (
 /turf/open/openspace,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "dbf" = (
 /turf/open/openspace,
 /area/station/maintenance/port/greater)
@@ -8051,6 +8065,11 @@
 /obj/structure/chair/sofa/bench{
 	dir = 8
 	},
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
+"ddF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
 "ddH" = (
@@ -8853,6 +8872,7 @@
 "dtg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "dtv" = (
@@ -9244,6 +9264,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/bamboo/tatami/black{
 	dir = 4
 	},
@@ -9685,6 +9706,7 @@
 /area/station/medical/medbay/lobby)
 "dJI" = (
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "dJJ" = (
@@ -10249,6 +10271,7 @@
 /area/station/service/hydroponics)
 "dUC" = (
 /obj/structure/chair/bronze,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/bronze,
 /area/station/service/library)
 "dUG" = (
@@ -10554,6 +10577,15 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"eaR" = (
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "ebh" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/effect/landmark/start/assistant,
@@ -10727,6 +10759,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eeG" = (
@@ -10751,8 +10784,11 @@
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "efk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/button/door/directional/west{
@@ -10879,6 +10915,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"ejM" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass/reinforced,
+/area/station/science/xenobiology)
 "ejP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11035,7 +11075,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/bamboo/tatami/black,
 /area/station/service/bar)
 "ens" = (
@@ -12102,6 +12141,7 @@
 "eIS" = (
 /obj/effect/spawner/xmastree/rdrod,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "eJm" = (
@@ -12404,8 +12444,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "eOj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -12764,8 +12806,9 @@
 /area/station/maintenance/radshelter/civil)
 "eTx" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "eTD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13340,10 +13383,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"fgi" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "fgk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -16428,6 +16467,7 @@
 /obj/machinery/duct,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "gqX" = (
@@ -16437,6 +16477,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "gqY" = (
@@ -17653,6 +17694,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "gQd" = (
@@ -18097,6 +18139,10 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/bamboo,
 /area/station/command/heads_quarters/qm)
+"gZF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "gZP" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/window/reinforced/spawner,
@@ -18741,7 +18787,7 @@
 	name = "Secure Art Exhibition"
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "hni" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -18867,6 +18913,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hpQ" = (
@@ -18905,7 +18952,7 @@
 /obj/machinery/door/airlock/bronze,
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "hqZ" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/dark_blue/anticorner{
@@ -20366,7 +20413,7 @@
 "hYE" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "hYF" = (
 /obj/structure/chair{
 	dir = 8
@@ -21200,6 +21247,9 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
 "ipt" = (
@@ -21276,6 +21326,11 @@
 	dir = 4
 	},
 /area/station/command/heads_quarters/cmo)
+"iqV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "irn" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
@@ -21492,11 +21547,7 @@
 /area/station/biodome)
 "ivz" = (
 /obj/structure/table/reinforced,
-/obj/item/phone{
-	desc = "He bought?";
-	pixel_x = -3;
-	pixel_y = 3
-	},
+/obj/item/papercutter,
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "ivB" = (
@@ -21678,6 +21729,7 @@
 /obj/effect/landmark/start/depsec/supply,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/brown/diagonal_edge,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/supply)
 "iAd" = (
@@ -21746,6 +21798,7 @@
 /area/station/hallway/primary/starboard)
 "iBn" = (
 /obj/structure/table/wood,
+/obj/item/phone,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "iBo" = (
@@ -22056,6 +22109,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "iHV" = (
@@ -22195,7 +22249,7 @@
 "iKU" = (
 /obj/machinery/vending/games,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "iLd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -22474,6 +22528,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
+"iRL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/bronze,
+/area/station/service/library)
 "iSu" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
@@ -22618,6 +22677,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/station/cargo/office)
 "iWF" = (
@@ -22732,6 +22792,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"iYB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet/black,
+/area/station/security/prison)
 "iYM" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -23852,6 +23920,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood/large,
 /area/station/biodome)
 "jwc" = (
@@ -24654,6 +24723,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "jMU" = (
@@ -24906,10 +24976,10 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Service - Museum/Hobby"
+	c_tag = "Service - Museum Lounge"
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "jSN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
@@ -25030,8 +25100,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "jVi" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/tubes,
@@ -25955,6 +26026,7 @@
 "klX" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "kmc" = (
@@ -26008,7 +26080,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "kmS" = (
 /turf/open/misc/asteroid/airless,
 /area/space)
@@ -26181,10 +26253,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
-"kpv" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "kpA" = (
 /obj/machinery/exodrone_launcher,
 /obj/item/exodrone,
@@ -26752,7 +26820,7 @@
 "kBa" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "kBd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26949,10 +27017,11 @@
 /area/station/commons/storage/tools)
 "kEL" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "kEX" = (
@@ -27088,14 +27157,6 @@
 /area/station/cargo/miningdock)
 "kIj" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Warden Desk"
 	},
@@ -27103,6 +27164,7 @@
 	name = "Warden Desk";
 	req_access = list("armory")
 	},
+/obj/item/papercutter,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/warden)
 "kIm" = (
@@ -27230,7 +27292,7 @@
 /obj/structure/displaycase/trophy,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "kKA" = (
 /obj/machinery/modular_computer/console/preset/cargochat/medical{
 	dir = 1
@@ -27267,6 +27329,7 @@
 "kLg" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "kLh" = (
@@ -27743,6 +27806,7 @@
 "kSU" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "kSX" = (
@@ -28341,6 +28405,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "leW" = (
@@ -28553,6 +28618,7 @@
 /area/station/engineering/atmos/hfr_room)
 "lky" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/meeting_room)
 "lkz" = (
@@ -29002,7 +29068,7 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "lty" = (
 /turf/open/floor/plating/plasma,
 /area/station/maintenance/space_hut/plasmaman)
@@ -29110,7 +29176,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "lvX" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -29152,8 +29218,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "lwE" = (
 /obj/structure/chair,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -29472,7 +29539,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "lBh" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
@@ -29724,6 +29791,7 @@
 "lFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lFP" = (
@@ -30073,6 +30141,7 @@
 /area/station/hallway/primary/aft)
 "lNs" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "lNF" = (
@@ -31183,7 +31252,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "mgm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -32892,6 +32961,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"mQK" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "mRe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -32968,7 +33044,7 @@
 	req_access = list("library")
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "mTg" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/sign/clock/directional/north,
@@ -34858,6 +34934,7 @@
 /area/station/security/prison)
 "nFk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "nFl" = (
@@ -35345,6 +35422,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"nPd" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nPv" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_empty,
@@ -35401,7 +35482,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "nQh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -35637,6 +35718,10 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"nUr" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome)
 "nUv" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -35671,7 +35756,6 @@
 /area/station/maintenance/department/security)
 "nVf" = (
 /obj/structure/ladder,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "nVo" = (
@@ -35996,6 +36080,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "occ" = (
@@ -36710,7 +36795,6 @@
 "opv" = (
 /obj/machinery/teleport/station,
 /obj/machinery/light/small/directional/west,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "opw" = (
@@ -36757,8 +36841,13 @@
 "oqn" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/cyan,
 /area/station/commons/storage/art)
+"oqy" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "oqE" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -36812,10 +36901,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/atmos/hfr_room)
-"orx" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "orQ" = (
 /obj/effect/decal/cleanable/xenoblood/xsplatter,
 /turf/open/floor/plating,
@@ -37622,8 +37707,10 @@
 /area/station/science/ordnance/testlab)
 "oHe" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "oHh" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -37754,7 +37841,7 @@
 	spawn_loot_chance = 50
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "oJQ" = (
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -37795,13 +37882,10 @@
 /turf/open/floor/carpet,
 /area/station/cargo/lobby)
 "oKR" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
 "oKS" = (
@@ -37874,7 +37958,6 @@
 /area/station/engineering/lobby)
 "oMn" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oMw" = (
@@ -38698,6 +38781,7 @@
 /area/station/biodome/aft)
 "pdI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pdK" = (
@@ -39058,6 +39142,9 @@
 /obj/effect/decal/remains/human,
 /turf/open/misc/asteroid,
 /area/station/maintenance/port/central)
+"pkB" = (
+/turf/closed/wall/mineral/bronze,
+/area/station/service/library/lounge)
 "pkE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -39935,6 +40022,11 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
+"pFm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "pFA" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/aft)
@@ -40548,6 +40640,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"pRM" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass/reinforced,
+/area/station/security/warden)
 "pRY" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/east{
@@ -41449,6 +41545,10 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"qkK" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qkN" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/black,
@@ -41792,6 +41892,13 @@
 "qqD" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
+"qqK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/commissary)
 "qqM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
@@ -41885,6 +41992,7 @@
 /turf/open/misc/ashplanet/wateryrock/biodome,
 /area/station/biodome)
 "qsv" = (
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "qsW" = (
@@ -42000,8 +42108,9 @@
 "qvg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "qvq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -42112,7 +42221,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "qxo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -42787,13 +42896,14 @@
 /turf/open/water/jungle/biodome,
 /area/station/biodome)
 "qKs" = (
-/obj/machinery/space_heater,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
 "qKz" = (
@@ -44161,6 +44271,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "rkF" = (
@@ -44207,8 +44318,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "rlo" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Bar Starboard Entrance"
@@ -44915,6 +45028,7 @@
 "rxD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/science,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "rxL" = (
@@ -45102,7 +45216,7 @@
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_nineteen,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "rBr" = (
 /obj/structure/table,
 /obj/item/stamp/qm,
@@ -45200,6 +45314,7 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "rDu" = (
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/orange,
 /area/station/security/prison)
 "rDI" = (
@@ -45564,7 +45679,7 @@
 "rMD" = (
 /obj/machinery/skill_station,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "rMK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -45774,6 +45889,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
+"rRN" = (
+/obj/structure/cable,
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "rRR" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -46725,7 +46844,7 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "sle" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
@@ -47210,6 +47329,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "swB" = (
@@ -47582,6 +47702,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/holopad/secure,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "sDq" = (
@@ -47889,7 +48010,7 @@
 "sJN" = (
 /obj/item/kirbyplants,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "sJW" = (
 /obj/machinery/chem_dispenser,
 /obj/structure/window/reinforced{
@@ -48429,6 +48550,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /turf/open/floor/iron/terracotta,
 /area/station/engineering/gravity_generator)
+"sUp" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet/royalblue,
+/area/station/command/heads_quarters/hos)
 "sUT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48963,6 +49088,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"tfd" = (
+/obj/effect/spawner/structure/window/bronze,
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "tfv" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/fakebasalt,
@@ -49070,6 +49199,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "tir" = (
@@ -49700,6 +49830,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 1
 	},
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "tui" = (
@@ -50882,12 +51013,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"tRg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/bronze,
-/area/station/service/library)
 "tRp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50945,7 +51070,7 @@
 /obj/structure/chair/bronze,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "tSR" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 9
@@ -51098,6 +51223,11 @@
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"tWv" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tWx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -52908,6 +53038,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
 "uNV" = (
@@ -53677,8 +53808,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "vdL" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan{
@@ -53691,7 +53823,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "vdV" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/glass/reinforced,
@@ -53746,6 +53878,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "vfw" = (
@@ -54486,6 +54619,7 @@
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/security/office)
 "vtU" = (
@@ -55940,6 +56074,8 @@
 "vXL" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/item/papercutter,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "vXN" = (
@@ -55980,6 +56116,7 @@
 "vYg" = (
 /obj/structure/table/wood,
 /obj/item/food/cake/birthday,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain)
 "vYR" = (
@@ -56246,6 +56383,7 @@
 /area/station/service/library)
 "weT" = (
 /obj/machinery/medical_kiosk,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/white,
 /area/station/medical/treatment_center)
 "weY" = (
@@ -56388,6 +56526,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "whu" = (
@@ -56540,6 +56679,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"wkC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "wkD" = (
 /obj/structure/railing{
 	dir = 8
@@ -56592,14 +56738,15 @@
 /area/station/security/detectives_office)
 "wlg" = (
 /obj/structure/table/reinforced,
-/obj/structure/desk_bell{
-	pixel_x = -7;
-	pixel_y = 8
-	},
 /obj/machinery/door/window/left/directional/south{
 	req_access = list("cargo")
 	},
 /obj/machinery/door/firedoor,
+/obj/item/papercutter,
+/obj/structure/desk_bell{
+	pixel_x = 7;
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wlo" = (
@@ -56963,7 +57110,7 @@
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/nineteen_nineteen,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "wpy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57028,6 +57175,14 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
+"wrx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wrB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57232,6 +57387,11 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"wvU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wwk" = (
@@ -57511,6 +57671,7 @@
 /area/station/command/teleporter)
 "wzW" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
 "wzY" = (
@@ -57591,7 +57752,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "wBu" = (
 /obj/structure/closet/emcloset,
 /obj/item/radio/intercom/directional/east,
@@ -57904,7 +58065,7 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "wHq" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -58754,6 +58915,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
+"wYG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "wYN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -59117,7 +59284,7 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/item/book/random,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "xfO" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -59187,6 +59354,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "xhE" = (
@@ -60265,7 +60433,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "xEX" = (
 /obj/effect/decal/cleanable/blood/xtracks{
 	dir = 8
@@ -60397,6 +60565,7 @@
 "xGM" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "xHf" = (
@@ -60653,6 +60822,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"xLu" = (
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xLy" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -60890,7 +61067,7 @@
 "xPG" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/bronze,
-/area/station/service/library)
+/area/station/service/library/lounge)
 "xPZ" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
 /turf/open/floor/plating,
@@ -60949,6 +61126,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"xQI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "xRa" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -85380,7 +85563,7 @@ cai
 oLd
 oLd
 gLk
-oLd
+mQK
 myr
 aUt
 wrB
@@ -86141,7 +86324,7 @@ sLz
 vMK
 mkZ
 dsa
-dsa
+tWv
 dsa
 rAX
 gnE
@@ -89515,7 +89698,7 @@ uQR
 kbn
 dht
 vMt
-dht
+wvU
 dht
 uGn
 myL
@@ -90514,7 +90697,7 @@ oYq
 bjN
 cPm
 jau
-dzB
+iRL
 kaK
 weR
 lRh
@@ -91818,7 +92001,7 @@ nVA
 wvQ
 lfr
 riY
-pcK
+wrx
 fjV
 eSU
 eSU
@@ -93881,7 +94064,7 @@ hwf
 atv
 hwf
 hwf
-cbR
+eaR
 cbR
 gYi
 rlh
@@ -95122,7 +95305,7 @@ xkU
 pWk
 ajU
 nej
-bRu
+mqy
 dQU
 wmz
 oAS
@@ -96210,7 +96393,7 @@ kdt
 gMZ
 gMZ
 oPb
-rKd
+xLu
 avb
 lfG
 mSg
@@ -97476,7 +97659,7 @@ qmt
 vaW
 ljW
 mGW
-srU
+wkC
 vjl
 jZC
 fhc
@@ -99751,7 +99934,7 @@ ngd
 oXf
 pQt
 ngd
-ngd
+nUr
 ngd
 ngd
 ngd
@@ -105389,7 +105572,7 @@ hzh
 wfX
 ajG
 wLu
-fgi
+hzh
 qHe
 cly
 wfX
@@ -106241,7 +106424,7 @@ dCO
 dCO
 dCO
 cJs
-aYJ
+iYB
 cJs
 nVV
 bEX
@@ -143166,7 +143349,7 @@ ngE
 gJk
 dDW
 ngE
-kpv
+dDW
 fXt
 eLE
 iBP
@@ -148300,7 +148483,7 @@ rps
 rps
 rps
 rps
-orx
+rps
 rps
 sfX
 txv
@@ -148605,7 +148788,7 @@ blt
 vLg
 lUD
 woD
-woD
+qkK
 lDP
 dVy
 wyP
@@ -153238,7 +153421,7 @@ aVG
 ruD
 neH
 neH
-neH
+nPd
 jhb
 vxC
 vxC
@@ -153984,7 +154167,7 @@ eIQ
 cqe
 neH
 neH
-neH
+nPd
 neH
 neH
 cqe
@@ -155275,16 +155458,16 @@ rAq
 rAq
 rAq
 ctt
-weR
-weR
+pkB
+pkB
 qxk
 ctt
-weR
-weR
+pkB
+pkB
 cZN
 qxk
-weR
-weR
+pkB
+pkB
 cZN
 fQs
 fQs
@@ -155531,18 +155714,18 @@ rAq
 rAq
 vMh
 rsY
-weR
-weR
-weR
-weR
-weR
-weR
-weR
-ilj
-ilj
-weR
-weR
-weR
+pkB
+pkB
+pkB
+pkB
+pkB
+pkB
+pkB
+tfd
+tfd
+pkB
+pkB
+pkB
 fQs
 fQs
 jpN
@@ -155788,18 +155971,18 @@ rAq
 rAq
 bsz
 wUg
-weR
+pkB
 oJI
 hne
 mSW
 anU
 oHe
 xPG
-oYq
+cEw
 xEV
 bfl
 wBq
-weR
+pkB
 fQs
 fQs
 jpN
@@ -155828,7 +156011,7 @@ fPg
 ufj
 uAq
 cJN
-cJN
+abi
 uAq
 aVf
 bmu
@@ -156045,18 +156228,18 @@ rAq
 rAq
 rAq
 rAq
-ilj
+tfd
 kKv
-ylL
-ylL
-ylL
-oYq
-oYq
+cJg
+cJg
+cJg
+rRN
+cEw
 tSQ
 nPT
 cgt
 bcB
-weR
+pkB
 fQs
 fQs
 jpN
@@ -156302,18 +156485,18 @@ rAq
 rAq
 rAq
 rAq
-weR
+pkB
 kKv
-ylL
-tRg
+cJg
+wYG
 skY
 vdG
-oYq
+cEw
 wHn
 lvI
 cgt
 bcB
-weR
+pkB
 fQs
 fQs
 jpN
@@ -156559,18 +156742,18 @@ rAq
 rAq
 rAq
 rAq
-ilj
+tfd
 sJN
 hYE
 kmM
 dba
 lwy
-oYq
-oYq
+cEw
+wYG
 mgh
 mgh
 efa
-weR
+pkB
 fQs
 fQs
 sXp
@@ -156816,18 +156999,18 @@ rAq
 rAq
 rAq
 rAq
-weR
+pkB
 kKv
-ylL
-gpa
+cJg
+xQI
 eOf
 rln
-oYq
-oYq
-oYq
-oYq
+pFm
+pFm
+gZF
+gZF
 eTx
-weR
+pkB
 fQs
 fQs
 sXp
@@ -157073,18 +157256,18 @@ rAq
 rAq
 rAq
 rAq
-ilj
+tfd
 lBf
 kBa
 qvg
-ylL
+cJg
 jSF
 vdL
 wpw
 rBo
 iKU
 rMD
-weR
+pkB
 fQs
 fQs
 sXp
@@ -157330,18 +157513,18 @@ rAq
 rAq
 sjl
 twp
-weR
-weR
-weR
+pkB
+pkB
+pkB
 jVe
 hqK
-weR
-weR
-ilj
-ilj
-weR
-weR
-weR
+pkB
+pkB
+tfd
+tfd
+pkB
+pkB
+pkB
 fQs
 fQs
 jpN
@@ -157588,16 +157771,16 @@ rAq
 pHy
 psK
 xfC
-weR
-weR
+pkB
+pkB
 rkx
 ajB
-weR
-weR
+pkB
+pkB
 cZN
 cZN
-weR
-weR
+pkB
+pkB
 ltx
 fQs
 fQs
@@ -158398,7 +158581,7 @@ fDQ
 fDQ
 wNu
 qvq
-iat
+iqV
 xib
 iNZ
 ygC
@@ -159061,7 +159244,7 @@ rlY
 rlY
 rlY
 rlY
-rlY
+ejM
 eGS
 rfG
 rKS
@@ -159665,7 +159848,7 @@ maE
 jib
 ppS
 mrF
-akZ
+qqK
 uZV
 jIg
 vxC
@@ -166603,7 +166786,7 @@ pAd
 hWt
 gbr
 gbr
-gbr
+ddF
 gbr
 bkZ
 rSn
@@ -171251,7 +171434,7 @@ hNy
 eCA
 pZD
 qBS
-qBS
+pRM
 cWD
 cnA
 gEQ
@@ -171262,7 +171445,7 @@ cwu
 vTi
 vQG
 cwt
-iDZ
+sUp
 iDZ
 ijv
 eBh
@@ -171514,7 +171697,7 @@ rTx
 rvQ
 uox
 rLd
-cwu
+cmh
 cwu
 vTi
 azL
@@ -177120,7 +177303,7 @@ hNy
 kgB
 dBY
 inr
-inr
+oqy
 inr
 kkv
 qqD


### PR DESCRIPTION
- Adds the paper cutters
- Removes some event spawns from maint, adds a lot more everywhere else
- The library's upper floor is now the library lounge