### PR TITLE
Readds the orb override that makes leaving chasms safer

### DIFF
--- a/orbstation/code/jobs/mining/chasm_rescue.dm
+++ b/orbstation/code/jobs/mining/chasm_rescue.dm
@@ -1,0 +1,27 @@
+
+// Orb override to climb calmly out of a chasm instead of hurling yourself in a random direction
+/obj/effect/abstract/chasm_storage/on_revive(mob/living/escapee)
+	var/turf/turf = get_turf(src)
+
+	if(!turf.GetComponent(/datum/component/chasm))
+		return ..() // Fall back to break through the floor by flinging
+
+	var/turf/escape_turf = get_nearest_safe_turf(turf)
+	if (!escape_turf)
+		return ..() // Fall back to flinging
+
+	turf.visible_message(span_boldwarning("After a long climb, [escapee] emerges from [turf]!"))
+	escapee.forceMove(escape_turf)
+	escapee.Paralyze(5 SECONDS, TRUE)
+	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)
+
+/obj/effect/abstract/chasm_storage/proc/get_nearest_safe_turf(atom/chasm)
+	var/list/nearby_open_turfs = list()
+	for (var/turf/open/sanctuary in orange(3, chasm))
+		if (sanctuary.is_blocked_turf(exclude_mobs = FALSE) || ischasm(sanctuary) || islava(sanctuary))
+			continue
+		nearby_open_turfs += sanctuary
+
+	if (!length(nearby_open_turfs))
+		return null
+	return get_closest_atom(/turf/, nearby_open_turfs, chasm)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5652,6 +5652,7 @@
 #include "orbstation\code\jobs\medical\surgery\misc.dm"
 #include "orbstation\code\jobs\medical\surgery\pacification.dm"
 #include "orbstation\code\jobs\medical\virology\red_eyes.dm"
+#include "orbstation\code\jobs\mining\chasm_rescue.dm"
 #include "orbstation\code\jobs\mining\demonic_portal.dm"
 #include "orbstation\code\jobs\mining\megafauna.dm"
 #include "orbstation\code\jobs\mining\safer_stomach.dm"


### PR DESCRIPTION

## About The Pull Request

Readds the orb override, where leaving the chasm will lets you calmly climb out into a safe tile. If there is no safe tile, as before, you will fling yourself randomly. If the chasm has been covered up, we will fall back to a new upstream code, where you will burst through the floor and fling yourself.

This PR does not readd the code that ensures people will fish out corpses from the chasm at a high chance, because the bug that made the chance 0% has been fixed.

## Why It's Good For The Game
You won't accidentally jump from a different chasm, or lava, if there is a safe tile right there.


