### PR TITLE
You can't print revolver ammo from the hacked lathe (and removes fun traitor item)

### DIFF
--- a/orbstation/code/antagonists/traitor/items/rebalancing.dm
+++ b/orbstation/code/antagonists/traitor/items/rebalancing.dm
@@ -29,16 +29,3 @@
 /datum/uplink_item/role_restricted/modified_syringe_gun
 	purchasable_from = NONE
 
-/datum/uplink_item/stealthy_tools/randomize
-	name = "Trigger Unfortunate Occurence"
-	desc = "When purchased, syndicate probabilty matrixes will cause a random event to occur on the station."
-	item = /obj/effect/gibspawner/generic
-	surplus = 0
-	cost = 1
-	progression_minimum = 10 MINUTES
-	restricted = TRUE
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
-/datum/uplink_item/stealthy_tools/randomize/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
-	SSevents.spawnEvent()
-	return source //For log icon

--- a/orbstation/code/objects/machinery/autolathe_overrides.dm
+++ b/orbstation/code/objects/machinery/autolathe_overrides.dm
@@ -1,3 +1,3 @@
 /// remove ability to print ammo from the autolathe, no one should be able to print twenty revolver bullets on orbstation at this point in time
 /datum/design/a357
-	build_path = null
+	build_type = null

--- a/orbstation/code/objects/machinery/autolathe_overrides.dm
+++ b/orbstation/code/objects/machinery/autolathe_overrides.dm
@@ -1,0 +1,3 @@
+/// remove ability to print ammo from the autolathe, no one should be able to print twenty revolver bullets on orbstation at this point in time
+/datum/design/a357
+	build_path = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5429,6 +5429,7 @@
 #include "orbstation\code\objects\items\weapons\elance.dm"
 #include "orbstation\code\objects\items\weapons\fakebeesword.dm"
 #include "orbstation\code\objects\items\weapons\guns.dm"
+#include "orbstation\code\objects\machinery\autolathe_overrides.dm"
 #include "orbstation\code\objects\machinery\debug_chem.dm"
 #include "orbstation\code\objects\spawners\beach_spawners.dm"
 #include "orbstation\code\objects\vending\_vendors.dm"


### PR DESCRIPTION
## About The Pull Request
Currently you can print more ammo for the syndicate revolver (mainly) from a hacked autolathe, this makes the 13 TC for a very specific number of shots weapon have a lot more than we can account for. This PR removes the ammo from the hacked lathe.

also it takes out my funny april fools trraitor item

## Why It's Good For The Game
Making it so that you can only get more ammo from the uplink for the syndicate revolver is probably better for the current orbstation state of balance. The revolver now does just give you what you pay it for.

## Changelog

:cl:
balance: you can no longer print out more revolver ammo at hacked autolathes
del: removed random event spawn from uplink
/:cl:


