### PR TITLE
Revenants require less dead players to spawn.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -684,7 +684,7 @@
 	var/dead_mobs_required = 20
 	var/need_extra_spawns_value = 15
 	var/list/spawn_locs = list()
-	var/dead_players_required = 3 //ORBSTATION
+	var/dead_players_required = 2 //ORBSTATION
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
 	//ORBSTATION EDIT

--- a/orbstation/code/antagonists/rulesets_midround.dm
+++ b/orbstation/code/antagonists/rulesets_midround.dm
@@ -1,8 +1,4 @@
-//////////////////////////////////////////////
-//                                          //
-//           SYNDICATE TRAITORS             //
-//                                          //
-//////////////////////////////////////////////
+/// Midround Traitor Ruleset (From Living)
 
 // Don't create more traitors if it exceeds the limit for the current population & threat level.
 /datum/dynamic_ruleset/midround/from_living/autotraitor/ready(forced = FALSE)
@@ -12,12 +8,7 @@
 			return FALSE
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//         CHANGELING INFILTRATOR           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Changeling Infiltrator Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator
 	name = "Changeling Infiltrator"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -42,12 +33,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_infiltrator/finish_setup(mob/new_character, index)
 	return // the spawned player is given the antag datum via the spawner, so we don't need to do it here
 
-//////////////////////////////////////////////
-//                                          //
-//            WIZARD JOURNEYMAN             //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Wizard Journeyman Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/wizard_journeyman
 	name = "Wizard Journeyman"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -78,12 +64,7 @@
 	if (GLOB.journeymanstart.len)
 		new_character.forceMove(pick(GLOB.journeymanstart))
 
-//////////////////////////////////////////////
-//                                          //
-//            HERETIC (MIDROUND)            //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Heretic Ruleset (From Living)
 /datum/dynamic_ruleset/midround/from_living/waking_heretic
 	name = "Waking Heretic"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT // heretics need time to set up, so this should happen earlier in the round
@@ -142,12 +123,7 @@
 
 	return TRUE
 
-//////////////////////////////////////////////
-//                                          //
-//              LONE OPERATIVE              //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Lone Operative Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/lone_operative
 	name = "Lone Operative"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the number of dead players needed for a revenant to spawn from 3 to 2.

Also makes some stylistic changes to the headers in our own `rulesets_midround` file to match the style used upstream.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Requiring three dead players at our population may have been a bit overzealous. We've hardly seen any revenants at all lately, so this might help change that a bit. If this doesn't do much, we can try changing it to 1 instead, but one step at a time.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Revenants can now spawn with only two dead players.
code: Changed some header comments in our midrounds file.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
