### PR TITLE
Biodome dorm buttons patch

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -5346,7 +5346,7 @@
 /area/station/security/processing)
 "cdF" = (
 /obj/machinery/button/door/directional/north{
-	id = "Dorm4";
+	id = "Dorm3";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
@@ -42520,8 +42520,8 @@
 /obj/machinery/button/door/directional/west{
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
-	sync_doors = 4;
-	id = "Dorm8"
+	id = "Dorm8";
+	specialfunctions = 4
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/commons/dorms)
@@ -54112,7 +54112,7 @@
 /area/station/medical/surgery/aft)
 "vld" = (
 /obj/machinery/button/door/directional/south{
-	id = "Dorm3";
+	id = "Dorm4";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
@@ -56556,6 +56556,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "wia" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/south{
+	id = "Dorm7";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/carpet/neon/simple/white,
 /area/station/commons/dorms)
 "wif" = (


### PR DESCRIPTION


## About The Pull Request

Some of the dorms had incorrect locking buttons on the biodome, this PR fixes that.

## Why It's Good For The Game

You want to lock your door when you go AFK, or lesser form changeling.
