### PR TITLE
Status displays show reboot countdown.

### DIFF
--- a/_maps/orbstation/automapper/templates/centcom/centcom_emergency_wing.dmm
+++ b/_maps/orbstation/automapper/templates/centcom/centcom_emergency_wing.dmm
@@ -185,6 +185,7 @@
 	},
 /obj/structure/table,
 /obj/structure/bedsheetbin,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/central_command_areas/evacuation)
 "dq" = (
@@ -407,6 +408,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/smooth,
 /area/centcom/central_command_areas/evacuation)
 "hI" = (
@@ -415,6 +417,10 @@
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/evacuation)
+"hK" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/carpet/neon/simple/purple,
 /area/centcom/central_command_areas/evacuation)
 "hN" = (
 /obj/machinery/vending/boozeomat,
@@ -444,6 +450,13 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 1
 	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"il" = (
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 2
+	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "iD" = (
@@ -501,6 +514,7 @@
 "kx" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "kB" = (
@@ -512,6 +526,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/dark_red/full,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "kF" = (
@@ -762,6 +777,10 @@
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
+"pk" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/carpet/neon/simple/orange,
+/area/centcom/central_command_areas/evacuation)
 "pp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -849,6 +868,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/full,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/evacuation)
 "qp" = (
@@ -931,6 +951,15 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"tf" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/evacuation)
 "tg" = (
 /obj/structure/dresser,
@@ -1046,6 +1075,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "vx" = (
@@ -1103,6 +1133,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "wX" = (
@@ -1295,6 +1326,10 @@
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/evacuation)
+"Az" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/carpet/neon/simple/teal,
+/area/centcom/central_command_areas/evacuation)
 "AG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -1306,6 +1341,12 @@
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"AH" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/urinal/directional/north,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "AQ" = (
 /obj/structure/window/spawner/directional/south,
@@ -1581,6 +1622,15 @@
 /obj/structure/sign/warning/secure_area,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/prison/cells)
+"Fk" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/evacuation)
 "Fv" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
@@ -1598,6 +1648,7 @@
 "FN" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark_red/full,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "FO" = (
@@ -1701,6 +1752,7 @@
 	pixel_y = 7
 	},
 /obj/effect/turf_decal/tile/dark_red/full,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "HF" = (
@@ -1799,6 +1851,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "Jr" = (
@@ -1891,6 +1944,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/full,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/evacuation)
 "La" = (
@@ -1931,6 +1985,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "LD" = (
@@ -1979,6 +2034,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"Mm" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "Mo" = (
 /obj/structure/bed/double{
 	dir = 1
@@ -2012,6 +2072,7 @@
 "MQ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "MS" = (
@@ -2065,6 +2126,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
+"Nn" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/carpet/neon/simple/green,
+/area/centcom/central_command_areas/evacuation)
 "Np" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/reinforced,
@@ -2095,6 +2160,13 @@
 	},
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
 /turf/open/floor/iron/smooth,
+/area/centcom/central_command_areas/evacuation)
+"NW" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "NX" = (
 /obj/structure/toilet{
@@ -2138,6 +2210,13 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
+"OA" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "OB" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/dark_blue/full,
@@ -2145,6 +2224,10 @@
 /area/centcom/central_command_areas/evacuation)
 "OL" = (
 /turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"OQ" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/carpet,
 /area/centcom/central_command_areas/evacuation)
 "Pa" = (
 /obj/structure/chair/sofa/corp/right,
@@ -2203,6 +2286,7 @@
 "Qf" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/flag/nanotrasen/directional/north,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Qq" = (
@@ -2257,6 +2341,7 @@
 /area/centcom/central_command_areas/evacuation)
 "QV" = (
 /obj/item/soap/nanotrasen,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "Ra" = (
@@ -2354,10 +2439,10 @@
 /turf/open/floor/iron/checker,
 /area/centcom/central_command_areas/evacuation)
 "Ut" = (
-/obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
+/obj/structure/weightmachine,
 /turf/open/floor/iron/checker,
 /area/centcom/central_command_areas/evacuation)
 "Uu" = (
@@ -2389,6 +2474,7 @@
 /obj/effect/spawner/random/food_or_drink/snack/lizard,
 /obj/effect/spawner/random/food_or_drink/dinner,
 /obj/effect/spawner/random/food_or_drink/salad,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "UI" = (
@@ -2658,6 +2744,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/trashcart/laundry,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/central_command_areas/evacuation)
 "ZQ" = (
@@ -2954,7 +3041,7 @@ ck
 XG
 Jg
 Cc
-gu
+NW
 gu
 iD
 gU
@@ -2980,7 +3067,7 @@ dM
 kb
 kb
 Jg
-hk
+Nn
 hk
 hk
 hk
@@ -3090,7 +3177,7 @@ or
 Rm
 Vv
 Jg
-pc
+AH
 Vg
 aL
 wS
@@ -3120,11 +3207,11 @@ Jg
 Er
 ZV
 Iq
-Zg
+Fk
 JN
 SA
 hT
-Gi
+tf
 pC
 Yg
 Rm
@@ -3140,7 +3227,7 @@ dM
 kb
 kb
 Jg
-gg
+pk
 gg
 gg
 gg
@@ -3189,7 +3276,7 @@ ik
 CF
 FB
 kM
-FB
+OQ
 Jg
 hN
 Xo
@@ -3277,7 +3364,7 @@ rX
 rX
 rX
 Jg
-Er
+OA
 Rm
 vx
 JD
@@ -3300,7 +3387,7 @@ dM
 kb
 kb
 Jg
-gO
+hK
 gO
 gO
 gO
@@ -3460,13 +3547,13 @@ dM
 kb
 kb
 Jg
-iG
+Az
 iG
 iG
 iG
 ZT
 or
-CF
+il
 Jg
 WQ
 Yv
@@ -3508,7 +3595,7 @@ Jg
 XQ
 rj
 Jg
-WQ
+Mm
 Yv
 ap
 nX

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -66,6 +66,9 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
+	//ORBSTATION ADDITIONS
+	var/reboot_time = 0
+
 /datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid" = TRUE,
@@ -699,11 +702,13 @@ SUBSYSTEM_DEF(ticker)
 	to_chat(world, span_boldannounce("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
 
 	var/start_wait = world.time
+	reboot_time = start_wait + delay //ORBSTATION ADDITION
 	UNTIL(round_end_sound_sent || (world.time - start_wait) > (delay * 2)) //don't wait forever
 	sleep(delay - (world.time - start_wait))
 
 	if(delay_end && !skip_delay)
 		to_chat(world, span_boldannounce("Reboot was cancelled by an admin."))
+		reboot_time = 0 //ORBSTATION ADDITION
 		return
 	if(end_string)
 		end_state = end_string

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -219,6 +219,12 @@
 		// the shuttle is missing - no processing
 		set_messages("shutl?","")
 		return PROCESS_KILL
+	//ORBSTATION ADDITION - display round end countdown
+	else if(SSticker.current_state == GAME_STATE_FINISHED)
+		var/time_left = (SSticker.reboot_time - world.time) / 10
+		var/time = time_left > 0 ? "[add_leading(num2text((time_left / 60) % 60), 2, "0")]:[add_leading(num2text(time_left % 60), 2, "0")]" : "00:00"
+		set_messages("- END -", time)
+	//ORBSTATION ADDITION END
 	else if(shuttle.timer)
 		var/line1 = "- [shuttle.getModeStr()] -"
 		var/line2 = shuttle.getTimerStr()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/lizardqueenlexi/orbstation/assets/105025397/cab07a93-78ce-4c3a-a4aa-66ddfed2cbe4)

As the title says, you will now be able to see the time until the round restarts on all shuttle status displays. This includes non-emergency shuttle displays.

Also adds many more status displays to the CentCom Emergency Wing, so that players anywhere in the wing will be able to tell at a glance when the round will end.

"END" does not have any clearly-defined in-universe meaning. Use your imagination if you like!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One of the main complaints leveled at the longer end-of-round timer that was implemented with the Emergency Wing is that you do not know when the round will restart. This should hopefully help with that, so that you don't get surprised when you're still typing something.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Shuttle status displays now show when the server will reboot post-round.
add: Added many more status displays to Centcom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
