### PR TITLE
Removed the 'got wood' and 'free Tonto' posters.

### DIFF
--- a/orbstation/code/cleanup/items.dm
+++ b/orbstation/code/cleanup/items.dm
@@ -87,8 +87,13 @@
 /obj/structure/sign/poster/official/no_erp
 	desc = "This poster reminds the crew that Eroticism, Raunchiness and Pornography are banned on Nanotrasen stations."
 
-//Delete this poster if it ever appears and replace it with a random one.
+//Delete these poster if it ever appears and replace it with a random one.
 /obj/structure/sign/poster/contraband/got_wood/Initialize(mapload, vol)
+	. = ..()
+	new /obj/structure/sign/poster/contraband/random(loc)
+	return INITIALIZE_HINT_QDEL
+
+/obj/structure/sign/poster/contraband/free_tonto/Initialize(mapload, vol)
 	. = ..()
 	new /obj/structure/sign/poster/contraband/random(loc)
 	return INITIALIZE_HINT_QDEL

--- a/orbstation/code/cleanup/items.dm
+++ b/orbstation/code/cleanup/items.dm
@@ -87,6 +87,12 @@
 /obj/structure/sign/poster/official/no_erp
 	desc = "This poster reminds the crew that Eroticism, Raunchiness and Pornography are banned on Nanotrasen stations."
 
+//Delete this poster if it ever appears and replace it with a random one.
+/obj/structure/sign/poster/contraband/got_wood/Initialize(mapload, vol)
+	. = ..()
+	new /obj/structure/sign/poster/contraband/random(loc)
+	return INITIALIZE_HINT_QDEL
+
 //Removed the word "ghetto" from item descriptions
 /obj/item/flashlight/lamp/bananalamp
 	desc = "Only a clown would think to make a silly banana-shaped lamp. Even has a goofy pullstring."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

These ones got missed in all the other cleanup. When the "got wood" or "free Tonto" posters would spawn, they are instantly deleted and replaced with a random contraband poster.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One poster is just gross and based on one of tg's absolute worst memes, and the other is about a player who was banned for just like. Being gross. Get 'em out of here.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the "got wood" and "free Tonto" posters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
