### PR TITLE
Biodome: The maintenance spring cleaning update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -5099,7 +5099,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark/opposingcorners,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
 "bXS" = (
@@ -57613,15 +57612,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"wwD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/warden)
 "wwF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -172168,7 +172158,7 @@ eCA
 rmg
 cuy
 ick
-wwD
+wlt
 wlt
 vSA
 uox

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -232,7 +232,6 @@
 /area/station/science/cytology)
 "aeD" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -586,6 +585,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"akR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "akU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -744,7 +752,6 @@
 "anL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -1891,7 +1898,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/grass,
 /area/station/science/research)
@@ -2044,7 +2050,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/diagonal,
@@ -3884,6 +3889,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "bys" = (
@@ -4003,6 +4009,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
+"bzV" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bAd" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -4054,6 +4067,15 @@
 	},
 /turf/open/floor/grass,
 /area/station/security/courtroom)
+"bBk" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "bBn" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -6362,6 +6384,7 @@
 /area/station/service/janitor)
 "cwn" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "cwr" = (
@@ -7658,7 +7681,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
@@ -7809,7 +7831,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cXZ" = (
@@ -8638,6 +8659,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "doc" = (
@@ -10778,14 +10800,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"eez" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "eeG" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -10940,8 +10954,8 @@
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
 "ejP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ekj" = (
@@ -11140,6 +11154,12 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"eoE" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "eoF" = (
 /obj/machinery/button/door/directional/north{
 	id = "pharmacy_shutters";
@@ -12050,7 +12070,6 @@
 "eHg" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/loading_area/white,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -14107,7 +14126,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
@@ -14162,7 +14180,6 @@
 /area/station/hallway/primary/central/aft)
 "fuP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -14438,6 +14455,7 @@
 "fAz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "fAC" = (
@@ -16868,7 +16886,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
@@ -17200,6 +17217,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "gEi" = (
@@ -17508,7 +17526,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
@@ -17684,7 +17701,6 @@
 	name = "Robotics Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -17836,6 +17852,7 @@
 /area/station/hallway/secondary/entry)
 "gRn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "gRq" = (
@@ -18313,10 +18330,6 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"hcm" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
 "hcu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19038,6 +19051,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -19095,6 +19109,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -19393,6 +19408,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "hAx" = (
@@ -20140,7 +20156,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -20612,6 +20627,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "ibj" = (
@@ -22670,6 +22686,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "iUm" = (
@@ -23192,11 +23209,11 @@
 "jeh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "jep" = (
@@ -23448,6 +23465,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jjA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "jjE" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/trapdoor_placer,
@@ -24534,6 +24561,7 @@
 "jGM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "jGN" = (
@@ -24644,8 +24672,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
@@ -25975,7 +26001,6 @@
 "kkx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
@@ -26978,7 +27003,6 @@
 "kCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "kCx" = (
@@ -27322,6 +27346,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/court,
+/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/security/courtroom)
 "kJg" = (
@@ -30714,6 +30739,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
 "lWl" = (
@@ -33354,7 +33380,6 @@
 /area/station/asteroid)
 "mXw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
@@ -33668,6 +33693,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "ndr" = (
@@ -34020,6 +34046,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"njP" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "njY" = (
 /obj/structure/window/paperframe,
 /obj/effect/turf_decal/siding/wood/end{
@@ -34657,7 +34690,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nxG" = (
@@ -35925,6 +35957,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/white,
 /area/station/medical/medbay/lobby)
 "nWa" = (
@@ -36352,6 +36385,7 @@
 /obj/structure/fence/door/opened,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/security/courtroom)
 "oep" = (
@@ -36809,6 +36843,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
 "omv" = (
@@ -37095,6 +37130,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -39473,7 +39509,6 @@
 /area/station/maintenance/starboard/central)
 "pnz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	name = "sorting disposal pipe (Research Director's Office)"
@@ -41316,11 +41351,12 @@
 "qdC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -42274,6 +42310,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "qvg" = (
@@ -42955,7 +42992,6 @@
 /area/station/engineering/atmos)
 "qIe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -43047,7 +43083,6 @@
 /area/station/service/library)
 "qKh" = (
 /obj/effect/turf_decal/loading_area/white,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -43599,6 +43634,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"qUC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/security/courtroom)
 "qUE" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sticky_tape/surgical,
@@ -44083,7 +44124,6 @@
 /area/station/science/server)
 "rdh" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple,
@@ -44424,6 +44464,17 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"rjy" = (
+/obj/machinery/door/airlock/research{
+	name = "Robotics Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/science/robotics/lab)
 "rjJ" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -45167,13 +45218,13 @@
 /area/station/service/chapel)
 "rwK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "rwT" = (
@@ -45431,6 +45482,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "rBO" = (
@@ -45700,6 +45752,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "rIP" = (
@@ -47045,6 +47098,8 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "skY" = (
@@ -47169,6 +47224,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "snL" = (
@@ -48084,6 +48140,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/funeral)
+"sHL" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/spawner/random/clothing/twentyfive_percent_cyborg_mask,
+/turf/open/floor/plating,
+/area/station/science/research)
 "sHR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -48206,7 +48269,6 @@
 /area/station/hallway/primary/central/aft)
 "sJy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49214,7 +49276,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
@@ -51981,6 +52042,10 @@
 	dir = 8
 	},
 /area/station/service/bar)
+"ulx" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "ulB" = (
 /obj/machinery/pdapainter/supply,
 /obj/machinery/button/door/directional/west{
@@ -52063,6 +52128,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
 "umR" = (
@@ -53100,6 +53166,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"uKd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "uKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55656,6 +55734,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vKh" = (
@@ -55832,6 +55911,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vNy" = (
@@ -56246,6 +56326,24 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"vVp" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "vVu" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/south{
@@ -56496,6 +56594,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
+"wbN" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "wca" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
@@ -57001,7 +57106,6 @@
 	},
 /obj/machinery/door/window/right/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/grass,
 /area/station/science/research)
@@ -57098,7 +57202,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "wme" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/trunk/multiz/down{
@@ -57963,10 +58066,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "wAH" = (
-/obj/structure/cable/multilayer/multiz,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/spawner/random/clothing/island_time,
 /turf/open/floor/plating,
 /area/station/science/research)
 "wAL" = (
@@ -58193,7 +58296,6 @@
 	name = "sorting disposal pipe (Robotics)"
 	},
 /obj/effect/mapping_helpers/mail_sorting/science/robotics,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -59147,7 +59249,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "wYk" = (
@@ -59413,12 +59514,6 @@
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "xcG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/drone_dispenser,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -59584,7 +59679,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "xhn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/structure/railing{
@@ -59913,6 +60007,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/white,
 /area/station/medical/medbay/lobby)
 "xok" = (
@@ -60152,7 +60247,6 @@
 /area/station/science/xenobiology)
 "xtX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
@@ -61000,6 +61094,7 @@
 "xJQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "xJW" = (
@@ -106907,8 +107002,8 @@ dNL
 tIP
 rJn
 nQF
-dms
-dms
+uZn
+uZn
 gok
 uQi
 jCu
@@ -107162,8 +107257,8 @@ oqE
 snK
 sbp
 tIP
-dms
-dms
+uZn
+uZn
 umA
 wxd
 rIP
@@ -107419,7 +107514,7 @@ rlF
 jGM
 jGM
 kJc
-hEb
+qUC
 dmu
 hEb
 qCH
@@ -149810,8 +149905,8 @@ uCM
 phg
 jJj
 aEg
-skW
-skW
+njP
+njP
 skW
 ybO
 fAu
@@ -151866,7 +151961,7 @@ acV
 oLd
 aZD
 gxh
-eez
+mQK
 mXw
 oLd
 dVr
@@ -152123,7 +152218,7 @@ hbg
 hbg
 qDO
 kUH
-kqT
+eoE
 ejP
 jUz
 pxl
@@ -152639,7 +152734,7 @@ uCO
 bIP
 eyw
 bIP
-uCO
+vVp
 eyw
 ahq
 lRH
@@ -152896,7 +152991,7 @@ fkk
 kCx
 fUE
 kCx
-fkk
+uKd
 chZ
 ahq
 xeC
@@ -158996,7 +159091,7 @@ dJN
 eNU
 eWK
 dJN
-wAH
+sHL
 xhn
 wme
 czJ
@@ -159259,7 +159354,7 @@ eHg
 czJ
 faz
 cWS
-pJa
+jjA
 eWZ
 czJ
 bTR
@@ -161072,7 +161167,7 @@ dhe
 phW
 dIO
 oWu
-cSp
+hNO
 iXV
 phW
 jfX
@@ -161316,7 +161411,7 @@ uES
 rKc
 hWk
 ibi
-hWk
+wbN
 rfB
 uES
 dCg
@@ -161329,7 +161424,7 @@ eKW
 phW
 lUm
 oWu
-cSp
+hNO
 pGx
 phW
 dSl
@@ -161573,7 +161668,7 @@ gcX
 wCz
 azQ
 eIS
-azQ
+ulx
 vUg
 gcX
 dCg
@@ -161586,7 +161681,7 @@ icQ
 chi
 chi
 aMm
-aMm
+rjy
 chi
 lSi
 lyT
@@ -161830,7 +161925,7 @@ uES
 mBE
 ejv
 vJY
-ejv
+bzV
 bMR
 uES
 dCg
@@ -162862,7 +162957,7 @@ dCg
 tGP
 dCg
 dCg
-jeh
+pJa
 kAO
 lzU
 umy
@@ -163118,7 +163213,7 @@ pnz
 xtX
 qIe
 xUK
-xUK
+bBk
 jeh
 kAO
 aME
@@ -163887,7 +163982,7 @@ nJi
 ivJ
 kFW
 eKq
-bTC
+akR
 jnh
 qfx
 kmV
@@ -170137,12 +170232,12 @@ tby
 uld
 eGA
 rUx
-hcm
-hcm
-hcm
+eGA
+eGA
+eGA
 cwn
-uEl
-uEl
+rUx
+rUx
 oay
 oay
 kfh

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2302,7 +2302,7 @@
 	name = "Diner Canopy"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
 "aQb" = (
@@ -2580,6 +2580,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
+"aVd" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "aVf" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -10897,6 +10901,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/door/window/right/directional/south{
+	name = "Freezer";
+	req_access = list("kitchen")
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "egm" = (
@@ -16228,8 +16237,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "Bar Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
 "giE" = (
@@ -21856,6 +21864,12 @@
 "iyR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/window/left/directional/east{
+	req_one_access = list("service","maint_tunnels")
+	},
+/obj/machinery/door/window/left/directional/east{
+	req_one_access = list("service","maint_tunnels")
+	},
 /turf/open/floor/wood/parquet,
 /area/station/service/kitchen/diner)
 "izf" = (
@@ -22681,8 +22695,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "Bar Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
 "iRL" = (
@@ -33448,6 +33461,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/research)
+"mXg" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "mXi" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 1;
@@ -33951,6 +33968,11 @@
 /area/station/science/xenobiology)
 "nfG" = (
 /obj/structure/ladder,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/right/directional/south{
+	name = "Backroom";
+	req_access = list("bar")
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "nfH" = (
@@ -44954,13 +44976,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/theater)
-"rpC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/falsewall/wood,
-/turf/open/floor/wood/parquet,
-/area/station/service/kitchen/diner)
 "rpM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -47934,9 +47949,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/falsewall/wood,
 /turf/open/floor/wood/parquet,
-/area/station/service/kitchen/diner)
+/area/station/biodome)
 "szX" = (
 /obj/structure/noticeboard/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -48192,6 +48206,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"sFP" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "sFT" = (
 /obj/effect/spawner/structure/window/hollow/plasma,
 /turf/open/floor/plating/plasma,
@@ -52137,6 +52156,10 @@
 "ukj" = (
 /turf/open/floor/glass,
 /area/station/hallway/primary/starboard)
+"ukp" = (
+/obj/structure/ladder,
+/turf/open/floor/engine/hull,
+/area/station/asteroid)
 "ukO" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -53040,7 +53063,7 @@
 	name = "Diner Canopy"
 	},
 /obj/structure/lattice/catwalk,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
 "uDQ" = (
@@ -56904,6 +56927,10 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/biodome/aft)
+"wfw" = (
+/obj/structure/ladder,
+/turf/open/floor/plating/airless,
+/area/station/solars/port/aft)
 "wfF" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/camera{
@@ -85067,9 +85094,9 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+wfw
 ycJ
-cCZ
+kcX
 cCZ
 cCZ
 cCZ
@@ -89629,7 +89656,7 @@ oQV
 cJU
 cJU
 cJU
-cJU
+rZH
 wpF
 tbw
 tbw
@@ -145396,7 +145423,7 @@ tiU
 ikk
 tMa
 ikk
-vxs
+aVd
 wbu
 vxs
 ahB
@@ -150603,9 +150630,9 @@ hHc
 hHc
 hHc
 hHc
+ukp
 hHc
-hHc
-hHc
+kQJ
 hHc
 hHc
 hHc
@@ -156484,7 +156511,7 @@ fJC
 vxC
 xsO
 vxC
-eKQ
+sFP
 fJC
 geA
 bxE
@@ -162354,7 +162381,7 @@ qrZ
 iJt
 nTY
 lpO
-rpC
+nTY
 szR
 lKQ
 lKQ
@@ -170101,7 +170128,7 @@ nIC
 cEV
 fKL
 gww
-uEl
+mXg
 uEl
 kSo
 uEl
@@ -174227,7 +174254,7 @@ xfs
 avN
 ouU
 rRv
-hHc
+rRv
 hNy
 hNy
 oOB
@@ -174741,7 +174768,7 @@ avN
 ups
 ouU
 hHc
-hHc
+rRv
 hHc
 hNy
 hNy

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1275,6 +1275,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"awT" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "axh" = (
 /obj/structure/cable,
 /obj/structure/falsewall,
@@ -1997,6 +2002,13 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
+"aKJ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aKL" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm5";
@@ -5038,6 +5050,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"bWf" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bWg" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing,
@@ -5793,6 +5811,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"ckM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "clm" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
@@ -6103,6 +6128,12 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"crU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "crW" = (
 /obj/machinery/plumbing/synthesizer{
 	reagent_id = /datum/reagent/water;
@@ -6315,6 +6346,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"cvz" = (
+/obj/item/relic,
+/obj/item/bedsheet/black{
+	dir = 1
+	},
+/obj/structure/bed/dogbed,
+/turf/open/floor/carpet,
+/area/station/maintenance/port/central)
 "cvI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -7668,7 +7707,9 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "cUf" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	space_dir = 8
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -8061,6 +8102,9 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space/nearstation)
+"dcz" = (
+/turf/open/floor/carpet,
+/area/station/maintenance/port/central)
 "dcB" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -11318,6 +11362,7 @@
 "esE" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "esU" = (
@@ -15267,10 +15312,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"fRf" = (
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "fRk" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Brig Infirmary"
@@ -15749,6 +15790,9 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"fZq" = (
+/turf/open/floor/carpet/green,
+/area/station/maintenance/port/central)
 "fZr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16502,14 +16546,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"gps" = (
-/obj/structure/closet/crate/necropolis{
-	desc = "Presumably placed here by top men.";
-	name = "\improper Ark of the Covenant"
-	},
-/obj/item/toy/plush/ratplush,
-/turf/open/misc/asteroid,
-/area/station/maintenance/port/central)
 "gpM" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -18701,6 +18737,11 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"hkA" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet,
+/area/station/maintenance/port/central)
 "hkN" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/computer/records/security{
@@ -18748,6 +18789,12 @@
 /obj/item/storage/box/evidence,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"hle" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hlj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
@@ -20399,6 +20446,16 @@
 /obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hWU" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Chemical Factory Starboard";
+	network = list("ss13","network")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hWV" = (
 /obj/structure/chair{
 	dir = 4
@@ -23575,7 +23632,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "jmc" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	space_dir = 8
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -23653,6 +23712,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/cargo/lobby)
+"job" = (
+/obj/item/reagent_containers/cup/bottle/water,
+/turf/open/floor/iron,
+/area/station/maintenance/port/central)
 "joP" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/order_console/mining,
@@ -25935,9 +25998,8 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "kjC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kjE" = (
@@ -26515,6 +26577,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ksO" = (
@@ -26775,6 +26838,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/cargo)
+"kxR" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kxY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 1
@@ -28454,6 +28524,13 @@
 	},
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"leo" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lep" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -28569,6 +28646,16 @@
 "lgw" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
+"lgA" = (
+/obj/machinery/camera/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Chemical Factory Port"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lgL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -28882,7 +28969,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/plating,
-/area/station/medical/chemistry)
+/area/station/maintenance/port/central)
 "lnK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/fake_snow/safe,
@@ -28967,6 +29054,10 @@
 "lps" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
+"lpv" = (
+/obj/structure/mirror/directional/north,
+/turf/open/floor/carpet,
+/area/station/maintenance/port/central)
 "lpy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/full,
@@ -30207,13 +30298,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"lLI" = (
-/obj/machinery/camera/directional/west{
-	network = list("ss13","medbay");
-	c_tag = "Medbay - Chemical Factory Port"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lLK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32053,10 +32137,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"mum" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "muJ" = (
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/button/door/directional/south{
@@ -32264,9 +32344,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
-"mzc" = (
-/turf/closed/wall,
-/area/station/medical/chemistry)
 "mzh" = (
 /obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/fakebasalt,
@@ -32576,6 +32653,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"mGA" = (
+/obj/machinery/power/floodlight,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/medical/chemistry)
 "mGK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34183,6 +34270,7 @@
 /area/station/security/prison/safe)
 "noi" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nol" = (
@@ -35235,6 +35323,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"nIu" = (
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nIC" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -37165,6 +37259,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"otT" = (
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/engineering/vending_restock,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "otU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -37977,10 +38076,6 @@
 	dir = 4
 	},
 /area/station/service/bar)
-"oIu" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "oIv" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
@@ -39275,6 +39370,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"pjp" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/station/maintenance/port/central)
 "pjw" = (
 /obj/machinery/button/door/directional/south{
 	id = "Dorm2";
@@ -39497,6 +39596,13 @@
 "pnf" = (
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"pni" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pnj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40010,6 +40116,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"pAe" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pAg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -40032,8 +40142,12 @@
 "pAr" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot_red,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -40154,6 +40268,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pDY" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pEb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40943,12 +41064,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"pUa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pUc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43691,6 +43806,14 @@
 "qUX" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
+"qUZ" = (
+/obj/item/toy/plush/ratplush,
+/obj/structure/closet/crate/necropolis{
+	desc = "Presumably placed here by top men.";
+	name = "\improper Ark of the Covenant"
+	},
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/central)
 "qVc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -46947,6 +47070,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"shx" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "shB" = (
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 1
@@ -47815,10 +47945,14 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "szZ" = (
-/obj/machinery/plumbing/sender,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/camera/directional/north{
+	network = list("ss13","network");
+	c_tag = "Medbay - Chemical Factory Central"
+	},
+/obj/machinery/plumbing/sender,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -48330,13 +48464,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/vaporwave,
 /area/station/science/lab)
-"sKt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sKC" = (
 /obj/structure/reagent_dispensers/watertank{
 	pixel_x = -1
@@ -48621,6 +48748,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"sQq" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "sQx" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "AI Minisat - Chamber Starboard"
@@ -50665,6 +50796,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"tEu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tEN" = (
 /obj/structure/bookcase/random/fiction,
 /obj/machinery/door/firedoor/border_only{
@@ -53511,10 +53647,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uQS" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "uQU" = (
 /obj/item/clothing/suit/costume/cardborg,
 /turf/open/misc/asteroid/airless,
@@ -56738,10 +56870,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"weE" = (
-/obj/structure/sign/warning/vacuum/external/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
 "weK" = (
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
@@ -57527,6 +57655,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
+"wqV" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wqY" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -57775,8 +57910,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "wwF" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "wwO" = (
@@ -60236,13 +60371,6 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"xtM" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Chemical Factory Starboard";
-	network = list("ss13","network")
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xtP" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -61322,6 +61450,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"xMO" = (
+/obj/effect/spawner/random/engineering/vending_restock,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "xNh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81794,13 +81926,13 @@ vtU
 vtU
 vtU
 vtU
-vtU
-vtU
-dMJ
-vtU
-vtU
-vtU
-vtU
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
 vtU
 vtU
 dMJ
@@ -82050,14 +82182,14 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-vtU
-cCZ
-cCZ
-cCZ
-cCZ
+pKF
+pKF
+wug
+exM
+vKR
+exM
+nhf
+pKF
 cCZ
 cCZ
 vtU
@@ -82303,19 +82435,19 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-vtU
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
+pKF
+pKF
+pKF
+pKF
+pKF
+wug
+ewM
+pKF
+pKF
+pKF
+gxB
+pKF
+pKF
 cCZ
 vtU
 cCZ
@@ -82560,19 +82692,19 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-vtU
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
+pKF
+hkA
+cvz
+pjp
+pKF
+gxB
+pKF
+pKF
+rkQ
+pKF
+agH
+nhf
+pKF
 cCZ
 aWF
 cCZ
@@ -82817,20 +82949,20 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
+pKF
+lpv
+fZq
+dcz
+pKF
+xis
+pKF
+ote
+fKy
 pKF
 pKF
+xis
 pKF
-pKF
-pKF
-pKF
-pKF
-cCZ
-cCZ
+hNy
 aWF
 cCZ
 cCZ
@@ -83074,23 +83206,23 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
 pKF
 pKF
-wug
-exM
-vKR
-exM
-nhf
+wqV
 pKF
-cCZ
-cCZ
-aWF
-cCZ
-cCZ
+pKF
+jly
+pKF
+dIN
+lcJ
+gmo
+pKF
+jly
+pKF
+pKF
+pKF
+hNy
+hNy
 cCZ
 hNy
 hNy
@@ -83331,23 +83463,23 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
 pKF
-wug
-ewM
+sQq
+cJU
+hgp
+dBC
+cJU
+cJU
+cgO
+gjU
+gjU
+gjU
+cJU
+cJU
+job
 pKF
-pKF
-pKF
-gxB
-pKF
-pKF
-cCZ
-vtU
-cCZ
-cCZ
+hNy
+hNy
 hNy
 hNy
 hNy
@@ -83588,23 +83720,23 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-cCZ
-hNy
-hNy
 pKF
-gxB
+cJU
+cJU
+cJU
+cJU
+cJU
+hgp
+cJU
+cJU
+dBC
+cJU
+cJU
+cJU
+cJU
 pKF
 pKF
-rkQ
 pKF
-agH
-nhf
-pKF
-cCZ
-vtU
-cCZ
-hNy
 hNy
 hNy
 hNy
@@ -83845,23 +83977,23 @@ cCZ
 cCZ
 cCZ
 rRv
-rRv
-rRv
-hNy
-hNy
 pKF
-xis
+cJU
+cJU
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+cJU
+cJU
+otT
 pKF
-ote
-fKy
-pKF
-pKF
-xis
-pKF
-hNy
-vtU
-hNy
-hNy
 hNy
 hNy
 hNy
@@ -84103,21 +84235,21 @@ lnl
 tSF
 tSF
 pKF
-pKF
-pKF
-pKF
-pKF
-jly
-pKF
-dIN
-lcJ
-gmo
-pKF
-jly
-pKF
-pKF
-pKF
-pKF
+fJe
+cJU
+bGW
+hle
+hle
+hle
+aKJ
+lgA
+kxR
+hle
+shx
+bGW
+cJU
+cJU
+xMO
 pKF
 pKF
 pKF
@@ -84360,23 +84492,23 @@ lRV
 ciy
 cJU
 cvI
-weE
+cJU
 hgp
+bGW
+mkZ
+mkZ
+mkZ
+mkZ
+mkZ
+mkZ
+mkZ
+pAe
+bGW
 cJU
 cJU
 cJU
 cJU
-cJU
-gjU
-gjU
-gjU
-cJU
-cJU
-cJU
-cJU
-cJU
-cJU
-cJU
+hgp
 cJU
 cJU
 vYf
@@ -84618,24 +84750,24 @@ tSF
 tSF
 pKF
 fJe
-cJU
+cgO
+bGW
+mGA
+vMK
+mkZ
+mkZ
+mkZ
+mkZ
+mkZ
+mkZ
 lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-pov
-pov
-pov
-pov
-pov
-pov
+bGW
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
 pov
 gfv
 sXc
@@ -84876,15 +85008,15 @@ rRv
 pKF
 cJU
 cJU
-lHf
+bGW
 tvp
+ckM
 mkZ
 mkZ
-mum
-lLI
 mkZ
 mkZ
-oIu
+qAP
+mkZ
 mjt
 lHf
 kdb
@@ -85133,15 +85265,15 @@ cCZ
 pKF
 hgp
 cJU
-lHf
+bGW
 htc
 kjC
-mkZ
-mkZ
-mkZ
-mkZ
-qAP
-mkZ
+rEj
+qbU
+qbU
+qbU
+ute
+ute
 jzX
 lHf
 qUd
@@ -85390,15 +85522,15 @@ cCZ
 pKF
 cJU
 cJU
-lHf
+bGW
 bwe
-qbU
-rEj
-qbU
-qbU
-qbU
-ute
-ute
+vMK
+tmx
+rAX
+rAX
+rAX
+urq
+tEu
 bUf
 lHf
 yjx
@@ -85647,14 +85779,14 @@ cCZ
 pKF
 cJU
 cJU
-lHf
+bGW
 xIL
+awT
 mkZ
-tmx
+dsa
+dsa
+aiq
 rAX
-rAX
-rAX
-urq
 gnE
 klk
 lHf
@@ -85904,13 +86036,13 @@ cCZ
 pKF
 hec
 hec
-lHf
+bGW
 ePs
-fRf
+vMK
 mkZ
 dsa
 dsa
-aiq
+dsa
 rAX
 ute
 esE
@@ -86163,8 +86295,8 @@ cJU
 lye
 lnJ
 kNf
-vMK
-vMK
+nIu
+pni
 uGY
 uGY
 uGY
@@ -86418,12 +86550,12 @@ pKF
 pKF
 cJU
 dMM
-lHf
+bGW
 szZ
 vMK
-gLN
+mkZ
 dsa
-dsa
+tWv
 dsa
 rAX
 ute
@@ -86675,12 +86807,12 @@ ieB
 wDW
 cJU
 dMM
-lHf
+bGW
 sLz
-vMK
+oHY
 mkZ
 dsa
-tWv
+dsa
 dsa
 rAX
 gnE
@@ -86932,15 +87064,15 @@ pKF
 pKF
 cJU
 dMM
-lHf
+bGW
 sYd
-oHY
-mkZ
+vMK
+gLN
 dsa
 dsa
 dsa
 rAX
-cJZ
+ute
 lHf
 xAb
 kHo
@@ -87189,15 +87321,15 @@ pKF
 pKF
 cJU
 dMM
-lHf
+bGW
 utg
-vMK
-gLN
+viy
+yjw
 dsa
 dsa
-dsa
+hqZ
 rAX
-pUa
+cJZ
 lHf
 vuX
 tbb
@@ -87446,14 +87578,14 @@ rRv
 pKF
 cJU
 dMM
-lHf
+bGW
 pAr
-viy
-yjw
-dsa
-dsa
-hqZ
+wzP
+tmx
 rAX
+rAX
+rAX
+rfe
 ute
 lHf
 meq
@@ -87703,14 +87835,14 @@ pKF
 pKF
 fld
 dMM
-lHf
+bGW
 nxZ
-wzP
-tmx
-rAX
-rAX
-rAX
-rfe
+vMK
+crU
+mkZ
+mkZ
+mkZ
+mkZ
 fiz
 lHf
 oaw
@@ -87960,10 +88092,10 @@ owW
 pKF
 cJU
 dMM
-lHf
+bGW
 mkZ
 qbU
-sKt
+qbU
 qbU
 qbU
 qbU
@@ -88217,7 +88349,7 @@ wPL
 jJc
 cJU
 dMM
-lHf
+bGW
 mkZ
 xmW
 mkZ
@@ -88474,12 +88606,12 @@ wiZ
 pKF
 cJU
 dMM
-lHf
+bGW
 mkZ
 mkZ
 mkZ
-uQS
-xtM
+mkZ
+mkZ
 mkZ
 mkZ
 mkZ
@@ -88731,15 +88863,15 @@ pKF
 pKF
 cJU
 dMM
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
-lHf
+bGW
+bWf
+bWf
+bWf
+pDY
+hWU
+leo
+bWf
+bWf
 lHf
 wdc
 xiW
@@ -88989,15 +89121,15 @@ cJU
 cJU
 dMM
 bGW
-cJU
-bJf
-sWs
-dIN
-aIQ
-tyi
-dIN
-gps
-mzc
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+bGW
+lHf
 biS
 xiW
 sLT
@@ -89247,13 +89379,13 @@ uHr
 aPN
 rNL
 cJU
-cJU
-tyi
-pkn
+dIN
+sWs
+bJf
 dIN
 aIQ
-bJf
-bJf
+tyi
+pkn
 vco
 vco
 vco
@@ -89506,12 +89638,12 @@ tbw
 cJU
 fmH
 aIQ
+dIN
+aIQ
+bJf
 bJf
 dIN
-bJf
-bJf
-bJf
-bJf
+qUZ
 ktR
 gHE
 wfp

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -6384,7 +6384,6 @@
 /area/station/service/janitor)
 "cwn" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "cwr" = (
@@ -14167,6 +14166,10 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
+"fuo" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "fuu" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/radshelter/civil)
@@ -170232,12 +170235,12 @@ tby
 uld
 eGA
 rUx
-eGA
-eGA
-eGA
+fuo
+fuo
+fuo
 cwn
-rUx
-rUx
+uEl
+uEl
 oay
 oay
 kfh

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -564,7 +564,7 @@
 /area/station/medical/storage)
 "aku" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/starboard/lesser)
 "akx" = (
@@ -3253,7 +3253,7 @@
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/spawner/random/food_or_drink/booze,
 /obj/effect/spawner/random/food_or_drink/booze,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/food_or_drink/booze,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "bkp" = (
@@ -3415,7 +3415,7 @@
 /area/station/service/kitchen/diner)
 "bnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "bny" = (
@@ -4090,7 +4090,7 @@
 /area/station/maintenance/radshelter/civil)
 "bCA" = (
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/food_or_drink/booze,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/greater)
 "bCE" = (
@@ -4586,6 +4586,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"bNN" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/misc/asteroid,
+/area/station/maintenance/central/greater)
 "bNO" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
@@ -5647,6 +5653,13 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ciw" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "cix" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -5686,6 +5699,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/obj/effect/spawner/random/engineering/tank,
 /turf/open/water/jungle/biodome,
 /area/station/maintenance/central/greater)
 "ciW" = (
@@ -6236,7 +6250,7 @@
 "cuz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/medical/surgery_tool,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "cuF" = (
@@ -6462,7 +6476,7 @@
 /area/station/maintenance/radshelter/civil)
 "cxJ" = (
 /obj/effect/spawner/random/structure/crate_empty,
-/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cxL" = (
@@ -8171,7 +8185,8 @@
 /area/station/hallway/primary/aft)
 "dfk" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/obj/effect/spawner/random/entertainment/coin,
 /turf/open/misc/asteroid/dug,
 /area/station/maintenance/starboard/lesser)
 "dfn" = (
@@ -9915,6 +9930,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"dOp" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "dOs" = (
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
@@ -10384,7 +10403,7 @@
 /area/station/hallway/primary/central/aft)
 "dVO" = (
 /obj/structure/closet/radiation,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
 "dWa" = (
@@ -10910,10 +10929,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/breakroom)
-"eji" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/greater)
 "ejv" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
@@ -11675,6 +11690,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"ezV" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/central)
 "eAh" = (
 /obj/structure/transit_tube/curved/flipped,
 /turf/open/openspace,
@@ -14807,6 +14828,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"fKL" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "fKO" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15245,7 +15272,6 @@
 /area/station/maintenance/starboard/lesser)
 "fRJ" = (
 /obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/station/construction)
@@ -15860,7 +15886,7 @@
 /area/station/hallway/secondary/entry)
 "gcN" = (
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/money,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "gcR" = (
@@ -16304,7 +16330,7 @@
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "gmo" = (
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/coin,
 /turf/open/misc/asteroid,
 /area/station/maintenance/port/central)
 "gmp" = (
@@ -18738,8 +18764,9 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "hlC" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
+/obj/structure/railing{
+	dir = 6
+	},
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
 "hlL" = (
@@ -19763,7 +19790,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "hJn" = (
 /obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/food_or_drink/condiment,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "hJs" = (
@@ -20934,7 +20961,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "ihI" = (
-/obj/effect/spawner/random/maintenance/eight,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "ihO" = (
@@ -23084,6 +23111,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/space/nearstation)
+"jcP" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "jcT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -23422,7 +23455,7 @@
 /area/station/command/heads_quarters/hop)
 "jjS" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "jjT" = (
@@ -23573,7 +23606,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jnF" = (
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/entertainment/cigarette,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "jnI" = (
@@ -31854,11 +31887,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"mqD" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood/parquet,
-/area/station/cargo/storage)
 "mqM" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /obj/machinery/door/airlock{
@@ -33553,7 +33581,7 @@
 /area/station/command/bridge)
 "nct" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/bureaucracy,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ncx" = (
@@ -35526,12 +35554,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"nPv" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate_empty,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "nPx" = (
 /turf/closed/wall/mineral/wood,
 /area/station/hallway/primary/aft)
@@ -35594,6 +35616,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"nQr" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "nQu" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "prisondorm";
@@ -36904,6 +36930,7 @@
 /area/station/asteroid)
 "opt" = (
 /obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/spawner/random/entertainment/money,
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/department/crew_quarters/dorms)
 "opv" = (
@@ -39326,6 +39353,15 @@
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"plz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "plF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39770,7 +39806,7 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "pwg" = (
-/obj/effect/spawner/random/maintenance/four,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/fore/greater)
 "pwC" = (
@@ -39876,7 +39912,7 @@
 /area/station/commons/storage/primary)
 "pze" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "pzj" = (
@@ -40897,8 +40933,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "pUs" = (
-/obj/effect/spawner/random/maintenance/eight,
 /obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "pUx" = (
@@ -41208,7 +41244,7 @@
 /area/station/science/research)
 "qbT" = (
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qbU" = (
@@ -42095,8 +42131,7 @@
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "qrH" = (
-/obj/item/stack/sheet/cardboard,
-/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "qrV" = (
@@ -43967,6 +44002,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"rba" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "rbc" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -46703,6 +46744,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
+"sej" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sel" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46861,9 +46906,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "shZ" = (
-/obj/item/poster/random_contraband,
 /obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/maintenance,
+/obj/item/poster/random_contraband,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "sid" = (
@@ -48227,6 +48272,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"sKC" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "sKE" = (
 /obj/machinery/computer/records/security,
 /obj/machinery/requests_console/directional/north{
@@ -49680,7 +49731,9 @@
 /area/station/maintenance/port/greater)
 "tmw" = (
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/four,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/effect/spawner/random/entertainment/toy,
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/department/crew_quarters/dorms)
 "tmx" = (
@@ -49791,10 +49844,6 @@
 	},
 /turf/open/openspace,
 /area/station/biodome)
-"tpf" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/misc/dirt/jungle/wasteland,
-/area/station/maintenance/central/greater)
 "tpC" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron,
@@ -50048,7 +50097,7 @@
 /area/station/service/theater)
 "tuZ" = (
 /obj/structure/closet,
-/obj/effect/spawner/random/maintenance/four,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
 "tva" = (
@@ -50250,10 +50299,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
-"tyL" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
 "tyM" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/food_or_drink,
@@ -51459,10 +51504,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"tXQ" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
 "tYa" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
@@ -52060,6 +52101,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"unQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "uoa" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
@@ -52737,10 +52782,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
-"uCL" = (
-/obj/effect/spawner/random/maintenance/eight,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
 "uCM" = (
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
@@ -53233,6 +53274,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/water/jungle/biodome,
 /area/station/maintenance/central/greater)
+"uNX" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "uOb" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -55836,9 +55883,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "vOO" = (
-/obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/maintenance,
+/obj/item/poster/random_official,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vOV" = (
@@ -55901,6 +55948,10 @@
 	dir = 4
 	},
 /area/station/commons/lounge)
+"vQn" = (
+/obj/effect/spawner/random/clothing/wardrobe_closet_colored,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/cargo)
 "vQp" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/filingcabinet,
@@ -56002,6 +56053,11 @@
 /obj/structure/railing,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"vSK" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "vSP" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet6";
@@ -58455,6 +58511,10 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"wLL" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wLQ" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -58750,8 +58810,8 @@
 /area/station/command/heads_quarters/cmo)
 "wRn" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/four,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/station/construction)
 "wRo" = (
@@ -59943,10 +60003,6 @@
 /obj/item/toy/plush/space_lizard_plushie,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"xqe" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
 "xqB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60683,7 +60739,7 @@
 /area/station/engineering/supermatter/room)
 "xFw" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/seven,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/construction)
 "xFy" = (
@@ -61327,10 +61383,6 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"xQB" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/starboard/central)
 "xQD" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -61669,6 +61721,7 @@
 /area/station/medical/virology)
 "xWj" = (
 /obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
 "xWn" = (
@@ -61947,10 +62000,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ycn" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/starboard/central)
 "ycq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -75721,7 +75770,7 @@ rRv
 cCZ
 cCZ
 pKF
-uCL
+aoY
 jDW
 tUp
 pKF
@@ -79061,7 +79110,7 @@ hNy
 hNy
 hNy
 pKF
-cJU
+wLL
 qjl
 kHz
 pKF
@@ -85498,7 +85547,7 @@ cCZ
 cCZ
 cCZ
 pKF
-xqe
+cJU
 cJU
 lHf
 xIL
@@ -85744,7 +85793,7 @@ pKF
 cJU
 cJU
 dBC
-cJU
+jcP
 jDW
 pKF
 hNy
@@ -86306,7 +86355,7 @@ hNy
 fTB
 fTB
 fTB
-tyL
+fTB
 gCQ
 xrY
 hNy
@@ -86550,7 +86599,7 @@ oAe
 oAe
 oAe
 oFB
-gRN
+sKC
 wJI
 cAe
 oAe
@@ -87786,7 +87835,7 @@ hNy
 pKF
 pKF
 cJU
-gxB
+plz
 pKF
 pKF
 pKF
@@ -92237,7 +92286,7 @@ bqj
 bqj
 xwg
 wnY
-fTB
+bNN
 cSi
 hNy
 hNy
@@ -93216,7 +93265,7 @@ asD
 asD
 asD
 cKp
-yhu
+ota
 ota
 cKp
 sAB
@@ -93689,7 +93738,7 @@ dYQ
 hZC
 sBz
 tMJ
-dYQ
+rba
 mDo
 dYQ
 dYQ
@@ -94180,7 +94229,7 @@ vpU
 hiv
 jlt
 dYQ
-dYQ
+rba
 jlt
 czJ
 czJ
@@ -98831,7 +98880,7 @@ dYQ
 uiF
 dYQ
 sBz
-ydf
+ciw
 dYQ
 dZv
 sBz
@@ -99089,7 +99138,7 @@ mlR
 rRt
 sBz
 vLz
-eji
+dYQ
 dZv
 sBz
 gzJ
@@ -100692,7 +100741,7 @@ oAe
 gRN
 oAe
 hJn
-vpF
+vSK
 hJn
 vpF
 oAe
@@ -102243,7 +102292,7 @@ qXx
 rGK
 wSk
 vGd
-tpf
+rrp
 ead
 bSh
 hNy
@@ -105278,7 +105327,7 @@ feK
 bRU
 nUv
 gKU
-tXQ
+uZp
 oyW
 nQH
 hml
@@ -106028,7 +106077,7 @@ dDE
 hNy
 hNy
 hNy
-oCL
+ezV
 ykP
 wfX
 hzh
@@ -106563,7 +106612,7 @@ hSH
 hNy
 tzy
 tzy
-ycn
+plH
 hNy
 oyW
 oyW
@@ -107078,7 +107127,7 @@ tzy
 tzy
 tzy
 tzy
-xQB
+tzy
 hNy
 hNy
 hNy
@@ -109636,7 +109685,7 @@ cCZ
 cCZ
 hNy
 dAF
-nPv
+mlo
 iwy
 kcb
 lPy
@@ -144586,7 +144635,7 @@ ngE
 mWR
 nRT
 dDW
-tzH
+uNX
 fXt
 kRv
 oxi
@@ -148211,7 +148260,7 @@ szh
 ikk
 eRz
 aJI
-pSH
+sej
 nKV
 jOb
 aEh
@@ -149265,7 +149314,7 @@ jHc
 jHc
 jHc
 gDE
-rpq
+sej
 ikk
 hHc
 wQN
@@ -151545,8 +151594,8 @@ oJi
 hDO
 hDO
 ikk
-dvI
-pSH
+sej
+nQr
 qyt
 nRf
 aKV
@@ -159030,7 +159079,7 @@ fJC
 fJC
 fJC
 vxC
-uIF
+dOp
 fJC
 fJC
 fJC
@@ -169820,8 +169869,8 @@ neH
 uVy
 nIC
 cEV
+fKL
 gww
-uEl
 uEl
 uEl
 kSo
@@ -171310,7 +171359,7 @@ dlY
 sGo
 sBt
 wfX
-aBm
+vQn
 iHx
 eyB
 iHx
@@ -174674,7 +174723,7 @@ jGu
 tlL
 jZy
 aoJ
-mqD
+jGu
 ecr
 ecr
 cMq
@@ -175184,7 +175233,7 @@ xvk
 kyG
 jQL
 cMq
-mqD
+jGu
 tlL
 jZy
 aoJ
@@ -176228,7 +176277,7 @@ bkm
 uHX
 rnO
 avN
-avN
+unQ
 dET
 lzy
 eZB


### PR DESCRIPTION
- Rebalanced the maintenance loot spawners: their numbers have decreased, and in some cases, they have been replaced by different items or spawners
- Increased the number of guaranteed watertanks and fueltanks in maintenance
- Removed a stray rail and decal from security
- Some wires have been adjusted, to make certain departments harder, or easier to sabotage
- Chemistry factory is now bigger
- One new tiny maint room
- External airlocks by the garden has space dir set, meaning you can open it without access
- Added a ladder so people can visit the plasmaman startup
- The freezer and the bar backroom ladders are safer now
- Makes the diner canopy more reachable by all of service, turns two falsewalls into a single windoor

Power seems to be well connected, yell at me if anything is off