### PR TITLE
Consolidates soviet and anarchist employers

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -156,11 +156,9 @@ GLOBAL_LIST_INIT(syndicate_employers, list(
 	//ORBSTATION EMPLOYERS
 	"Azik Interstellar",
 	"Chariraxa Agricultural Concern",
-	"Children of the 3rd Soviet Republic",
-	"Free Radicals",
-	"Ghosts of the 3rd Soviet Union",
 	"Ngaouhaki FPC",
 	"Suojaheimøstusek Resource & Logistics, plc",
+	"True Soldiers of the 3rd Soviet Union",
 ))
 ///employers that are from nanotrasen
 GLOBAL_LIST_INIT(nanotrasen_employers, list(
@@ -169,8 +167,6 @@ GLOBAL_LIST_INIT(nanotrasen_employers, list(
 	"Gone Postal",
 	"Internal Affairs Agent",
 	"Legal Trouble",
-	//ORBSTATION EMPLOYERS
-	"Flagbearers of the New Kronstadt",
 ))
 
 ///employers who hire agents to do the hijack
@@ -180,9 +176,6 @@ GLOBAL_LIST_INIT(hijack_employers, list(
 	"Gone Postal",
 	"Tiger Cooperative Fanatic",
 	"Waffle Corporation Terrorist",
-	//ORBSTATION EMPLOYERS
-	"Children of the 3rd Soviet Republic",
-	"Free Radicals",
 ))
 
 ///employers who hire agents to do a task and escape... or martyrdom. whatever

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -128,35 +128,11 @@
         "ui_theme": "syndicate",
         "uplink": "You have been provided with a standard uplink to accomplish your task."
     },
-    "Children of the 3rd Soviet Republic": {
-        "allies": "You may collaborate with any friends of the Syndicate coalition, but not the Ghosts of the 3rd Soviet Union, who are revisionist liars and backstabbers.",
-        "goal": "Strike a blow to NT that their wallets can't afford. Persuade others to follow our cause through any means necessary.",
-        "introduction": "You are a vanguard of the 4rd Soviet Union.",
-        "roundend_report": "was a Soviet Revolutionary.",
-        "ui_theme": "syndicate",
-        "uplink": "The Syndicate have relucantly loaned us one of their uplinks for your task."
-    },
-    "Flagbearers of the New Kronstadt": {
-        "allies": "The Free Radicals, Bee Liberation Front, and any revolutionary you meet is an ally. Do not Trust Capitalists and Vanguards, they will use you and throw you to the wolves.",
-        "goal": "Establish an anarcho syndicalist faction within the syndicate by demonstrating our superiority.",
-        "introduction": "You are a Flagbearer of the New Kronstadt.",
-        "roundend_report": "was a Soviet Anarchist.",
-        "ui_theme": "syndicate",
-        "uplink": "We've aqcuired a contraband syndicate uplink for you to complete their tasks in our name."
-    },
-    "Free Radicals": {
-        "allies": "Any who recognize the Tyranny of Nanotrasen and fight for liberation are our ally.",
-        "goal": "We're here to liberate the workers, don't kill them if they aren't a target. Everything else is allowed.",
-        "introduction": "You are the Free Radical Revolutionary.",
-        "roundend_report": "was a Free Radical Terrorist.",
-        "ui_theme": "syndicate",
-        "uplink": "You have been provided with a standard uplink to accomplish your task."
-    },
-    "Ghosts of the 3rd Soviet Union": {
-        "allies": "You may collaborate with any friends of the Syndicate coalition, but remember that they are all pawns of Capitalist interests. Guide them justly.",
-        "goal": "Strike a blow to NT that their wallets can't afford. Don't muddy our message by killing low level workers needlessly.",
-        "introduction": "You are a vanguard of the 3rd Soviet Union.",
-        "roundend_report": "was a Soviet Revolutionary.",
+    "True Soldiers of the 3rd Soviet Union": {
+        "allies": "As future investors, Cybersun syndicate agents may be tentatively trusted. Try to convince Donk co and Waffle co agents to defect to your side. Do not trust others who claim to be True Agents, they are mere pretenders!",
+        "goal": "Spreads the TRUE message of the 3rd Soviet Union to labourers of the station, while causing lasting harm to NT's funds and infrastructure.",
+        "introduction": "You are one of the few True Soldiers of the 3rd Soviet Union.",
+        "roundend_report": "was a True Soviet Soldier.",
         "ui_theme": "syndicate",
         "uplink": "The Syndicate have graciously given one of their uplinks for your task."
     },


### PR DESCRIPTION

## About The Pull Request

This PR removes the Children of the 3rd Soviet Republic, Free Radicals, Ghosts of the 3rd Soviet Union and Flagbearers of the New Kronstadt, and replaces them with the True Soldiers of the 3rd Soviet Union.

## Why It's Good For The Game

Children and Ghosts were extremely similar in tone, and so was Free Radicals. New Kronstadt was marked Neutral, but was actually syndicate in tone. These four soviets/anarchists took over quite a large chunk of potential employers, with rather similar flavours.

I have solved the issue by introducing the True Soldiers of the 3rd Soviet Union. They are tentatively allied with Cybersun, but of course, Cybersun does not ally with them. They have the moral prerogative to strike a truce between Donk Co and Waffle Co employees and poach them over to their side, along with the labourers of the station. In addition, every True Soldier is actually from a different group called True Soldiers, so the communist infighting persists, without muddying up the employer list.

## Changelog

:cl:
add: Only the TRUE SOLDIERS of the soviet union remain
/:cl:
