### PR TITLE
Biodome: The intercoms and lit maint update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -17141,6 +17141,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Bridge Aft Access"
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "gtH" = (
@@ -31077,7 +31078,6 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -32119,6 +32119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mbi" = (
@@ -37183,6 +37184,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Theater Dressing Room"
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
 "nVA" = (
@@ -42383,6 +42385,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/maintenance/port/greater)
+"pTL" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/misc/beach/coast{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "pTY" = (
 /obj/structure/table,
 /obj/machinery/computer/records/medical/laptop,
@@ -45604,6 +45617,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Bridge Fore Access"
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "rcq" = (
@@ -51758,7 +51772,6 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -57430,6 +57443,10 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vGy" = (
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "vGA" = (
 /obj/structure/railing{
 	dir = 8
@@ -57939,6 +57956,9 @@
 "vQt" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/structure/sign/poster/contraband/random/directional/south,
+/obj/item/trapdoor_remote/preloaded{
+	pixel_x = -8
+	},
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
 "vQz" = (
@@ -58968,6 +58988,10 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"wki" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood,
+/area/station/command/bridge)
 "wkm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/structure/cable/layer3,
@@ -60684,9 +60708,6 @@
 /area/station/maintenance/disposal/incinerator)
 "wNB" = (
 /obj/structure/dresser,
-/obj/item/trapdoor_remote/preloaded{
-	pixel_x = -8
-	},
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
 "wNF" = (
@@ -64347,6 +64368,7 @@
 /area/station/cargo/storage)
 "yeN" = (
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
 "yeO" = (
@@ -150656,9 +150678,9 @@ xuo
 xuo
 wfW
 kiH
-wfW
+vGy
 jcM
-wfW
+vGy
 jcM
 wfW
 hHc
@@ -151170,9 +151192,9 @@ xuo
 xuo
 wfW
 kiH
-wfW
+vGy
 jcM
-wfW
+vGy
 jcM
 wfW
 hHc
@@ -169478,7 +169500,7 @@ meU
 gxl
 sQM
 iuT
-qWj
+wki
 qWj
 qWj
 qWj
@@ -169486,7 +169508,7 @@ uGr
 qWj
 qWj
 qWj
-qWj
+wki
 rOP
 hiu
 wXd
@@ -177954,7 +177976,7 @@ cMq
 lwi
 tHt
 tHt
-kWo
+pTL
 bOm
 bOm
 bOm

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1667,7 +1667,6 @@
 /obj/structure/bed,
 /obj/item/pillow/random,
 /obj/item/bedsheet/dorms,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "aDG" = (
@@ -1961,6 +1960,10 @@
 /obj/item/radio/intercom/chapel/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"aJf" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "aJm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -4026,7 +4029,6 @@
 /obj/structure/bed,
 /obj/item/pillow/random,
 /obj/item/bedsheet/dorms,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
@@ -4229,6 +4231,11 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/radshelter/civil)
+"bCp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "bCA" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/food_or_drink/booze,
@@ -5394,6 +5401,7 @@
 "bZG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /mob/living/basic/blob_minion/spore/minion/weak,
+/obj/machinery/light/floor/broken,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
 "bZQ" = (
@@ -6426,6 +6434,11 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/construction/engineering)
+"cty" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/dim/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "ctI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/electric_shock{
@@ -7509,6 +7522,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
+"cKX" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/machinery/light/floor,
+/turf/open/floor/plating/reinforced,
+/area/station/maintenance/central/greater)
 "cLd" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -7817,6 +7835,13 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"cRz" = (
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "cRP" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/turf_decal/bot,
@@ -8787,6 +8812,10 @@
 	},
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
+"dkm" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "dky" = (
 /obj/machinery/camera/autoname/directional/west{
 	c_tag = "Storage - Tech"
@@ -9040,6 +9069,10 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"dpR" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "dpZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -10457,10 +10490,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/grass,
 /area/station/biodome/fore)
-"dSM" = (
-/obj/machinery/light/warm/directional/east,
-/turf/open/openspace,
-/area/station/biodome)
 "dSP" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -13778,6 +13807,10 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"ffW" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "fgk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -16755,6 +16788,10 @@
 "gls" = (
 /turf/open/floor/wood/parquet,
 /area/station/cargo/miningdock)
+"glu" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "glD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan{
@@ -17969,6 +18006,12 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"gJE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "gJS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19145,6 +19188,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"hix" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/openspace,
+/area/station/maintenance/port/greater)
 "hiA" = (
 /obj/item/storage/fancy/nugget_box,
 /turf/open/misc/asteroid/airless,
@@ -19770,6 +19820,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "hwf" = (
@@ -20020,6 +20071,10 @@
 /obj/structure/fluff/beach_umbrella/science,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"hCC" = (
+/obj/machinery/light/small/blacklight/directional/south,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/central/greater)
 "hCI" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /mob/living/basic/butterfly,
@@ -21073,6 +21128,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"hXO" = (
+/obj/structure/broken_flooring/singular/directional/north,
+/obj/structure/broken_flooring/singular/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "hXP" = (
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/science)
@@ -22639,6 +22699,11 @@
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"iCC" = (
+/obj/effect/spawner/random/bureaucracy,
+/obj/structure/table/glass,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "iCF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -23071,6 +23136,10 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/command/heads_quarters/cmo)
+"iLW" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/port/greater)
 "iMg" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock"
@@ -23710,13 +23779,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"jaU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/grass,
-/area/station/commons/dorms)
 "jaZ" = (
 /obj/structure/broken_flooring/singular/directional/west,
 /turf/open/floor/plating,
@@ -23868,8 +23930,13 @@
 /area/station/medical/psychology)
 "jdn" = (
 /obj/item/trash/can/food/pine_nuts,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"jdD" = (
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "jdJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24271,6 +24338,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"jlV" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "jmc" = (
 /obj/machinery/door/airlock/external{
 	space_dir = 8
@@ -24515,6 +24593,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"jry" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "jrD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 9
@@ -29900,13 +29982,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/chapel)
-"lpS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/directional/west,
-/turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
 "lpZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -30197,6 +30272,7 @@
 /area/station/engineering/atmos)
 "luw" = (
 /obj/effect/spawner/random/trash/graffiti,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "luN" = (
@@ -31568,6 +31644,13 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"lTD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "lTG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -33057,6 +33140,13 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"mtT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small/red/dim/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "mtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33441,6 +33531,10 @@
 /obj/item/paper/natural,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"mCk" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "mCn" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -33975,7 +34069,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/item/pillow/random,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "mNG" = (
@@ -34461,7 +34554,6 @@
 /area/station/maintenance/department/chapel)
 "mYc" = (
 /obj/structure/bed,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "mYe" = (
@@ -34669,7 +34761,6 @@
 /area/station/command/bridge)
 "nct" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/bureaucracy,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ncx" = (
@@ -34780,6 +34871,11 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"ndw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "ndD" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
@@ -35111,6 +35207,10 @@
 /obj/structure/sign/departments/holy/directional/east,
 /turf/open/floor/iron/terracotta,
 /area/station/service/chapel)
+"njj" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/port/central)
 "njy" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
 	dir = 4
@@ -37224,6 +37324,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"nYN" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/openspace,
+/area/station/biodome)
 "nYQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -39360,6 +39464,7 @@
 /area/station/engineering/lobby)
 "oMn" = (
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oMw" = (
@@ -40103,6 +40208,7 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "pbD" = (
+/obj/machinery/light/floor,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/fore/greater)
 "pbH" = (
@@ -43212,6 +43318,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/catwalk_floor,
 /area/station/command/gateway)
+"qma" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "qmd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43746,6 +43857,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qwG" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "qwL" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/fakebasalt,
@@ -44839,6 +44954,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
+"qQN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "qQO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
 	dir = 5
@@ -44882,6 +45004,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/station/cargo/lobby)
+"qRG" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "qRP" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/stairs/medium,
@@ -46365,10 +46491,6 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"rsQ" = (
-/obj/machinery/light/small/red/dim/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
 "rsS" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -46927,7 +47049,6 @@
 	},
 /obj/item/pillow/random,
 /obj/item/pillow/random,
-/obj/machinery/airalarm/directional/north,
 /obj/item/bedsheet/dorms_double,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
@@ -46986,6 +47107,9 @@
 "rDI" = (
 /turf/open/misc/asteroid,
 /area/station/asteroid)
+"rDV" = (
+/turf/closed/wall,
+/area/space)
 "rEj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow,
@@ -49215,6 +49339,10 @@
 /obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"sxR" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "syh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -49894,6 +50022,11 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"sLt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/floor,
+/turf/open/floor/plating/reinforced,
+/area/station/maintenance/central/greater)
 "sLz" = (
 /obj/machinery/plumbing/sender,
 /obj/effect/turf_decal/stripes/line,
@@ -54524,6 +54657,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/research)
+"uCr" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "uCt" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/smooth_half,
@@ -55051,6 +55188,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
+"uNS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "uNV" = (
 /obj/item/melee/fakebeesword,
 /turf/open/water/jungle/biodome,
@@ -55186,6 +55328,7 @@
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "uQH" = (
+/obj/machinery/light/small/red/dim/directional/south,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
@@ -57583,6 +57726,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"vLU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "vMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -58472,11 +58622,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"wdE" = (
-/obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "wdV" = (
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/terracotta/small,
@@ -62156,7 +62301,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -62491,6 +62635,10 @@
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"xAX" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "xAY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62819,6 +62967,11 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xGK" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xGL" = (
 /obj/structure/table,
 /obj/item/storage/briefcase,
@@ -63341,6 +63494,10 @@
 /obj/structure/cable,
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
+"xPW" = (
+/obj/machinery/light/small/red/dim/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "xPZ" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
 /turf/open/floor/plating,
@@ -63979,6 +64136,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"ybr" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "ybs" = (
 /turf/open/openspace,
 /area/station/maintenance/starboard/lesser)
@@ -64194,6 +64355,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"yeS" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "yeX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -81666,8 +81831,8 @@ cJU
 cJU
 hec
 cJU
-cJU
-cJU
+xAX
+cRz
 pKF
 dBC
 cJU
@@ -82184,7 +82349,7 @@ pSz
 pSz
 pSz
 drZ
-cJU
+ffW
 pKF
 hNy
 rRv
@@ -82685,7 +82850,7 @@ rRv
 hNy
 hNy
 pKF
-ugH
+uNS
 pSz
 nxV
 xlg
@@ -82952,7 +83117,7 @@ adI
 xVo
 vhE
 xEk
-vhE
+mCk
 pSz
 cJU
 cJU
@@ -83212,7 +83377,7 @@ vhE
 aMB
 pSz
 cJU
-cJU
+jaZ
 pKF
 pKF
 pKF
@@ -83471,7 +83636,7 @@ pSz
 cJU
 cgO
 cJU
-cJU
+hXO
 pKF
 flK
 dIN
@@ -83985,7 +84150,7 @@ pSz
 iro
 qdW
 pKF
-cJU
+ase
 rDy
 dIN
 hvz
@@ -84241,7 +84406,7 @@ aMB
 pSz
 cJU
 cJU
-cJU
+jaZ
 cJU
 pKF
 dIN
@@ -84482,8 +84647,8 @@ rRv
 rRv
 rRv
 hNy
-hNy
 pKF
+ugH
 ugH
 pSz
 jQc
@@ -84494,10 +84659,10 @@ mHU
 uhn
 uhn
 uhn
-vhE
+mCk
 pSz
 cJU
-rsQ
+ffW
 pKF
 pKF
 pKF
@@ -84739,9 +84904,9 @@ rRv
 rRv
 hNy
 hNy
-hNy
 pKF
 ugH
+pKF
 pSz
 hvX
 ssh
@@ -84996,9 +85161,9 @@ rRv
 hNy
 hNy
 hNy
-hNy
 pKF
 ugH
+qaC
 pSz
 pzL
 bjW
@@ -85253,9 +85418,9 @@ rRv
 hNy
 hNy
 hNy
-hNy
 pKF
-ugH
+uNS
+dBC
 pSz
 vUI
 pSz
@@ -85510,12 +85675,12 @@ rRv
 rRv
 rRv
 rRv
-hNy
 pKF
 ugH
+wpr
 pKF
 sUT
-cJU
+xAX
 kQc
 pKF
 rcq
@@ -85767,9 +85932,9 @@ hNy
 rRv
 hNy
 hNy
-hNy
 pKF
 ugH
+pKF
 pKF
 sUT
 cJU
@@ -86024,8 +86189,8 @@ cCZ
 rRv
 hNy
 hNy
-hNy
 pKF
+ugH
 ugH
 ugH
 sUT
@@ -86281,7 +86446,7 @@ rRv
 rRv
 hNy
 hNy
-hNy
+pKF
 pKF
 pKF
 pKF
@@ -86289,7 +86454,7 @@ sUT
 ugH
 ugH
 ugH
-ugH
+ndw
 ugH
 ugH
 cJU
@@ -88085,7 +88250,7 @@ wug
 mFh
 mFh
 nxR
-kAo
+qQN
 kAo
 kAo
 kAo
@@ -88094,7 +88259,7 @@ kAo
 bhV
 kAo
 kAo
-kAo
+qQN
 kAo
 cJU
 pKF
@@ -88651,7 +88816,7 @@ oAe
 oAe
 oAe
 oAe
-gRN
+dkm
 oAe
 oAe
 fTB
@@ -88899,7 +89064,7 @@ tqm
 gOY
 oAe
 iLA
-bib
+lTD
 bib
 xmN
 bib
@@ -88913,7 +89078,7 @@ bib
 bib
 bib
 bwN
-lpS
+tHc
 tHc
 aAt
 tHc
@@ -89446,7 +89611,7 @@ bqj
 bqj
 bqj
 bqj
-vUn
+mtT
 oAe
 oAe
 oAe
@@ -90923,7 +91088,7 @@ hgp
 ebT
 pKF
 arC
-oTM
+gJE
 pKF
 pKF
 pKF
@@ -91422,7 +91587,7 @@ uXI
 cJU
 cJU
 cJU
-cJU
+uXI
 pUC
 cJU
 wpF
@@ -91434,7 +91599,7 @@ cus
 tRr
 rNa
 agM
-hgp
+njj
 jBj
 cJU
 cJU
@@ -91725,7 +91890,7 @@ ktR
 ktR
 ktR
 oAe
-ydb
+jlV
 kIN
 kJg
 aFv
@@ -91930,7 +92095,7 @@ hNy
 hNy
 hNy
 sBz
-dYQ
+ydf
 dYQ
 sBz
 pOj
@@ -94992,7 +95157,7 @@ orQ
 gbs
 gbs
 gbs
-gbs
+vLU
 gbs
 gbs
 gbs
@@ -95014,7 +95179,7 @@ gbs
 gbs
 dYQ
 mDo
-dYQ
+ydf
 dYQ
 dYQ
 sBz
@@ -96273,7 +96438,7 @@ rsj
 vpU
 hiv
 jlt
-dYQ
+cCt
 rba
 jlt
 czJ
@@ -102212,7 +102377,7 @@ jpC
 dYQ
 fRH
 sBz
-dYQ
+ybr
 sBz
 gtc
 ndH
@@ -103312,7 +103477,7 @@ vDl
 rrp
 qnJ
 bHm
-bHm
+hCC
 bSh
 hNy
 cCZ
@@ -103563,7 +103728,7 @@ wSk
 cam
 vny
 qBt
-gRe
+sLt
 gRe
 vDl
 rrp
@@ -104268,7 +104433,7 @@ lee
 xwM
 vjs
 fPt
-dYQ
+qwG
 sBz
 gtc
 hQu
@@ -104588,7 +104753,7 @@ oAe
 bSh
 dVO
 gRe
-cam
+cKX
 oAe
 qXx
 nRY
@@ -104848,7 +105013,7 @@ wSk
 gRe
 rIS
 wSk
-gRe
+sLt
 vhZ
 jUq
 jUq
@@ -106067,7 +106232,7 @@ geE
 hNy
 hNy
 sBz
-dYQ
+ybr
 sBz
 kBo
 lcr
@@ -106345,7 +106510,7 @@ ykP
 ykP
 ykP
 uZp
-uZp
+jry
 uZp
 uZp
 uZp
@@ -106581,7 +106746,7 @@ geE
 hNy
 hNy
 bRU
-uZp
+glu
 uZp
 ykP
 ykP
@@ -106619,7 +106784,7 @@ uZp
 uZp
 uZp
 uZp
-uZp
+xPW
 bRU
 ftr
 dUI
@@ -107349,7 +107514,7 @@ cgz
 quv
 cbt
 pBE
-uZp
+glu
 uZp
 tUo
 ykP
@@ -107385,7 +107550,7 @@ oyW
 flV
 jNx
 bGM
-uZp
+xPW
 bRU
 eEI
 eEI
@@ -108927,7 +109092,7 @@ oyW
 uZp
 bRU
 bGM
-uZp
+xPW
 bRU
 vWr
 mFd
@@ -144640,7 +144805,7 @@ ikk
 gnX
 bnJ
 bnJ
-bnJ
+bCp
 vHx
 bnJ
 ikk
@@ -145650,7 +145815,7 @@ cCZ
 cCZ
 ngE
 gJk
-dDW
+jdD
 ngE
 dDW
 fXt
@@ -146696,7 +146861,7 @@ hdY
 pTI
 ikk
 tMa
-tMa
+cty
 tMa
 hfI
 iMV
@@ -147463,14 +147628,14 @@ nFw
 mUN
 mUN
 mUN
-mUN
+hix
 cJX
 cJX
 cJX
 vkh
 vkh
 vkh
-vkh
+xGK
 vkh
 vkh
 vkh
@@ -148767,7 +148932,7 @@ vyS
 qUB
 ikk
 pSH
-pSH
+qRG
 ikk
 jdn
 xdX
@@ -149298,7 +149463,7 @@ cdb
 kVn
 pSH
 pSH
-pSH
+nQr
 khI
 dce
 pSH
@@ -152060,7 +152225,7 @@ kAI
 hHc
 hHc
 jJi
-cdP
+kQd
 rps
 rps
 rps
@@ -152317,7 +152482,7 @@ kAI
 dUQ
 dUQ
 jJi
-cdP
+kQd
 rps
 jJi
 jJi
@@ -152831,7 +152996,7 @@ kAI
 hHc
 hHc
 jJi
-cdP
+dpR
 rxV
 pkE
 hii
@@ -153416,7 +153581,7 @@ xrC
 nkV
 nkV
 nkV
-nkV
+iLW
 ikk
 hNy
 kcg
@@ -154883,7 +155048,7 @@ hHc
 hHc
 kAI
 hHc
-hHc
+jJi
 jJi
 rxV
 jJi
@@ -155140,8 +155305,8 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
+rxV
 rxV
 jJi
 ipc
@@ -155397,9 +155562,9 @@ hHc
 hHc
 kAI
 dUQ
-dUQ
 jJi
 rxV
+uCr
 jJi
 vqW
 vHM
@@ -155654,9 +155819,9 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
 rxV
+aJf
 jJi
 rBX
 ldC
@@ -155911,9 +156076,9 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
 rxV
+iCC
 jJi
 phJ
 phJ
@@ -155926,7 +156091,7 @@ phJ
 phJ
 ipc
 xOr
-jaU
+nCs
 nUi
 phJ
 xLH
@@ -156168,9 +156333,9 @@ hHc
 hHc
 kAI
 dUQ
-dUQ
 jJi
 rxV
+sxR
 jJi
 eUt
 uGK
@@ -156425,9 +156590,9 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
-wdE
+rxV
+rxV
 jJi
 ipc
 vHM
@@ -156682,9 +156847,9 @@ hHc
 hHc
 kAI
 hHc
-hHc
+rDV
 jJi
-rxV
+qma
 jJi
 mNy
 mcK
@@ -171361,9 +171526,9 @@ sZD
 xBf
 rAq
 rAq
+nYN
 rAq
 rAq
-dSM
 rAq
 lTv
 gRD
@@ -171864,7 +172029,7 @@ jzd
 jzd
 dhf
 dhf
-jzd
+yeS
 jzd
 jzd
 jzd

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -90353,7 +90353,7 @@ pKF
 pKF
 pKF
 kAo
-cJU
+kAo
 pKF
 cCZ
 cCZ

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -9522,6 +9522,7 @@
 /area/station/commons/locker)
 "dzB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
 /turf/open/floor/bronze,
 /area/station/service/library)
 "dzO" = (
@@ -17812,6 +17813,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/bronze,
 /area/station/service/library)
 "gGb" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -126,6 +126,10 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
+"acO" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "acP" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6221,7 +6225,7 @@
 /obj/structure/chair/sofa/bench/tram/right{
 	dir = 4
 	},
-/obj/item/radio/intercom/prison/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
 "cqh" = (
@@ -6505,7 +6509,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
 "cuy" = (
-/obj/item/radio/intercom/prison/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "cuz" = (
@@ -12023,6 +12027,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"eyR" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "eyX" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -15325,7 +15333,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "fLs" = (
-/obj/item/radio/intercom/prison/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
 "fLO" = (
@@ -18963,7 +18971,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "hdy" = (
-/obj/item/radio/intercom/prison/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hdC" = (
@@ -19152,7 +19160,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/item/radio/intercom/prison/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/aft)
 "hhy" = (
@@ -25449,7 +25457,7 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
 "jIv" = (
-/obj/item/radio/intercom/prison/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
 "jIE" = (
@@ -27388,6 +27396,10 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"ksG" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/lesser)
 "ksO" = (
 /obj/structure/barricade/wooden,
 /turf/open/misc/asteroid,
@@ -27421,7 +27433,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
-/obj/item/radio/intercom/prison/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kty" = (
@@ -30030,7 +30042,7 @@
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
 "lqC" = (
-/obj/item/radio/intercom/prison/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lqF" = (
@@ -39161,7 +39173,7 @@
 	},
 /area/station/ai_monitored/command/nuke_storage)
 "oGl" = (
-/obj/item/radio/intercom/prison/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
 "oGo" = (
@@ -47524,7 +47536,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "rML" = (
-/obj/item/radio/intercom/prison/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rMY" = (
@@ -53348,7 +53360,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/prison/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "tYa" = (
@@ -55463,7 +55475,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/item/radio/intercom/prison/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "uTg" = (
@@ -60416,7 +60428,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/item/radio/intercom/prison/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "wGP" = (
@@ -159963,7 +159975,7 @@ htY
 mMI
 pco
 htY
-htY
+eyR
 dwX
 phJ
 cLQ
@@ -173107,7 +173119,7 @@ dfk
 mvF
 eZB
 wSw
-uHX
+ksG
 eQc
 eZB
 ybs
@@ -178508,7 +178520,7 @@ lrb
 bkm
 eZB
 rnO
-avN
+acO
 unQ
 dET
 lzy

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -10862,10 +10862,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "dZR" = (
@@ -20796,11 +20796,11 @@
 /turf/open/floor/plating,
 /area/station/security/processing)
 "hTu" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "hTA" = (
@@ -28373,7 +28373,8 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Cold Room"
 	},
-/obj/item/radio/intercom/prison/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "kMq" = (
@@ -29368,6 +29369,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "leE" = (
@@ -40826,10 +40829,10 @@
 /area/station/hallway/primary/central/aft)
 "pom" = (
 /obj/structure/statue/snow/snowman,
-/obj/machinery/light/cold/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pon" = (
@@ -43121,14 +43124,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qkU" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "qlm" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -18021,6 +18021,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "gJS" = (
@@ -39819,6 +39820,7 @@
 "oTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "oTW" = (


### PR DESCRIPTION
Maintenance was extremely dark. Most station maintenance have at least *some* light in it. I have added some small lights, particularly next to door. I have also added some lights to non maintenance areas.

I have also tweaked some maintenance areas around the garden to break up long corridors.

I also fixed a large amount of intercoms that were incorrectly one way prison intercoms. Sorry about that!

Also fixes the garden's wires being  disconnected.