### PR TITLE
Hypnosis X-Card

### DIFF
--- a/code/__DEFINES/orb/traits.dm
+++ b/code/__DEFINES/orb/traits.dm
@@ -10,6 +10,8 @@
 #define TRAIT_XCARD_EYE_TRAUMA "xcard_eye_trauma"
 // Prevents this character from being chosen by the Paradox Clone antag.
 #define TRAIT_XCARD_PARADOX_CLONE "xcard_paradox_clone"
+// Prevents this character from being hypnotised.
+#define TRAIT_XCARD_HYPNOSIS "xcard_hypnosis"
 // Makes you immune to bioscrambler limb-swapping (used for x-card, but may be applied to species with a unique shape too)
 #define TRAIT_BIOSCRAMBLER_IMMUNE "bioscrambler_immune"
 // Multiplies the time it takes to craft items by FAST_CRAFTER_MOD

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -23,19 +23,6 @@
 	..()
 
 /datum/brain_trauma/hypnosis/on_gain()
-	if (HAS_TRAIT(owner, TRAIT_XCARD_HYPNOSIS)) // ORBSTATION ADDITION
-		to_chat(owner, span_boldwarning("You feel a splitting pain in your head and your mind goes blank!"))
-		to_chat(owner, span_notice("You cannot remember what just triggered this."))
-		var/migraine_glow = owner.client?.prefs?.read_preference(/datum/preference/toggle/darkened_flash) ? \
-			/atom/movable/screen/fullscreen/flash/black : \
-			/atom/movable/screen/fullscreen/flash
-		owner.overlay_fullscreen("migraine", migraine_glow)
-		addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/, clear_fullscreen), "migraine", 5 SECONDS), 5 SECONDS)
-		owner.Stun(15 SECONDS)
-		owner.set_stutter_if_lower(1 MINUTES)
-		owner.set_hallucinations_if_lower(3 MINUTES)
-		qdel(src)
-		return
 	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	owner.log_message("was hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
 	to_chat(owner, span_reallybig(span_hypnophrase("[hypnotic_phrase]")))

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -23,6 +23,19 @@
 	..()
 
 /datum/brain_trauma/hypnosis/on_gain()
+	if (HAS_TRAIT(owner, TRAIT_XCARD_HYPNOSIS)) // ORBSTATION ADDITION
+		to_chat(owner, span_boldwarning("You feel a splitting pain in your head and your mind goes blank!"))
+		to_chat(owner, span_notice("You cannot remember what just triggered this."))
+		var/migraine_glow = owner.client?.prefs?.read_preference(/datum/preference/toggle/darkened_flash) ? \
+			/atom/movable/screen/fullscreen/flash/black : \
+			/atom/movable/screen/fullscreen/flash
+		owner.overlay_fullscreen("migraine", migraine_glow)
+		addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/, clear_fullscreen), "migraine", 5 SECONDS), 5 SECONDS)
+		owner.Stun(15 SECONDS)
+		owner.set_stutter_if_lower(1 MINUTES)
+		owner.set_hallucinations_if_lower(3 MINUTES)
+		qdel(src)
+		return
 	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	owner.log_message("was hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
 	to_chat(owner, span_reallybig(span_hypnophrase("[hypnotic_phrase]")))
@@ -49,7 +62,10 @@
 	hypno_alert.desc = "\"[hypnotic_phrase]\"... your mind seems to be fixated on this concept."
 	..()
 
-/datum/brain_trauma/hypnosis/on_lose()
+/datum/brain_trauma/hypnosis/on_lose(silent)
+	if (HAS_TRAIT(owner, TRAIT_XCARD_HYPNOSIS)) // ORBSTATION ADDITION
+		silent = TRUE
+		return ..()
 	message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	owner.log_message("is no longer hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
 	to_chat(owner, span_userdanger("You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you."))

--- a/orbstation/code/customisation/quirks/xcard/hypnosis.dm
+++ b/orbstation/code/customisation/quirks/xcard/hypnosis.dm
@@ -1,0 +1,15 @@
+// Don't apply if you are immune
+/datum/brain_trauma/hypnosis/on_gain()
+	if (!HAS_TRAIT(owner, TRAIT_XCARD_HYPNOSIS))
+		return ..()
+	to_chat(owner, span_boldwarning("You feel a splitting pain in your head and your mind goes blank!"))
+	to_chat(owner, span_notice("You cannot remember what just triggered this."))
+	var/migraine_glow = owner.client?.prefs?.read_preference(/datum/preference/toggle/darkened_flash) ? \
+		/atom/movable/screen/fullscreen/flash/black : \
+		/atom/movable/screen/fullscreen/flash
+	owner.overlay_fullscreen("migraine", migraine_glow)
+	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/, clear_fullscreen), "migraine", 5 SECONDS), 5 SECONDS)
+	owner.Stun(15 SECONDS)
+	owner.set_stutter_if_lower(1 MINUTES)
+	owner.set_hallucinations_if_lower(3 MINUTES)
+	qdel(src)

--- a/orbstation/code/customisation/quirks/xcard/xcard-quirks.dm
+++ b/orbstation/code/customisation/quirks/xcard/xcard-quirks.dm
@@ -48,6 +48,13 @@
 	mob_trait = TRAIT_XCARD_PARADOX_CLONE
 	//this SHOULDN'T appear on examine - other players should not know that you can't have an evil twin.
 
+/datum/quirk/xcard/hypnosis
+	name = "X-CARD: Hypnosis"
+	desc = "You have an iron force of will and can shrug off sources of brainwashing, \
+		reducing them instead to merely a painful migraine."
+	mob_trait = TRAIT_XCARD_HYPNOSIS
+	examine_text = "immune to hypnotic suggestion."
+
 /*
 /datum/quirk/xcard/uncyborgable
 	name = "Cyborg Incompatibility"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5298,6 +5298,7 @@
 #include "orbstation\code\customisation\quirks\damned\damned.dm"
 #include "orbstation\code\customisation\quirks\damned\damned_halo.dm"
 #include "orbstation\code\customisation\quirks\xcard\bioscrambler_immune.dm"
+#include "orbstation\code\customisation\quirks\xcard\hypnosis.dm"
 #include "orbstation\code\customisation\quirks\xcard\revolution.dm"
 #include "orbstation\code\customisation\quirks\xcard\xcard-quirks.dm"
 #include "orbstation\code\customisation\quirks\xcard\xenotoxin.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes #572

Long time coming and like many of these things, not very hard to implement. To do it you just got to do it.
If you have this X-Card and would gain the hypnosis trauma you instead do not. In its place you are stunned for 15 seconds, unable to speak clearly for a minute, and hallucinate for three minutes.
Flavour text instructs you to forget how this happened.

I didn't go for the "you can opt in sometimes" approach because that's way more complicated, it seemed more useful to get this in now and expand it later rather than make perfect the enemy of the good enough.

## Why It's Good For The Game

Commonly requested option which allows you to use a reasonably common (more so now the rep requirement was removed) item with less fear of triggering someone.

## Changelog

:cl:
add: You can now render your character immune to hypnotism.
/:cl:
