### PR TITLE
Silences the coroner's heirloom clock

### DIFF
--- a/orbstation/code/jobs/medical/coroner.dm
+++ b/orbstation/code/jobs/medical/coroner.dm
@@ -1,0 +1,14 @@
+/datum/job/coroner
+	family_heirlooms = list(/obj/item/clothing/head/helmet/skull, /obj/item/table_clock/heirloom)
+
+/// A silent, permanently broken table clock for the coroner's heirloom
+/obj/item/table_clock/heirloom
+	desc = "While this clock was broken beyond repair for its annoying ticking, it still holds some sentimental value."
+	times_broken = 3 //unrepairable
+
+/// Immediately break the table clock on load
+/obj/item/table_clock/heirloom/Initialize(mapload)
+	. = ..()
+	broken = TRUE
+	soundloop.stop()
+	update_appearance(UPDATE_ICON)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5431,6 +5431,7 @@
 #include "orbstation\code\jobs\genetics\ratfolk_infusion.dm"
 #include "orbstation\code\jobs\hydroponics\exploding_bananas.dm"
 #include "orbstation\code\jobs\medical\brain_trauma.dm"
+#include "orbstation\code\jobs\medical\coroner.dm"
 #include "orbstation\code\jobs\medical\organ_decay.dm"
 #include "orbstation\code\jobs\medical\surgery\height_manipulation.dm"
 #include "orbstation\code\jobs\medical\surgery\lobotomy.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The table clock the coroner can get as an heirloom is now a special "heirloom" variant, which starts broken and cannot be repaired.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's bad to be compelled to carry around something that makes an annoying sound for the entire round. You can technically just break it, but it feels weirdly dissonant to compel you to smash your treasured heirloom. So, instead, your grandpa broke it long ago or something.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: the Coroner's heirloom clock has been silenced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
