### PR TITLE
Ebow can only be fired 6 times before needing rewinding

### DIFF
--- a/orbstation/code/antagonists/traitor/items/ebow.dm
+++ b/orbstation/code/antagonists/traitor/items/ebow.dm
@@ -1,0 +1,47 @@
+#define MAX_EBOW_CHARGE 6
+
+/datum/uplink_item/stealthy_weapons/crossbow
+	desc = "A short bow mounted across a tiller in miniature. \
+	Small enough to fit into a pocket or slip into a bag unnoticed. \
+	It will synthesize and fire bolts tipped with a debilitating \
+	toxin that will damage and disorient targets, causing them to \
+	slur as if inebriated. It can produce an infinite number \
+	of bolts, but takes time to automatically recharge after each shot. \
+	Additionally, its internal battery must be manually rewound after six shots."
+
+/obj/item/gun/energy/recharge/ebow
+	desc = "A weapon favored by syndicate stealth specialists. It generates its own ammo, but its internal battery must be rewound after a few shots."
+	/// How many shots can you fire before needing to pump it?
+	var/charges = MAX_EBOW_CHARGE
+
+/obj/item/gun/energy/recharge/ebow/examine(mob/user)
+	. = ..()
+	. += span_notice("It can be fired [charges] more times before it needs to be rewound.")
+
+/obj/item/gun/energy/recharge/ebow/can_shoot()
+	. = ..()
+	if (!.)
+		return FALSE
+	return charges > 0
+
+/obj/item/gun/energy/recharge/ebow/shoot_with_empty_chamber(mob/living/user)
+	if (charges > 0)
+		return ..()
+	balloon_alert(user, "needs winding!")
+	playsound(src, dry_fire_sound, 30, TRUE)
+
+/obj/item/gun/energy/recharge/ebow/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
+	. = ..()
+	charges--
+
+/obj/item/gun/energy/recharge/ebow/attack_self(mob/living/user)
+	. = ..()
+	if (charges == MAX_EBOW_CHARGE)
+		return
+	balloon_alert(user, "rewinding...")
+	if(!do_after(user, 6 SECONDS, target = src, interaction_key = REF(src)))
+		return
+	balloon_alert(user, "recharged!")
+	charges = MAX_EBOW_CHARGE
+
+#undef MAX_EBOW_CHARGE

--- a/orbstation/code/antagonists/traitor/items/ebow.dm
+++ b/orbstation/code/antagonists/traitor/items/ebow.dm
@@ -6,8 +6,8 @@
 	It will synthesize and fire bolts tipped with a debilitating \
 	toxin that will damage and disorient targets, causing them to \
 	slur as if inebriated. It can produce an infinite number \
-	of bolts, but takes time to automatically recharge after each shot. \
-	Additionally, its internal battery must be manually rewound after six shots."
+	of bolts, but can only be fired once every two seconds. \
+	After firing six shots, its mechanism must be manually rewound."
 
 /obj/item/gun/energy/recharge/ebow
 	desc = "A weapon favored by syndicate stealth specialists. It generates its own ammo, but its internal battery must be rewound after a few shots."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5305,6 +5305,7 @@
 #include "orbstation\code\antagonists\traitor\items\booze_grenade.dm"
 #include "orbstation\code\antagonists\traitor\items\cheese_implant.dm"
 #include "orbstation\code\antagonists\traitor\items\cursed_tome.dm"
+#include "orbstation\code\antagonists\traitor\items\ebow.dm"
 #include "orbstation\code\antagonists\traitor\items\integrated_chainsaw.dm"
 #include "orbstation\code\antagonists\traitor\items\letter_opener.dm"
 #include "orbstation\code\antagonists\traitor\items\rebalancing.dm"


### PR DESCRIPTION
## About The Pull Request

See title.
After firing the ebow six times you will need to use it in your hands while motionless in order to resume firing it.
This process is silent but takes six seconds, which makes it implausible to perform during a fight.

## Why It's Good For The Game

This allows the ebow to maintain its niche as a powerful guerilla initiation or escape tool without it being a permanent disable (and kill) on multiple targets.
6 shots with 15 toxin damage won't kill an undamaged target (and definitely not two), so you'll need to augment it with something else in order to kill someone.

## Changelog

:cl:
balance: The ebow can only be fired six times consecutively before it needs to be manually re-wound in your hands to recharge it.
/:cl:
