### PR TITLE
Nerfs bullet damage on the Syndicate Revolver

### DIFF
--- a/orbstation/code/objects/items/weapons/ammunition.dm
+++ b/orbstation/code/objects/items/weapons/ammunition.dm
@@ -22,3 +22,6 @@
 	icon_state = "brassa357"
 	caliber = CALIBER_357
 	projectile_type = null
+
+/obj/projectile/bullet/a357
+    damage = 45


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the bullet damage on .357 rounds to 45 brute from 60 brute. This means:
3 shots to crit on unarmored/lightly armored targets (previously 2 shots)
4 shots to crit on heavily armored targets (previously 3 shots)
## Why It's Good For The Game

The syndicate revolver is too strong. Making the ammo craftable instead of just printable is barely a nerf, at least not an effective one. Most players did not know you could print rounds. Making rounds harder to make is a knowledge check that was barely interacted with to begin with, and large amounts of ammo was not the issue the revolver has. 

Changing the damage to 45 makes all kills take 1 more bullet on average. This change makes the ttk slightly longer, but allows the revolver to stay easy to use, forgiving, and an overall good option for new players at it's tc cost while making it slightly less strong at just murdering you without any counter play. This makes it a lot harder for you to be instantly deleted by a revolver, but does not make the ttk too long (it's still faster and easier to kill with than a markov) 

Fighting a player with a revolver can be very frustrating, especially if you're unarmored. It feels very at odds with the way we expect combat to go on our server and the way we play the game to have a gun that can near instantly delete someone from existence. This change makes playing against the revolver slightly more forgiving, allowing players a extra second or two to react to the revolver. 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
nerf: Changes .357 damage from 60 to 45
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
