### PR TITLE
Removes the built in armour from quirk cyber limbs

### DIFF
--- a/orbstation/code/customisation/quirks/augmented.dm
+++ b/orbstation/code/customisation/quirks/augmented.dm
@@ -1,21 +1,53 @@
 /datum/quirk/augmented
 	name = "Fully Augmented"
-	desc = "You never asked for this. Or maybe you did. Either way, all your limbs are cybernetic."
+	desc = "You never asked for this. Or maybe you did. Either way, all your limbs are cybernetic. They are civilian grade, and provide no armour."
 	icon = FA_ICON_PLUG_CIRCLE_BOLT
 	value = 0
 	medical_record_text = "During physical examination, patient was found to have fully augmented limbs."
 
 /datum/quirk/augmented/add_unique()
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/quirk)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/quirk)
 	if(human_holder.bodytype & BODYTYPE_DIGITIGRADE)
-		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/digitigrade)
-		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/digitigrade)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/digitigrade/quirk)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/digitigrade/quirk)
 	else
-		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/)
-		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/quirk)
+		human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/quirk)
 
 /datum/quirk/augmented/post_add()
 	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with cybernetic parts. They are roughly analogous to organic limbs. However, \
-	you need to use a welding tool and cables to repair them, instead of standard medical treatment."))
+	you need to use a welding tool and cables to repair them, instead of standard medical treatment. They are also civilian grade, providing no armour."))
+
+/obj/item/bodypart/arm/left/robot/quirk
+	name = "civilian grade cyborg left arm"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour."
+	burn_modifier = 1
+	brute_modifier = 1
+
+/obj/item/bodypart/arm/right/robot/quirk
+	name = "civilian grade cyborg right arm"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour."
+	burn_modifier = 1
+	brute_modifier = 1
+
+/obj/item/bodypart/leg/left/robot/quirk
+	name = "civilian grade cyborg left left"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour."
+	burn_modifier = 1
+	brute_modifier = 1
+
+/obj/item/bodypart/leg/right/robot/quirk
+	name = "civilian grade cyborg right left"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour."
+	burn_modifier = 1
+	brute_modifier = 1
+
+/obj/item/bodypart/leg/left/robot/digitigrade/quirk
+	name = "civilian grade digitigrade robotic left leg"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour. This one is shaped like a digitigrade Tiziran leg."
+
+/obj/item/bodypart/leg/right/robot/digitigrade/quirk
+	name = "civilian grade digitigrade robotic left leg"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case. Civilian grade, thus has no armour. This one is shaped like a digitigrade Tiziran leg."


### PR DESCRIPTION
  
## About The Pull Request

The limbs you get from the Fully Augmented qurik are now Civilian Grade, and provide no brute and burn damage reduction.

## Why It's Good For The Game

The limbs from the "Fully Augmented Quirk" gave 20% burn and brute damage reduction. The limbs are completely hideable, giving you usually invisible armour without  the need for preparation. This quirk is marked as a Neutral Quirk, and yet give a distinct combat advantage. By changing it to not provide armour, it is now properly balanced trade off wise, and fits our quirk philosophy.

## Changelog
 
:cl: 
balance: Fully Augmented folks are now decked out in civilian grade limbs
/:cl: 
