### PR TITLE
Biodome beach fixes

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2799,7 +2799,7 @@
 /area/station/science/server)
 "baf" = (
 /obj/machinery/light_switch/directional/east,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 4
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -7588,9 +7588,6 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/station/science/research)
 "cQY" = (
@@ -7802,7 +7799,7 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "cVX" = (
-/turf/open/misc/beach/sand,
+/turf/open/misc/beach/coast,
 /area/station/ai_monitored/command/nuke_storage)
 "cVY" = (
 /obj/structure/sign/departments/maint/directional/east,
@@ -9890,7 +9887,7 @@
 /area/station/medical/medbay/central)
 "dMg" = (
 /obj/structure/closet/crate/silvercrate,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -11949,9 +11946,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Research - Xenobiology Pals  Pen";
 	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
@@ -16697,7 +16691,7 @@
 /area/station/cargo/drone_bay)
 "gsy" = (
 /obj/machinery/light/directional/west,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 8
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -18426,7 +18420,7 @@
 	c_tag = "Vault";
 	network = list("vault")
 	},
-/turf/open/misc/beach/sand,
+/turf/open/misc/beach/coast,
 /area/station/ai_monitored/command/nuke_storage)
 "hcV" = (
 /obj/item/emptysandbag,
@@ -19451,7 +19445,7 @@
 	dir = 10
 	},
 /obj/item/banner/cargo/mundane,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/station/cargo/storage)
@@ -21131,7 +21125,7 @@
 	dir = 6
 	},
 /obj/item/banner/cargo/mundane,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/station/cargo/storage)
@@ -28083,9 +28077,6 @@
 /area/station/medical/pharmacy)
 "kSY" = (
 /obj/structure/flora/bush/stalky/style_random,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/station/science/research)
 "kTc" = (
@@ -28251,7 +28242,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/station/cargo/storage)
@@ -28377,7 +28368,7 @@
 "kZn" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 6
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -38036,7 +38027,7 @@
 /area/station/science/ordnance/freezerchamber)
 "oGk" = (
 /obj/structure/closet/crate/goldcrate,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -40910,9 +40901,6 @@
 /obj/structure/flora/bush/stalky/style_random,
 /obj/item/toy/beach_ball/baseball,
 /obj/structure/sign/departments/xenobio/alt/directional/north,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/station/science/research)
 "pPf" = (
@@ -42436,7 +42424,7 @@
 /area/station/service/library)
 "qtp" = (
 /obj/machinery/computer/bank_machine,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 5
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -43057,7 +43045,7 @@
 /obj/item/clothing/head/costume/bearpelt,
 /obj/item/ammo_box/a357,
 /obj/item/gun/ballistic/revolver/russian,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 10
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -43980,7 +43968,7 @@
 /area/station/engineering/transit_tube)
 "qWt" = (
 /obj/machinery/ore_silo,
-/turf/open/misc/beach/sand{
+/turf/open/misc/beach/coast{
 	dir = 9
 	},
 /area/station/ai_monitored/command/nuke_storage)
@@ -50093,9 +50081,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/basic/pet/dog/corgi/puppy/slime,
 /obj/structure/sign/departments/xenobio/directional/north,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/station/science/research)
 "toN" = (

--- a/_maps/shuttles/arrival_biodome.dmm
+++ b/_maps/shuttles/arrival_biodome.dmm
@@ -128,7 +128,7 @@
 /area/shuttle/arrival)
 "p" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "q" = (
 /turf/template_noop,
@@ -163,7 +163,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "y" = (
 /obj/structure/chair/comfy/shuttle{
@@ -207,7 +207,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "F" = (
 /obj/effect/turf_decal/siding/wood{
@@ -240,7 +240,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "J" = (
 /obj/machinery/door/airlock/titanium{
@@ -260,7 +260,7 @@
 "M" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/toy/beach_ball,
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "N" = (
 /obj/structure/closet/emcloset,
@@ -280,7 +280,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 "R" = (
 /obj/structure/table,
@@ -338,7 +338,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/misc/beach/coast,
+/turf/open/water/beach,
 /area/shuttle/arrival)
 
 (1,1,1) = {"


### PR DESCRIPTION
Recently, the beach and ocean sprites have been update upstream, and the beach turfs have been also updated. This PR fixes some issues where the biodome cargo, arrivals shuttle and vault have been using incorrect dirs.