### PR TITLE
Traitor Announcement Item

### DIFF
--- a/orbstation/code/antagonists/traitor/items/announcement.dm
+++ b/orbstation/code/antagonists/traitor/items/announcement.dm
@@ -11,9 +11,19 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/badass/announcement/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
+	var/anonymize_name = tgui_alert(user, "Would you like this message to be anonymous?", "Conceal Identity", list("Yes", "No"))
+	var/should_anonymize = anonymize_name != "No"
 	var/announcement_text = tgui_input_text(user, "Insert message to be sent to the announcement system:", "Evil Message", "PREPARE FOR YOUR DOOM!", TRAITOR_ANNOUNCE_MAX_LEN)
 	if(!announcement_text) // such as if the user hits "cancel"
 		return source
-	priority_announce(text = announcement_text, title = null, sound = 'sound/misc/announce.ogg', type = "Syndicate Captain", has_important_message = TRUE)
-
+	if(should_anonymize)
+		priority_announce(text = announcement_text, title = null, sound = 'sound/misc/announce.ogg', type = "Syndicate Captain", has_important_message = TRUE)
+	else
+		var/displayed_name = user.name
+		var/mob/living/carbon/human/human_user = user
+		if(istype(human_user))
+			displayed_name = human_user.get_id_name(if_no_id = displayed_name)
+		priority_announce(text = announcement_text, title = null, sound = 'sound/misc/announce.ogg', type = null, sender_override = "[displayed_name] Announces", has_important_message = TRUE)
+	log_traitor("[key_name(user)] sent a priority message via uplink containing the message: [announcement_text]")
+	message_admins("[key_name(user)] sent a priority message via uplink.")
 	return source //For log icon

--- a/orbstation/code/antagonists/traitor/items/announcement.dm
+++ b/orbstation/code/antagonists/traitor/items/announcement.dm
@@ -1,0 +1,13 @@
+/datum/uplink_item/badass/announcement
+	name = "Intercept Announcement System"
+	desc = "When purchased, you will be able to send one message on the stations announcement system. The syndicate can only perform this hack once per agent."
+	item = /obj/effect/gibspawner/generic
+	surplus = 0
+	limited_stock = 1
+	cost = 0
+	restricted = TRUE
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+
+/datum/uplink_item/badass/announcement/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
+
+	return source //For log icon

--- a/orbstation/code/antagonists/traitor/items/announcement.dm
+++ b/orbstation/code/antagonists/traitor/items/announcement.dm
@@ -9,12 +9,14 @@
 	cost = 0
 	restricted = TRUE
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchase_log_vis = FALSE
 
 /datum/uplink_item/badass/announcement/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/anonymize_name = tgui_alert(user, "Would you like this message to be anonymous?", "Conceal Identity", list("Yes", "No"))
 	var/should_anonymize = anonymize_name != "No"
 	var/announcement_text = tgui_input_text(user, "Insert message to be sent to the announcement system:", "Evil Message", "PREPARE FOR YOUR DOOM!", TRAITOR_ANNOUNCE_MAX_LEN)
 	if(!announcement_text) // such as if the user hits "cancel"
+		uplink_handler.item_stock[stock_key] += 1
 		return source
 	if(should_anonymize)
 		priority_announce(text = announcement_text, title = null, sound = 'sound/misc/announce.ogg', type = "Syndicate Captain", has_important_message = TRUE)

--- a/orbstation/code/antagonists/traitor/items/announcement.dm
+++ b/orbstation/code/antagonists/traitor/items/announcement.dm
@@ -1,3 +1,5 @@
+#define TRAITOR_ANNOUNCE_MAX_LEN 500
+
 /datum/uplink_item/badass/announcement
 	name = "Intercept Announcement System"
 	desc = "When purchased, you will be able to send one message on the stations announcement system. The syndicate can only perform this hack once per agent."
@@ -9,5 +11,9 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/badass/announcement/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
+	var/announcement_text = tgui_input_text(user, "Insert message to be sent to the announcement system:", "Evil Message", "PREPARE FOR YOUR DOOM!", TRAITOR_ANNOUNCE_MAX_LEN)
+	if(!announcement_text) // such as if the user hits "cancel"
+		return source
+	priority_announce(text = announcement_text, title = null, sound = 'sound/misc/announce.ogg', type = "Syndicate Captain", has_important_message = TRUE)
 
 	return source //For log icon

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5338,6 +5338,7 @@
 #include "orbstation\code\antagonists\spider\egg_limit.dm"
 #include "orbstation\code\antagonists\traitor\contract_negotiation.dm"
 #include "orbstation\code\antagonists\traitor\items\advanced_beer_goggles.dm"
+#include "orbstation\code\antagonists\traitor\items\announcement.dm"
 #include "orbstation\code\antagonists\traitor\items\booze_grenade.dm"
 #include "orbstation\code\antagonists\traitor\items\cheese_implant.dm"
 #include "orbstation\code\antagonists\traitor\items\cursed_tome.dm"


### PR DESCRIPTION
## About The Pull Request
this has come up a few times and its a good idea so here it is

![dreamseeker_eL3wjyKOMZ](https://github.com/lizardqueenlexi/orbstation/assets/116288367/d2089f09-8959-4319-a7a3-5f944793edff)

so what we've got is
![VC4rFyr9Cj](https://github.com/lizardqueenlexi/orbstation/assets/116288367/3b308528-8bf7-46f5-9fa9-fd556d8b5ff7)
an item in the badass section that first
![sDvrnk3fD6](https://github.com/lizardqueenlexi/orbstation/assets/116288367/36f9d8ed-e12c-4a2a-b274-28bccf5f67aa)
asks if you want to be anonymous or not
![EnNw0ALNoh](https://github.com/lizardqueenlexi/orbstation/assets/116288367/cf921df6-78e7-432c-89b8-db08af56517a)
and then asks you to put in a message, you only get one! but its free! so dont mess it up!!!

## Why It's Good For The Game

being able to do a priority announcement for free encourages being fun when going loud and also allows for funny other possibilities

the limited nature but being free means that theres a lot of freedom in its usage but it also means that you cant be really annoying with it, if you want to send a lot of priority announcements buy an emag

## Changelog

:cl:
add: the syndicate can temporarily intercept station announcements
/:cl:
