### PR TITLE
Fixes numbering of previous objectives on endscreen.

### DIFF
--- a/orbstation/code/antagonists/traitor/contract_negotiation.dm
+++ b/orbstation/code/antagonists/traitor/contract_negotiation.dm
@@ -93,8 +93,8 @@
 
 	var/objectives_text = "<br> The original objectives were:"
 
+	var/count = 1
 	for(var/explanation in old_objectives)
-		var/count = 1
 		objectives_text += "<br><B>Objective #[count]</B>: [explanation]"
 		count++
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When taking a contract renegotiation, your original primary objectives are listed on the end screen. However, due to a bug, these are all listed as "Objective 1". They are now numbered properly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Counting is good.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: made previous objectives on endscreen numbered properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
