### PR TITLE
Biodome maint changes, fixes name of boat

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -3466,6 +3466,11 @@
 /obj/structure/stairs/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"boD" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/plating,
+/area/station/biodome/fore)
 "boN" = (
 /obj/item/food/grown/banana,
 /turf/open/floor/grass,
@@ -7607,10 +7612,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/stairs/medium,
 /area/station/command/gateway)
-"cRx" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plating,
-/area/station/biodome/fore)
 "cRP" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/turf_decal/bot,
@@ -11111,6 +11112,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/donk,
 /area/station/security/prison/mess)
+"emU" = (
+/obj/effect/spawner/random/engineering/vending_restock,
+/turf/open/floor/plating,
+/area/station/biodome/fore)
 "end" = (
 /obj/structure/railing,
 /obj/structure/table,
@@ -11496,6 +11501,15 @@
 /area/station/hallway/primary/central/fore)
 "euk" = (
 /obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"eus" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "euJ" = (
@@ -14800,6 +14814,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"fGZ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "fHJ" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -16531,6 +16549,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
+"gnL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "gnV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta,
@@ -18427,6 +18454,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hbp" = (
+/obj/structure/closet/crate/necropolis{
+	desc = "Presumably placed here by top men.";
+	name = "\improper Ark of the Covenant"
+	},
+/obj/item/toy/plush/ratplush,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/central)
 "hbq" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -19660,6 +19695,10 @@
 "hDB" = (
 /turf/open/misc/ashplanet/wateryrock/biodome,
 /area/station/biodome)
+"hDC" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "hDE" = (
 /obj/machinery/atmospherics/components/tank/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -19814,6 +19853,15 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"hFZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "hGq" = (
 /obj/structure/window/reinforced/spawner/directional/south{
 	pixel_y = 2
@@ -25583,7 +25631,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
@@ -28654,11 +28702,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"ldW" = (
-/obj/structure/frame/computer,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "lec" = (
 /obj/structure/flora/bush/jungle/a/style_random,
 /turf/open/floor/grass,
@@ -31664,6 +31707,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"mfO" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "mga" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/plating,
@@ -32059,6 +32107,10 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"mnY" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "mnZ" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -32678,6 +32730,8 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/security/brig)
 "mBn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
@@ -33113,7 +33167,6 @@
 "mLv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "mLz" = (
@@ -34448,12 +34501,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"nlV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/terracotta/small,
-/area/station/biodome/aft)
 "nme" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -36346,10 +36393,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
-"nWI" = (
-/obj/item/wallframe/airalarm,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "nWL" = (
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
@@ -39225,6 +39268,9 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"pbD" = (
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/fore/greater)
 "pbH" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/checker,
@@ -41879,6 +41925,10 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/wood,
 /area/station/command/bridge)
+"qeX" = (
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "qfe" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
@@ -44129,14 +44179,6 @@
 "qUX" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
-"qUZ" = (
-/obj/item/toy/plush/ratplush,
-/obj/structure/closet/crate/necropolis{
-	desc = "Presumably placed here by top men.";
-	name = "\improper Ark of the Covenant"
-	},
-/turf/open/misc/asteroid,
-/area/station/maintenance/port/central)
 "qVc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -44586,6 +44628,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "rdj" = (
 /obj/effect/spawner/random/exotic/technology,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "rdm" = (
@@ -45644,6 +45687,15 @@
 "rwT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"rxa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "rxs" = (
@@ -46778,6 +46830,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"rUH" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "rUM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/structure/disposalpipe/segment,
@@ -51298,6 +51356,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
+"tHs" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "tHt" = (
 /turf/open/openspace,
 /area/station/cargo/storage)
@@ -51466,6 +51528,15 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/cytology)
+"tKF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "tKM" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light/small/directional/west,
@@ -52223,6 +52294,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
+"ucv" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "ucy" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -52294,6 +52369,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
+"ueL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/fore/greater)
 "ueU" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -53444,6 +53525,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"uEu" = (
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/aft)
 "uEK" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -55381,10 +55466,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"vsW" = (
-/obj/effect/decal/cleanable/ants,
-/turf/open/floor/plating,
-/area/station/biodome/fore)
 "vtd" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -56917,6 +56998,11 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
+"vWx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/airalarm,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "vWz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57186,6 +57272,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"wcQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "wcR" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/cup/bottle/epinephrine,
@@ -61155,6 +61248,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
+"xAu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "xAC" = (
 /obj/structure/sign/flag/ssc/directional/east,
 /turf/open/floor/catwalk_floor/iron,
@@ -87489,8 +87588,8 @@ hNy
 hNy
 pKF
 pKF
-cJU
-gxB
+qeX
+wcQ
 pKF
 wTu
 hIo
@@ -87762,7 +87861,7 @@ qTq
 tyM
 pKF
 kAo
-cJU
+kAo
 qaC
 pKF
 cCZ
@@ -88018,8 +88117,8 @@ cJU
 vAT
 tFi
 pKF
+dBC
 kAo
-cJU
 pKF
 pKF
 cCZ
@@ -88275,8 +88374,8 @@ weY
 gqA
 lXk
 pKF
+bZB
 kAo
-cJU
 pKF
 cCZ
 cCZ
@@ -88532,8 +88631,8 @@ ugH
 cJU
 bZB
 pKF
+dBC
 kAo
-cJU
 pKF
 cCZ
 cCZ
@@ -89839,7 +89938,7 @@ dIN
 aIQ
 tyi
 pkn
-pKF
+hbp
 vco
 vco
 guG
@@ -90084,20 +90183,20 @@ cJU
 cJU
 rZH
 wpF
-tbw
-tbw
-tbw
-tbw
-cJU
+pKF
+pKF
+pKF
+pKF
+pKF
 fmH
 aIQ
-dIN
 aIQ
-bJf
-bJf
 dIN
-qUZ
-ktR
+pKF
+pKF
+pKF
+pKF
+pKF
 gHE
 wfp
 cDM
@@ -90340,20 +90439,20 @@ pKF
 pKF
 pKF
 pKF
-tbw
+pKF
 tbw
 oZp
 eZY
 tbw
-tbw
-tbw
-tbw
-tbw
-ktR
-ktR
-ktR
-ktR
-ktR
+pKF
+pKF
+pKF
+pKF
+pKF
+pKF
+mfO
+uEu
+mnY
 ktR
 eIi
 txw
@@ -90609,7 +90708,7 @@ aWc
 tlW
 hVC
 hVC
-nlV
+hVC
 mLv
 wxZ
 vfD
@@ -92369,7 +92468,7 @@ inF
 wZB
 sBz
 dYQ
-dYQ
+sBz
 sBz
 fsz
 kFI
@@ -92626,8 +92725,8 @@ biR
 wZB
 sBz
 eoI
-dYQ
 sBz
+jFC
 ftO
 kFI
 kFI
@@ -92883,9 +92982,9 @@ inF
 wZB
 sBz
 dYQ
-dYQ
 sBz
-jFC
+xWK
+fsz
 kFI
 wfm
 cov
@@ -93140,9 +93239,9 @@ eLt
 wZB
 sBz
 tkw
-dYQ
 sBz
-xWK
+sBz
+fsz
 kFI
 wfm
 kkE
@@ -93636,15 +93735,15 @@ gbs
 gbs
 gbs
 gbs
+ucv
+fRH
+fGZ
 gbs
 gbs
 gbs
 gbs
-gbs
-gbs
-gbs
-gbs
-gbs
+nyo
+rCY
 gbs
 gbs
 gbs
@@ -93892,20 +93991,20 @@ rBF
 jlt
 dYQ
 dYQ
-dYQ
-dYQ
-dYQ
-dYQ
-dYQ
+gbs
+gbs
+gbs
+gbs
+gbs
 cCt
 dYQ
+gbs
+gbs
+gbs
+gbs
 dYQ
 dYQ
-dYQ
-dYQ
-dYQ
-dYQ
-dYQ
+ggd
 gbs
 gbs
 gbs
@@ -95195,8 +95294,8 @@ sBz
 sXv
 gbs
 dYQ
-dYQ
-dYQ
+sBz
+sBz
 sBz
 xWK
 aWb
@@ -95452,10 +95551,10 @@ nPM
 gbs
 gbs
 iEc
-fRH
-tMJ
 sBz
-cRx
+emU
+boD
+fsz
 aWb
 diJ
 sgO
@@ -95709,8 +95808,8 @@ aNE
 dZv
 dYQ
 upu
-fRH
-upu
+sBz
+sBz
 sBz
 fsz
 aWb
@@ -95969,7 +96068,7 @@ dYQ
 dYQ
 hJD
 sBz
-vsW
+fsz
 bdd
 aTD
 pxZ
@@ -97559,8 +97658,8 @@ aUW
 frW
 vqS
 oAe
-kPD
-lJT
+wkE
+gnL
 lJT
 lJT
 lJT
@@ -97816,8 +97915,8 @@ cXv
 hLZ
 udX
 oAe
-kPD
-oAe
+pwY
+rxa
 oAe
 uXG
 oAe
@@ -98073,9 +98172,9 @@ aUW
 frW
 uQJ
 oAe
-kPD
+fOt
+eus
 oAe
-ldW
 cOq
 eLF
 nWL
@@ -98279,7 +98378,7 @@ rIk
 dYQ
 sBz
 sBz
-dYQ
+dZv
 dZv
 sBz
 jFC
@@ -98330,12 +98429,12 @@ aUW
 frW
 nDw
 oAe
-kPD
+tKF
+hFZ
 oAe
-nWI
-wJI
+vWx
 rdj
-wJI
+xAu
 jZC
 vUj
 osi
@@ -98536,8 +98635,8 @@ qcf
 eWD
 wNR
 sBz
-dYQ
 dZv
+upu
 sBz
 rwj
 gwG
@@ -98793,8 +98892,8 @@ pwg
 lsf
 sIf
 xIs
-dYQ
-dZv
+ueL
+pbD
 ndl
 qGx
 bOw
@@ -99050,8 +99149,8 @@ eWD
 oGU
 wNR
 sBz
-dYQ
 dZv
+upu
 sBz
 fsz
 fsz
@@ -99307,7 +99406,7 @@ fUv
 ogX
 sBz
 sBz
-dYQ
+dZv
 dZv
 sBz
 fYx
@@ -102135,7 +102234,7 @@ nSk
 rcP
 dYQ
 nSk
-dYQ
+hDC
 sBz
 aLk
 bCN
@@ -104191,7 +104290,7 @@ dYQ
 dYQ
 dYQ
 nSk
-dYQ
+hDC
 sBz
 aLk
 aLk
@@ -104972,25 +105071,25 @@ uZp
 jsk
 btj
 uZp
+ykP
+ykP
+ykP
 uZp
-uZp
-uZp
-uZp
-uZp
-uZp
-uZp
-uZp
+btj
+btj
 gNh
-uZp
-uZp
+ykP
+ykP
+ykP
 uZp
 uZp
 uZp
 uZp
 uZp
 sfP
-uZp
-uZp
+bGM
+bGM
+bGM
 mBn
 uZp
 uZp
@@ -105230,14 +105329,14 @@ ykP
 ykP
 ykP
 ykP
+bRU
 ykP
 ykP
 ykP
 ykP
 ykP
 ykP
-ykP
-ykP
+btj
 ykP
 mMx
 mMx
@@ -105246,8 +105345,8 @@ mMx
 mMx
 bGM
 bGM
-bGM
-bGM
+rUH
+tHs
 bGM
 bGM
 bGM
@@ -105486,7 +105585,7 @@ uZp
 uZp
 btj
 ykP
-uZp
+agK
 uZp
 agK
 gNh

--- a/orbstation/code/map/biodome/tram.dm
+++ b/orbstation/code/map/biodome/tram.dm
@@ -7,7 +7,7 @@
 	specific_lift_id = TRAM_BOAT
 
 /obj/machinery/computer/tram_controls/boat
-	name = "Please Boat Controls"
+	name = "Pleasure Boat Controls"
 	icon = 'orbstation/icons/obj/computer.dmi'
 	icon_screen = "tram_Aft Boat Dock_idle"
 	specific_lift_id = TRAM_BOAT


### PR DESCRIPTION


## About The Pull Request

This PR makes the corridors surrounding the dome a bit less straight. Some of the Back Alleys extend into previous maintenance space, grilles and windows have been added.
This PR also fixes an Emergency Air Storage room's manifold being rotated incorrectly.
Also renames the "Please boat" to "Pleasure  boat", as it should be.

## Why It's Good For The Game
Dodging grilles in the dark is exciting, and hiding in nooks is fun