### PR TITLE
BBs Get A Garunteed Assassination Objective After The Steal Reward

### DIFF
--- a/orbstation/code/antagonists/blood_brothers.dm
+++ b/orbstation/code/antagonists/blood_brothers.dm
@@ -130,6 +130,7 @@
 		to_chat(brother.current, span_notice("Your implant fizzles away! Objective Complete."))
 	if(CONFIG_GET(flag/log_traitor))
 		WRITE_LOG(GLOB.world_game_log, "BLOOD BROTHER: [name] delivered a [steal_objective.steal_target] at [worldtime2text()].")
+	add_objective(new /datum/objective/assassinate, needs_target = TRUE) //gives bbs new assassination objective
 
 /// generates a light steal objective if there are no objectives and then from then on generates murder or heist objectives
 /datum/team/brother_team/forge_single_objective()

--- a/orbstation/code/antagonists/blood_brothers.dm
+++ b/orbstation/code/antagonists/blood_brothers.dm
@@ -122,15 +122,23 @@
 	var/datum/objective/steal/brothers/steal_objective = locate() in objectives
 	if(steal_objective)
 		steal_objective.completed = TRUE
+
+	var/datum/objective/assassinate/newkill = new()
+	newkill.team = src
+	newkill.find_target()
+	newkill.update_explanation_text()
+	objectives += newkill
+
 	for(var/datum/mind/brother in members)
 		var/obj/item/implant/holo_pad_projector/possible_implant = locate() in brother.current.implants
 		if(!possible_implant)
 			continue
 		qdel(possible_implant)
-		to_chat(brother.current, span_notice("Your implant fizzles away! Objective Complete."))
+		to_chat(brother.current, span_notice("Your implant fizzles away! The Syndicate has given you a new objective."))
+		var/datum/antagonist/brother/bb_datum = brother.has_antag_datum(/datum/antagonist/brother)
+		bb_datum.objectives += newkill
 	if(CONFIG_GET(flag/log_traitor))
 		WRITE_LOG(GLOB.world_game_log, "BLOOD BROTHER: [name] delivered a [steal_objective.steal_target] at [worldtime2text()].")
-	add_objective(new /datum/objective/assassinate, needs_target = TRUE) //gives bbs new assassination objective
 
 /// generates a light steal objective if there are no objectives and then from then on generates murder or heist objectives
 /datum/team/brother_team/forge_single_objective()


### PR DESCRIPTION
## About The Pull Request

changes the bounty complete proc to do some evil vile shit that i dont like to add ONE new assassination objective to both blood brothers and their team datum if they choose to trade their stolen item for funny gear

## Why It's Good For The Game

ensures that the BBs will always have to kill someone given that there can be random combinations of steal and heist bros that lead to the BB's completing their two objectives too quickly

i will also add BB fluff objectives but this process made me not fucking want to do that now

## Changelog

:cl:
balance: the syndicate is impressed by the heisting blood brothers and now will request a new assassination after rewarding them with evil treats
/:cl:
