### PR TITLE
Made contract killer non-repeatable.

### DIFF
--- a/orbstation/code/antagonists/rulesets_latejoin.dm
+++ b/orbstation/code/antagonists/rulesets_latejoin.dm
@@ -25,4 +25,4 @@
 	required_candidates = 1
 	weight = 6
 	cost = 3
-	repeatable = TRUE
+	repeatable = FALSE

--- a/orbstation/code/antagonists/rulesets_midround.dm
+++ b/orbstation/code/antagonists/rulesets_midround.dm
@@ -240,9 +240,9 @@
 	)
 	required_enemies = list(1,1,1,0,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 4 //weight and cost are duplicated from Obsessed
+	weight = 4
 	cost = 3
-	repeatable = TRUE
+	repeatable = FALSE
 
 /datum/dynamic_ruleset/midround/from_living/contract_killer/trim_candidates()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Limits each of the two contract killer rulesets to only rolling once per round, functionally limiting contract killers to two max.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was an oversight more than anything. Due to its extremely lax requirements for rolling, contract killer is often the only eligible ruleset, which has apparently led to rounds with _five_ of them. They're supposed to add spice to the round, not overwhelm it. A maximum of two feels fair for now, and one of those will only happen on a latejoin.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: took out fewer contracts on the crew's heads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
