### PR TITLE
Biodome: Decals and Gardens Update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -184,8 +184,10 @@
 /area/station/service/abandoned_gambling_den)
 "adG" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "adK" = (
 /obj/machinery/duct,
@@ -845,7 +847,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/disposal/incinerator)
 "aoF" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/end{
@@ -1074,13 +1075,13 @@
 /turf/open/floor/iron/herringbone,
 /area/station/engineering/atmos/mix)
 "asX" = (
-/obj/machinery/modular_computer/preset/id{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/machinery/pdapainter/engineering,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "atd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1118,7 +1119,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "atv" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -1223,10 +1223,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome)
-"avb" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "avp" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -1341,16 +1337,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
-"axi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "axt" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/west,
@@ -1516,7 +1502,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "aAx" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -1633,6 +1619,9 @@
 	name = "Engineering Lockdown";
 	pixel_x = 6;
 	req_access = list("engineering")
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
@@ -1831,7 +1820,6 @@
 /area/station/biodome/fore)
 "aFZ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -1848,7 +1836,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "aGm" = (
 /obj/structure/railing{
 	dir = 8
@@ -2456,12 +2444,13 @@
 /area/station/command/heads_quarters/hos)
 "aRm" = (
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/modular_computer/preset/cargochat/engineering{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "aRs" = (
 /obj/machinery/air_sensor/plasma_tank,
@@ -2481,6 +2470,11 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"aRR" = (
+/obj/structure/curtain/bounty/start_closed,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "aSa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -2686,6 +2680,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"aVF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "aVG" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central/aft)
@@ -3163,10 +3164,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "bgm" = (
@@ -3193,7 +3194,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "bhl" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -3223,7 +3224,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "big" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -3513,6 +3514,11 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/project)
+"bmv" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "bmy" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3668,7 +3674,7 @@
 /area/station/commons/dorms)
 "bqj" = (
 /turf/closed/wall/r_wall,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "bqo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -3827,16 +3833,10 @@
 /obj/structure/sink/directional/south,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"bua" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+"bui" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"bui" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "buj" = (
@@ -3949,7 +3949,7 @@
 "bwr" = (
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "bwz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3981,7 +3981,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "bwO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/catwalk_floor,
@@ -4657,9 +4657,6 @@
 "bKT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bLh" = (
@@ -4787,9 +4784,8 @@
 	pixel_x = -1
 	},
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "bNO" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5515,6 +5511,9 @@
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/security/engine,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "caT" = (
@@ -5539,7 +5538,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "cbR" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -5770,7 +5768,7 @@
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cfU" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5985,13 +5983,6 @@
 /obj/item/stock_parts/micro_laser/high,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"ciS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/central/greater)
 "ciW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/iron,
@@ -6319,11 +6310,11 @@
 /area/station/biodome/aft)
 "cqH" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cqR" = (
@@ -6383,7 +6374,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "crU" = (
@@ -6665,8 +6655,10 @@
 /area/station/science/research)
 "cwf" = (
 /obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "cwg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6677,7 +6669,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cwi" = (
 /obj/structure/girder/displaced,
 /obj/effect/turf_decal/siding/brown,
@@ -7056,7 +7048,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cBO" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet1";
@@ -7250,6 +7242,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"cFg" = (
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/structure/curtain/bounty/start_closed,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "cFj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7542,7 +7540,7 @@
 	id = "ceprivacy";
 	name = "Privacy Shutters Control"
 	},
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cJU" = (
@@ -7713,7 +7711,7 @@
 "cMV" = (
 /obj/item/trash/ready_donk,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -7931,7 +7929,7 @@
 	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cSj" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/purple{
@@ -8013,7 +8011,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cTX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -8031,7 +8029,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "cUf" = (
 /obj/machinery/door/airlock/external{
 	space_dir = 8
@@ -8835,7 +8833,7 @@
 "diO" = (
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "diS" = (
 /obj/machinery/mining_weather_monitor/directional/south,
 /turf/open/floor/iron,
@@ -8901,7 +8899,7 @@
 "dkm" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "dky" = (
 /obj/machinery/camera/autoname/directional/west{
 	c_tag = "Storage - Tech"
@@ -9116,7 +9114,7 @@
 /obj/item/screwdriver,
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "doz" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
@@ -9173,18 +9171,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "dpZ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/cable,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "dqs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9647,6 +9639,11 @@
 	dir = 8
 	},
 /area/station/commons/fitness)
+"dAk" = (
+/obj/item/storage/fish_case/random/freshwater,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/department/engine)
 "dAm" = (
 /obj/machinery/mass_driver/trash{
 	dir = 4
@@ -9817,7 +9814,10 @@
 /area/station/maintenance/department/science)
 "dCI" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "dCO" = (
 /turf/closed/wall/r_wall,
@@ -10514,7 +10514,10 @@
 /area/station/hallway/primary/starboard)
 "dRm" = (
 /obj/machinery/photocopier,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "dRn" = (
 /obj/machinery/modular_computer/preset/cargochat/service{
@@ -10598,7 +10601,7 @@
 /obj/item/trash/energybar,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "dSl" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Service Hall Roof"
@@ -11069,12 +11072,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "eaR" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ebh" = (
@@ -11828,13 +11832,14 @@
 /area/station/engineering/storage/tech)
 "etf" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/microwave/engineering/cell_included,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "etl" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -12626,9 +12631,11 @@
 /area/station/ai_monitored/security/armory)
 "eIf" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "eIi" = (
 /obj/item/food/cookie/sugar/spookyskull,
@@ -12685,7 +12692,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "eJm" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -12895,8 +12902,11 @@
 	fax_name = "Engineering Lobby";
 	name = "Engineering Lobby Fax Machine"
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "eMF" = (
 /obj/structure/cable,
@@ -12927,8 +12937,8 @@
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/basic/parrot/poly,
 /obj/machinery/incident_display/delam/directional/north,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "eMY" = (
 /turf/closed/wall/mineral/wood,
@@ -13171,7 +13181,7 @@
 	name = "Maintenance Hatch"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "eQu" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -13259,7 +13269,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "eRR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
@@ -13307,6 +13317,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/server)
+"eSD" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/department/engine)
 "eSK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13359,7 +13375,6 @@
 /turf/open/floor/bronze,
 /area/station/service/library)
 "eTW" = (
-/obj/machinery/duct,
 /obj/machinery/button/elevator/directional/east{
 	id = "biodome_engie_lift"
 	},
@@ -13539,6 +13554,11 @@
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"eYD" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "eYF" = (
 /obj/structure/chair{
 	dir = 4
@@ -13866,7 +13886,7 @@
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -13909,7 +13929,7 @@
 /obj/effect/spawner/random/structure/table,
 /obj/item/food/fried_blood_sausage,
 /turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "feT" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/iron,
@@ -13986,7 +14006,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fgL" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -14176,7 +14196,11 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /obj/item/rcl/pre_loaded,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/siding/thinplating_new/light/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "fkk" = (
 /obj/structure/disposalpipe/segment{
@@ -14248,6 +14272,13 @@
 /obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"flX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "fmx" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -14475,7 +14506,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fqK" = (
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
@@ -14504,6 +14535,10 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/greater)
+"frr" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "frs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/bottle/basic_buffer{
@@ -14554,14 +14589,6 @@
 "frW" = (
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"fsn" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "fss" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -14782,7 +14809,6 @@
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "fwm" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14968,7 +14994,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fAe" = (
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
@@ -15111,7 +15137,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/janitor,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fBY" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/captain,
@@ -15432,7 +15458,7 @@
 "fKB" = (
 /obj/item/reagent_containers/cup/bucket/wooden,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fKF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -15484,7 +15510,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fLl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -15563,6 +15589,13 @@
 /obj/structure/sign/warning/firing_range/directional/south,
 /turf/open/floor/fake_dirt/dark,
 /area/station/science/research)
+"fMf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "fMp" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
@@ -16007,14 +16040,19 @@
 	pixel_y = 3
 	},
 /obj/item/book/manual/wiki/engineering_construction,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "fTb" = (
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "fTd" = (
 /obj/machinery/conveyor{
@@ -16089,7 +16127,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fUv" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood,
@@ -16338,6 +16376,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"fYn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/ce)
 "fYo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -16366,7 +16410,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "fYG" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16415,7 +16458,7 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/item/food/hotdog,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "fZT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16856,7 +16899,6 @@
 /area/station/biodome/aft)
 "giK" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "gjb" = (
@@ -17007,11 +17049,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"gmi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/terracotta,
-/area/station/hallway/secondary/construction/engineering)
 "gmo" = (
 /obj/effect/spawner/random/entertainment/coin,
 /turf/open/misc/asteroid,
@@ -17091,7 +17128,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
@@ -17105,7 +17142,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gnZ" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -17208,7 +17244,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "gqX" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -17261,7 +17296,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gsf" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -17454,10 +17489,10 @@
 /area/station/engineering/storage/tech)
 "gvg" = (
 /obj/item/banner/engineering/mundane,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gvj" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -17487,7 +17522,7 @@
 	reagent_id = /datum/reagent/water
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gwg" = (
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
@@ -17829,7 +17864,7 @@
 "gCQ" = (
 /obj/item/shovel/spade,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gCY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17840,7 +17875,7 @@
 "gDm" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gDp" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -18022,7 +18057,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "gGu" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18278,7 +18312,7 @@
 "gLc" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gLk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18333,7 +18367,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "gMu" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
@@ -18671,7 +18705,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
 "gTu" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -18888,7 +18921,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "gYi" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19036,7 +19068,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "hbf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -19297,10 +19329,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"hfR" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "hfV" = (
 /obj/structure/table/wood/fancy,
 /obj/item/plate,
@@ -19343,14 +19371,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/station/asteroid)
-"hgT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/terracotta,
-/area/station/hallway/secondary/construction/engineering)
 "hhr" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Medbay Delivery";
@@ -19605,7 +19625,7 @@
 	dir = 6
 	},
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "hlL" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/wood,
@@ -20060,7 +20080,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "hwf" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -20758,11 +20777,19 @@
 /obj/item/storage/bag/tray/cafeteria,
 /turf/open/floor/carpet/donk,
 /area/station/security/prison/mess)
+"hLe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "hLk" = (
 /obj/structure/rack,
 /obj/item/food/meat/slab/human/mutant/skeleton,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "hLl" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -21142,7 +21169,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "hUq" = (
 /obj/structure/table,
 /obj/item/pai_card,
@@ -21438,12 +21465,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
-"hYS" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/storage)
 "hYU" = (
 /obj/item/skub{
 	name = "medicinal skub"
@@ -21892,6 +21913,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
+"igH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/sign/departments/engineering/directional/south,
+/turf/open/floor/grass,
+/area/station/biodome/aft)
 "igQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21963,11 +21991,9 @@
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "ihE" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "ihI" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -22174,6 +22200,9 @@
 	pixel_x = 24
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "imZ" = (
@@ -22291,7 +22320,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ioR" = (
 /obj/structure/sign/directions/science/directional/south{
 	dir = 1;
@@ -22309,7 +22338,7 @@
 "ioS" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ipc" = (
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/grass,
@@ -22504,7 +22533,7 @@
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "itE" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/iron/dark/telecomms,
@@ -22986,6 +23015,7 @@
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "iDh" = (
@@ -23022,6 +23052,11 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"iEm" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "iEq" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -23152,7 +23187,7 @@
 "iGQ" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "iHt" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Chapel Office"
@@ -23207,6 +23242,9 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
+"iIl" = (
+/turf/closed/wall,
+/area/station/maintenance/department/engine)
 "iIH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23360,7 +23398,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "iLB" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -23465,7 +23503,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "iOb" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -23546,6 +23583,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"iQx" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "iQz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23576,6 +23616,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"iRd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "iRf" = (
 /obj/structure/chair{
 	dir = 8
@@ -23721,7 +23768,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "iUP" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -23760,7 +23806,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/central/greater)
 "iVx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23898,10 +23944,8 @@
 /area/station/maintenance/starboard/central)
 "iYy" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "iYB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24045,7 +24089,7 @@
 /obj/machinery/duct,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jaT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24093,10 +24137,8 @@
 /obj/item/reagent_containers/pill/patch/aiuri,
 /obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 10
-	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "jcb" = (
@@ -24538,7 +24580,10 @@
 /obj/structure/cable,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/empty,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "jjV" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
@@ -24598,7 +24643,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jll" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
@@ -24625,7 +24670,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jmc" = (
 /obj/machinery/door/airlock/external{
 	space_dir = 8
@@ -24742,7 +24787,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jpi" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Lab"
@@ -25082,7 +25127,7 @@
 /obj/effect/spawner/random/structure/table,
 /obj/item/food/grown/watermelon,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jvj" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/white,
@@ -25337,7 +25382,6 @@
 /obj/item/trash/can{
 	pixel_x = -8
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage{
 	pixel_x = -6;
 	spawn_loot_count = 2;
@@ -25348,7 +25392,10 @@
 	spawn_loot_count = 2;
 	spawn_random_offset = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "jAI" = (
 /obj/machinery/vending/cigarette,
@@ -25858,7 +25905,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "jKA" = (
 /obj/item/circuitboard/computer/operating,
 /turf/open/floor/plating,
@@ -25902,7 +25949,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/department/engine)
 "jLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26847,7 +26894,6 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/hydroponics)
 "keU" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Equipment"
 	},
@@ -27086,13 +27132,6 @@
 /obj/structure/falsewall/sandstone,
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
-"kjb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/terracotta,
-/area/station/hallway/secondary/construction/engineering)
 "kjj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/plumbing/synthesizer/soda{
@@ -27384,7 +27423,6 @@
 /area/space)
 "kmT" = (
 /obj/structure/cable/multilayer/connected,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -28113,6 +28151,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"kzE" = (
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "kzF" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -28351,11 +28395,13 @@
 /area/station/maintenance/department/security)
 "kDO" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Engineering Lobby"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "kDP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28430,6 +28476,13 @@
 /obj/structure/sign/warning/gas_mask,
 /turf/closed/wall,
 /area/station/cargo/storage)
+"kFA" = (
+/obj/effect/spawner/random/engineering/tank,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/department/engine)
 "kFI" = (
 /turf/closed/wall/mineral/wood,
 /area/station/service/hydroponics)
@@ -28515,10 +28568,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "kHI" = (
@@ -28619,7 +28672,7 @@
 "kIT" = (
 /obj/item/binoculars,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "kIW" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8;
@@ -28842,6 +28895,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/station/cargo/office)
+"kMB" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/bounty/start_closed,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction/engineering)
 "kMD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28884,7 +28942,7 @@
 /obj/item/stack/sheet/leather,
 /obj/item/knife,
 /turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "kMW" = (
 /obj/structure/window/reinforced/spawner/directional/south{
 	pixel_y = 2
@@ -28906,6 +28964,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"kNh" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/engine)
 "kNm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/mecha_wreckage/ripley,
@@ -28990,9 +29052,8 @@
 "kOT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "kOW" = (
@@ -29105,7 +29166,7 @@
 "kQH" = (
 /obj/item/chair/stool/bamboo,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "kQJ" = (
 /turf/open/floor/engine/hull,
 /area/station/asteroid)
@@ -29668,12 +29729,6 @@
 /obj/structure/statue/snow/snowman,
 /turf/open/misc/asteroid/snow/airless,
 /area/station/asteroid)
-"lcF" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/terracotta,
-/area/station/hallway/secondary/construction/engineering)
 "lcH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29758,7 +29813,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "lee" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/spawner/random/clothing/wardrobe_closet,
@@ -29883,7 +29938,10 @@
 /area/station/engineering/atmos)
 "lfG" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lfX" = (
 /obj/structure/disposalpipe/segment,
@@ -29923,20 +29981,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"lgL" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/item/storage/fish_case/random/freshwater,
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/central/greater)
 "lgW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "lhm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30139,7 +30190,7 @@
 "lkK" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "lkP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30700,7 +30751,12 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/stamp/head/ce,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "lvB" = (
 /obj/structure/disposalpipe/segment,
@@ -30799,7 +30855,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lxd" = (
-/obj/machinery/duct,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -31411,6 +31466,14 @@
 	},
 /turf/open/floor/noslip,
 /area/station/science/xenobiology/hallway)
+"lFT" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "lFU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31572,7 +31635,10 @@
 "lIk" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
+"lIo" = (
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/ce)
 "lIK" = (
 /obj/structure/holosign/barrier/atmos/leaf{
 	dir = 8
@@ -31596,6 +31662,9 @@
 /obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"lIV" = (
+/turf/open/floor/iron/terracotta,
+/area/station/biodome/aft)
 "lJa" = (
 /obj/item/picket_sign,
 /turf/open/misc/asteroid,
@@ -31607,6 +31676,7 @@
 "lJl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "lJx" = (
@@ -32072,7 +32142,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "lTG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -32199,7 +32269,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "lVd" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -32413,11 +32483,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lYf" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "lYh" = (
@@ -32592,7 +32664,6 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mbr" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32619,7 +32690,7 @@
 "mby" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "mbG" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -32697,7 +32768,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "mdd" = (
 /obj/structure/railing{
 	dir = 10
@@ -32812,6 +32883,10 @@
 "meJ" = (
 /turf/open/openspace,
 /area/station/cargo/miningdock)
+"meS" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "meU" = (
 /turf/closed/wall/r_wall/fakewood{
 	color = "#a9734f"
@@ -32933,7 +33008,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mgY" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
@@ -33024,7 +33098,7 @@
 "miF" = (
 /obj/structure/cable,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "miI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -33098,7 +33172,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "mjF" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -33221,7 +33294,7 @@
 "mmz" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "mmF" = (
 /obj/structure/flora/rock/pile/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33548,7 +33621,6 @@
 /area/station/engineering/engine_smes)
 "msD" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
@@ -33590,7 +33662,7 @@
 	},
 /obj/machinery/light/small/red/dim/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "mtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33626,7 +33698,7 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "muW" = (
 /obj/structure/table,
 /obj/item/taperecorder{
@@ -33732,7 +33804,6 @@
 /area/station/security/prison)
 "mww" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mwz" = (
@@ -33877,7 +33948,10 @@
 /area/station/security/brig/entrance)
 "mzv" = (
 /obj/machinery/vending/engivend,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mzW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34000,14 +34074,14 @@
 /obj/item/pen,
 /turf/open/floor/plating,
 /area/station/asteroid)
-"mCu" = (
-/obj/structure/cable,
+"mCv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/obj/structure/cable,
+/turf/open/floor/iron/terracotta,
+/area/station/hallway/secondary/construction/engineering)
 "mCS" = (
 /obj/machinery/camera/motion/directional/west{
 	network = list("aicore");
@@ -34224,9 +34298,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "mHU" = (
@@ -34350,7 +34421,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "mKn" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
@@ -34387,6 +34458,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"mLj" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mLm" = (
 /turf/closed/wall,
 /area/station/hallway/primary/port)
@@ -34580,7 +34655,6 @@
 /area/station/service/hydroponics)
 "mPn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -34808,8 +34882,10 @@
 /area/station/maintenance/aft/upper)
 "mTt" = (
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "mTu" = (
 /turf/closed/wall,
@@ -35027,7 +35103,10 @@
 /area/station/science/cytology)
 "mYz" = (
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mYF" = (
 /obj/machinery/computer/security/labor{
@@ -35182,6 +35261,18 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nbO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "nbP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35211,7 +35302,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -35410,7 +35500,7 @@
 "neM" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "neN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/freezer/cream_pie,
@@ -36014,6 +36104,10 @@
 /obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"nqx" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/department/engine)
 "nqE" = (
 /obj/machinery/restaurant_portal/restaurant,
 /obj/effect/turf_decal/weather/dirt{
@@ -36217,6 +36311,7 @@
 /area/station/commons/toilet/auxiliary)
 "nvk" = (
 /obj/effect/decal/cleanable/fuel_pool,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "nvv" = (
@@ -36742,7 +36837,7 @@
 "nEB" = (
 /mob/living/basic/amoung,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "nEO" = (
 /obj/item/gun/energy/recharge/kinetic_accelerator{
 	recharge_time = 32;
@@ -36802,10 +36897,9 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain)
 "nFE" = (
-/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/turf/closed/wall,
+/area/station/maintenance/department/engine)
 "nFT" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36825,10 +36919,11 @@
 /area/station/engineering/supermatter/room)
 "nGl" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "nGo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -36864,8 +36959,8 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - CE's Office"
 	},
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "nGR" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -37073,8 +37168,10 @@
 /obj/machinery/modular_computer/preset/civilian{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "nLi" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -37862,12 +37959,14 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "oac" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/computer/department_orders/engineering{
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "oae" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
@@ -38148,12 +38247,13 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "oeS" = (
-/obj/machinery/disposal/bin,
 /obj/item/radio/intercom/directional/south,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/modular_computer/preset/id{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "oeT" = (
@@ -38169,7 +38269,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "oeZ" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39083,7 +39182,7 @@
 "owr" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "owx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/green,
@@ -39373,6 +39472,10 @@
 /obj/item/computer_disk/engineering,
 /obj/machinery/keycard_auth/directional/east,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "oBd" = (
@@ -39455,7 +39558,6 @@
 /area/station/medical/pharmacy)
 "oCD" = (
 /obj/structure/cable/layer3,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -39600,14 +39702,13 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "oFG" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -39662,6 +39763,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"oGD" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "oGJ" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -39850,6 +39955,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/grass,
 /area/station/biodome/aft)
 "oKk" = (
@@ -39954,11 +40060,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
-"oMf" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "oMn" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/light/floor,
@@ -40133,7 +40234,6 @@
 	name = "Engineering Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oPo" = (
@@ -40578,9 +40678,11 @@
 /turf/open/floor/grass,
 /area/station/biodome)
 "oZo" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "oZp" = (
 /obj/structure/stairs/west,
@@ -40718,7 +40820,7 @@
 "pbw" = (
 /obj/effect/spawner/random/trash/mopbucket,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pbx" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
@@ -40859,7 +40961,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/turbine_computer{
@@ -40915,6 +41017,13 @@
 	},
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
+"peO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "peP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41494,6 +41603,23 @@
 "pov" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
+"poC" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "ppl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -41582,6 +41708,10 @@
 /obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"prG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "prX" = (
 /obj/machinery/requests_console/directional/south{
 	name = "Cargo Bay Requests Console"
@@ -41656,6 +41786,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"ptw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "ptx" = (
 /obj/structure/table/wood,
 /obj/item/folder{
@@ -41766,7 +41901,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pwa" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -42038,7 +42173,7 @@
 "pAD" = (
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pAJ" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -42083,6 +42218,9 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"pCc" = (
+/turf/open/water/jungle/biodome,
+/area/station/maintenance/department/engine)
 "pCf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table/reinforced,
@@ -42251,6 +42389,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"pFP" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "pFX" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/directional/east{
@@ -42428,7 +42573,7 @@
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pJe" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -43184,7 +43329,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "pYM" = (
 /obj/machinery/holopad,
 /obj/item/radio/intercom/directional/south,
@@ -43233,6 +43378,9 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"pZS" = (
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/engine)
 "qav" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -43468,7 +43616,7 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "qeg" = (
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qen" = (
@@ -44054,9 +44202,11 @@
 /turf/open/misc/dirt/jungle/wasteland/biodome,
 /area/station/maintenance/central/greater)
 "qnV" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "qnX" = (
@@ -44527,6 +44677,8 @@
 "qxo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "qxr" = (
@@ -44700,7 +44852,7 @@
 "qAz" = (
 /obj/item/melee/skateboard/improvised,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "qAG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44804,6 +44956,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qCw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qCz" = (
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
@@ -44879,7 +45037,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -44912,10 +45069,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "qEh" = (
@@ -45072,7 +45229,6 @@
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/station/engineering/atmos/project)
 "qHm" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -45331,7 +45487,7 @@
 "qMs" = (
 /obj/effect/spawner/random/clothing/pirate_or_bandana,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "qMz" = (
 /obj/structure/railing{
 	dir = 8
@@ -46711,7 +46867,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rlh" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46945,10 +47100,8 @@
 "roG" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 6
-	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "roK" = (
@@ -47149,7 +47302,7 @@
 "rsU" = (
 /obj/machinery/light/small/directional,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "rsW" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -47200,7 +47353,7 @@
 "rtB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "rtD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Vault Access"
@@ -47404,6 +47557,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "rxs" = (
@@ -47505,7 +47659,7 @@
 	},
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ryG" = (
 /obj/structure/table,
 /obj/item/food/donut/plain{
@@ -47778,7 +47932,6 @@
 "rEs" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47907,7 +48060,7 @@
 "rGU" = (
 /obj/machinery/microwave,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "rGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -48052,7 +48205,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "rKd" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48285,7 +48437,6 @@
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "rQl" = (
-/obj/machinery/pdapainter/engineering,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/button/door/directional/west{
 	id = "atmos";
@@ -48305,8 +48456,12 @@
 	req_access = list("engineering")
 	},
 /obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 5
+	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "rQm" = (
@@ -48450,7 +48605,7 @@
 "rSG" = (
 /obj/effect/spawner/random/structure/chair_flipped,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "rSI" = (
 /obj/machinery/ticket_machine/directional/west,
 /obj/structure/disposalpipe/segment{
@@ -48603,7 +48758,10 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "rVi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48623,7 +48781,7 @@
 "rVu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/department/engine)
 "rVy" = (
 /obj/structure/sign/departments/maint/directional/north,
 /turf/open/floor/iron,
@@ -48636,7 +48794,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "rVH" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -48913,6 +49070,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"sak" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "saK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -48989,13 +49152,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/cargo/storage)
-"scl" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/central/greater)
 "scm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -49095,7 +49251,7 @@
 "ser" = (
 /obj/structure/statue/bone/skull,
 /turf/open/water/jungle/biodome,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "seM" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -49209,7 +49365,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "shb" = (
 /obj/item/reagent_containers/cup/glass/bottle/bottleofnothing,
 /turf/open/floor/wood,
@@ -49239,7 +49395,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Engine Entrance"
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "shZ" = (
@@ -49646,6 +49801,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"sqm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "sqo" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -49699,8 +49858,13 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "srz" = (
 /obj/machinery/camera/directional/east{
@@ -50005,9 +50169,9 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/primary/central/aft)
 "sxC" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/item/clothing/head/cone,
 /obj/structure/sign/warning/secure_area/directional/south,
+/obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "sxR" = (
@@ -50250,7 +50414,7 @@
 "sBS" = (
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "sBZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/lime,
@@ -50453,7 +50617,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "sHd" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50681,7 +50844,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "sKE" = (
 /obj/machinery/computer/records/security,
 /obj/machinery/requests_console/directional/north{
@@ -51392,7 +51555,6 @@
 /area/station/maintenance/central/greater)
 "sZb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
@@ -51896,7 +52058,7 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "tiN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52244,7 +52406,7 @@
 "tny" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "tnA" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -52267,6 +52429,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"toL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/engine)
 "toN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -52635,8 +52808,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "twr" = (
@@ -52886,6 +53059,9 @@
 	},
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "tBl" = (
@@ -53240,7 +53416,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "tHs" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
@@ -53372,7 +53548,6 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tKg" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -53391,8 +53566,10 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "tKt" = (
 /obj/structure/transit_tube/diagonal/crossing{
@@ -54155,7 +54332,7 @@
 "ubi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ubv" = (
 /obj/structure/sign/flag/pride{
 	pixel_x = 32
@@ -54202,7 +54379,7 @@
 "ucp" = (
 /obj/item/stack/sheet/leather,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ucq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -54417,7 +54594,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "ugI" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54515,7 +54691,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
 "ukO" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54796,7 +54971,6 @@
 /area/station/service/hydroponics/garden)
 "upK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	name = "sorting disposal pipe (Atmospherics)"
@@ -54954,6 +55128,9 @@
 /area/station/security/lockers)
 "usC" = (
 /obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "usE" = (
@@ -55072,7 +55249,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "uuK" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/camera/directional/north{
@@ -55119,7 +55296,6 @@
 /area/station/commons/dorms)
 "uwm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -55166,7 +55342,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "uxT" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -55466,7 +55641,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uEc" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -55661,7 +55835,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "uIr" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating/reinforced,
@@ -55996,7 +56170,7 @@
 "uPM" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "uPN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56042,7 +56216,7 @@
 /obj/machinery/light/small/red/dim/directional/south,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "uQI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mail Room"
@@ -56414,16 +56588,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"uYT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "uYV" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 14;
@@ -56865,6 +57029,18 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"vgD" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "vhi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57212,7 +57388,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "vnH" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/carpet/orange,
@@ -57264,6 +57440,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
 "vop" = (
@@ -57375,9 +57552,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "vqS" = (
-/obj/structure/flora/bush/jungle/c/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/grass,
 /area/station/biodome/aft)
@@ -57493,8 +57669,8 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
 "vtC" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/structure/sign/clock/directional/north,
+/obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vtH" = (
@@ -57880,7 +58056,7 @@
 "vBJ" = (
 /obj/item/food/bait/worm,
 /turf/open/misc/asteroid/dug,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "vBW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -57993,7 +58169,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "vDX" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -58225,7 +58401,6 @@
 /area/station/hallway/primary/starboard)
 "vHm" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
@@ -58622,10 +58797,6 @@
 /obj/effect/turf_decal/trimline/dark_red/corner,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"vOY" = (
-/obj/machinery/duct,
-/turf/open/floor/iron/terracotta,
-/area/station/hallway/secondary/construction/engineering)
 "vPi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -58900,7 +59071,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "vUr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59025,7 +59196,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "vVY" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
@@ -59447,7 +59618,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wfp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -59687,7 +59858,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wjE" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59875,7 +60045,6 @@
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
 "wmc" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -60061,7 +60230,7 @@
 "wnY" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wob" = (
 /obj/structure/table/reinforced,
 /obj/structure/displaycase/forsale/kitchen,
@@ -60180,9 +60349,8 @@
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wpW" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -60348,6 +60516,11 @@
 "wtu" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
+/area/station/biodome/aft)
+"wtE" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/grass,
 /area/station/biodome/aft)
 "wtM" = (
 /obj/machinery/holopad,
@@ -60529,6 +60702,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
+"wxg" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wxi" = (
 /turf/open/floor/glass,
 /area/station/biodome)
@@ -60753,12 +60930,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
-"wzY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/water/jungle/biodome,
-/area/station/maintenance/central/greater)
 "wAh" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -60794,7 +60965,6 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "wAL" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60808,7 +60978,7 @@
 	},
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wAS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -61242,7 +61412,7 @@
 "wIj" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wIk" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/door/window/left/directional/west{
@@ -61282,7 +61452,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "wJn" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -61425,7 +61594,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "wNb" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/item/toy/cattoy,
@@ -61468,9 +61637,8 @@
 /area/station/commons/storage/emergency/starboard)
 "wNI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -61675,6 +61843,10 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"wQS" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wRg" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -61805,7 +61977,6 @@
 	},
 /area/station/medical/morgue)
 "wTs" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -62737,7 +62908,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "xmW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -62963,7 +63134,7 @@
 "xrY" = (
 /obj/item/burner/oil,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "xsa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -63023,10 +63194,10 @@
 /turf/open/floor/grass,
 /area/station/biodome)
 "xtD" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "xtK" = (
@@ -63052,10 +63223,12 @@
 /area/station/science/research)
 "xua" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/structure/sign/calendar/directional/north,
 /obj/machinery/coffeemaker,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "xub" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -63089,7 +63262,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "xuP" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /obj/effect/spawner/random/maintenance/two,
@@ -63197,10 +63370,9 @@
 	},
 /obj/structure/cable,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "xwI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63376,7 +63548,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "xAa" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63648,7 +63819,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xFa" = (
-/obj/effect/turf_decal/tile/red/diagonal_edge,
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63694,7 +63864,10 @@
 /area/station/construction)
 "xFy" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xFA" = (
 /obj/structure/cable,
@@ -63861,6 +64034,9 @@
 "xII" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "xIJ" = (
@@ -64045,7 +64221,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "xLu" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64450,6 +64625,11 @@
 /area/station/service/kitchen/coldroom)
 "xSx" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "xSH" = (
@@ -64650,7 +64830,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xVL" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -64683,7 +64862,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "xWn" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
@@ -64695,6 +64874,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"xWG" = (
+/obj/structure/flora/bush/large/style_3,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/grass,
+/area/station/biodome/aft)
 "xWK" = (
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
@@ -65032,7 +65219,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/area/station/maintenance/department/engine)
 "ydd" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -65280,10 +65467,12 @@
 /obj/item/storage/medkit/fire{
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "yhZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86792,8 +86981,8 @@ hNy
 hNy
 hNy
 hNy
-oAe
-gRN
+iIl
+iQx
 bqj
 cCZ
 cCZ
@@ -87044,12 +87233,12 @@ bGS
 ylB
 qtg
 bqj
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
 fUu
 bqj
 bqj
@@ -87303,11 +87492,11 @@ aGA
 jle
 lVc
 rSG
-gRN
-ruE
-gRN
+iQx
+sak
+iQx
 diO
-gRN
+iQx
 neM
 bqj
 cCZ
@@ -87557,16 +87746,16 @@ pov
 gfv
 sXc
 gfv
-oAe
+iIl
 vUn
-gRN
-gRN
-ruE
-gRN
+iQx
+iQx
+sak
+iQx
 gDm
-gRN
+iQx
 sKC
-oAe
+iIl
 hNy
 cCZ
 cCZ
@@ -87814,16 +88003,16 @@ nZy
 pel
 rdw
 nwe
-oAe
+iIl
 vUn
-gRN
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
+iQx
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
 hNy
 hNy
 hNy
@@ -88071,16 +88260,16 @@ nZy
 iQm
 oso
 aaP
-oAe
+iIl
 vUn
-gRN
-oAe
-oAe
+iQx
+iIl
+iIl
 itq
 ucp
 uPM
 feP
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -88328,16 +88517,16 @@ pov
 iQm
 oso
 lax
-oAe
+iIl
 pvY
-aPT
+frr
 fgu
-jUS
+lFT
 ubi
 pJc
-uAp
+wQS
 rsU
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -88585,16 +88774,16 @@ pov
 iQm
 ssc
 jHc
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
 lgW
-oAe
+iIl
 rGU
 rtB
 ucp
 rtB
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -88616,7 +88805,7 @@ vtU
 hNy
 hNy
 led
-fTB
+pZS
 qMs
 hNy
 hNy
@@ -88844,14 +89033,14 @@ oso
 yfd
 mWP
 kty
-oAe
+iIl
 lgW
-oAe
+iIl
 fKB
 kMU
 bwr
 jvd
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -88874,8 +89063,8 @@ hNy
 hNy
 dov
 qAz
-fTB
-gRN
+pZS
+iQx
 hNy
 hNy
 cCZ
@@ -89101,14 +89290,14 @@ tlP
 tZn
 bRw
 agt
-oAe
+iIl
 lgW
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
 hNy
 kQH
 kQH
@@ -89130,9 +89319,9 @@ hNy
 hNy
 hNy
 sgV
-gRN
-gRN
-gRN
+iQx
+iQx
+iQx
 hNy
 hNy
 hNy
@@ -89355,22 +89544,22 @@ dMC
 boO
 iAA
 gAf
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
 eJi
 eRG
-aPT
-kyF
-oAe
+frr
+kzE
+iIl
 ioS
-oAe
+iIl
 hNy
-fTB
-fTB
-fTB
-fTB
+pZS
+pZS
+pZS
+pZS
 gCQ
 xrY
 hNy
@@ -89610,34 +89799,34 @@ vco
 vco
 vco
 vco
-oAe
+iIl
 bhb
-oAe
+iIl
 oFB
 sKC
 mcV
-cAe
-oAe
-oAe
-oAe
-oAe
+sqm
+iIl
+iIl
+iIl
+iIl
 dkm
-oAe
-oAe
-fTB
-oAe
-oAe
+iIl
+iIl
+pZS
+iIl
+iIl
 hlC
 vBJ
-fTB
+pZS
 pbw
-fTB
-oAe
-oAe
-oAe
-oAe
-oAe
-fTB
+pZS
+iIl
+iIl
+iIl
+iIl
+iIl
+pZS
 iGQ
 hNy
 hNy
@@ -89867,7 +90056,7 @@ xOn
 vKL
 tqm
 gOY
-oAe
+iIl
 iLA
 lTD
 bib
@@ -89896,22 +90085,22 @@ bib
 bib
 mKb
 uQH
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
 cfT
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
 cMV
-tFZ
-oAe
-oAe
+ptw
+iIl
+iIl
 cCZ
 cCZ
 cCZ
@@ -90124,7 +90313,7 @@ sWw
 xZk
 jqF
 mel
-oAe
+iIl
 cUc
 bqj
 bqj
@@ -90161,13 +90350,13 @@ hUd
 hUd
 xuN
 gsc
-tFZ
-tFZ
+ptw
+ptw
 pYK
-tFZ
-tFZ
-tFZ
-oAe
+ptw
+ptw
+ptw
+iIl
 cCZ
 cCZ
 cCZ
@@ -90381,7 +90570,7 @@ vUK
 gpL
 tZv
 tZv
-oAe
+iIl
 cUc
 bqj
 hNy
@@ -90417,14 +90606,14 @@ bqj
 bqj
 bqj
 mtT
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
+iIl
 cCZ
 cCZ
 cCZ
@@ -90638,7 +90827,7 @@ wHf
 hAG
 bvs
 bvs
-oAe
+iIl
 cUc
 bqj
 vtU
@@ -90666,7 +90855,7 @@ cCZ
 vtU
 cCZ
 bqj
-gRN
+iQx
 bqj
 vtU
 cCZ
@@ -90674,7 +90863,7 @@ hNy
 hNy
 bqj
 joY
-oAe
+iIl
 hNy
 cCZ
 cCZ
@@ -90892,10 +91081,10 @@ sZh
 ngO
 sZh
 qPQ
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
 cUc
 bqj
 vtU
@@ -90931,7 +91120,7 @@ hNy
 hNy
 bqj
 vUn
-oAe
+iIl
 hNy
 hNy
 cCZ
@@ -91149,10 +91338,10 @@ qTu
 tNO
 qTu
 wGo
-oAe
-bHm
+iIl
+pCc
 ser
-oAe
+iIl
 cUc
 bqj
 vtU
@@ -91189,7 +91378,7 @@ hNy
 bqj
 vUn
 lkK
-oAe
+iIl
 hNy
 cCZ
 cCZ
@@ -91406,10 +91595,10 @@ qTu
 ndf
 xiW
 iLB
-oAe
-bHm
-bHm
-oAe
+iIl
+pCc
+pCc
+iIl
 cUc
 bqj
 vtU
@@ -91445,7 +91634,7 @@ hNy
 hNy
 bqj
 vUn
-gRN
+iQx
 pAD
 hNy
 cCZ
@@ -91663,10 +91852,10 @@ xiW
 sOG
 qTu
 wGo
-oAe
+iIl
 hLk
 mmz
-oAe
+iIl
 cUc
 bqj
 vtU
@@ -91703,7 +91892,7 @@ hNy
 bqj
 wAM
 dSk
-gRN
+iQx
 hNy
 hNy
 cCZ
@@ -91920,9 +92109,9 @@ xiW
 sLT
 qTu
 wGo
-oAe
-vpF
-gRN
+iIl
+eYD
+iQx
 cfT
 cUc
 bqj
@@ -92177,10 +92366,10 @@ vco
 guG
 vco
 vco
-oAe
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
+iIl
 cUc
 bqj
 vtU
@@ -92216,8 +92405,8 @@ hNy
 hNy
 bqj
 tiH
-oAe
-oAe
+iIl
+iIl
 hNy
 hNy
 hNy
@@ -92439,7 +92628,7 @@ jaP
 hbe
 fBT
 ydb
-kIN
+bqj
 kIN
 nYl
 dXc
@@ -92473,7 +92662,7 @@ rRv
 hNy
 bqj
 ryC
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -92694,9 +92883,9 @@ ktR
 ktR
 ktR
 ktR
-oAe
+iIl
 jlV
-kIN
+bqj
 kJg
 aFv
 uBZ
@@ -92733,7 +92922,7 @@ xwg
 miF
 mby
 wIj
-jbz
+prG
 cCZ
 cCZ
 nLN
@@ -92951,9 +93140,9 @@ jdP
 bVc
 xVa
 fTi
-oAe
+iIl
 ydb
-kIN
+bqj
 vZP
 aBi
 fhY
@@ -92987,10 +93176,10 @@ hNy
 hNy
 bqj
 cTJ
-oAe
-gRN
+iIl
+iQx
 kIT
-jbz
+prG
 cCZ
 cCZ
 cCZ
@@ -93208,9 +93397,9 @@ weR
 weR
 vxS
 xub
-oAe
+iIl
 ydb
-kIN
+bqj
 rAf
 dah
 esz
@@ -93244,7 +93433,7 @@ hNy
 hNy
 bqj
 uuJ
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -93465,9 +93654,9 @@ iPO
 weR
 cDy
 xVa
-oAe
+iIl
 ydb
-kIN
+bqj
 nwq
 dgz
 blK
@@ -93501,7 +93690,7 @@ hNy
 hNy
 bqj
 cTJ
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -93722,7 +93911,7 @@ eRj
 weR
 yin
 vxS
-oAe
+iIl
 cwg
 rVu
 eqU
@@ -93758,8 +93947,8 @@ rRv
 hNy
 bqj
 xwg
-fTB
-qjv
+pZS
+kNh
 hNy
 cCZ
 cCZ
@@ -93979,9 +94168,9 @@ fzk
 weR
 akw
 vxS
-oAe
+iIl
 cwg
-kIN
+bqj
 cFB
 nvZ
 wsN
@@ -94236,7 +94425,7 @@ weR
 weR
 mZS
 npo
-oAe
+iIl
 vnE
 jLk
 ihU
@@ -94272,8 +94461,8 @@ hNy
 wOY
 bqj
 xwg
-fTB
-mBT
+pZS
+wxg
 hNy
 hNy
 cCZ
@@ -94493,9 +94682,9 @@ bxk
 weR
 cRs
 icc
-oAe
+iIl
 vnE
-kIN
+bqj
 oAD
 oAD
 oAD
@@ -94529,7 +94718,7 @@ hNy
 hNy
 bqj
 xwg
-oAe
+iIl
 hNy
 hNy
 cCZ
@@ -94750,7 +94939,7 @@ vyw
 weR
 bLt
 kMD
-oAe
+iIl
 vnE
 bqj
 sRq
@@ -94786,7 +94975,7 @@ hNy
 hNy
 bqj
 cTJ
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -95007,7 +95196,7 @@ kAN
 weR
 cRs
 oBg
-tIK
+toL
 aGk
 vDL
 phU
@@ -95043,7 +95232,7 @@ hNy
 hNy
 bqj
 xwg
-oAe
+iIl
 hNy
 hNy
 hNy
@@ -95264,8 +95453,8 @@ unq
 weR
 qda
 aXf
-oAe
-nFE
+iIl
+iEm
 bqj
 eGG
 kLR
@@ -95521,7 +95710,7 @@ weR
 weR
 miI
 rax
-oAe
+iIl
 muO
 bqj
 snk
@@ -95558,8 +95747,8 @@ wfo
 wMF
 fAd
 mby
-gRN
-pwY
+iQx
+meS
 hNy
 hNy
 cCZ
@@ -95778,7 +95967,7 @@ oAv
 ota
 fwz
 ooS
-oAe
+iIl
 vVP
 bqj
 dWb
@@ -95812,9 +96001,9 @@ vtU
 vtU
 bqj
 cTJ
-oAe
-oAe
-oAe
+iIl
+iIl
+iIl
 hNy
 hNy
 hNy
@@ -96035,9 +96224,9 @@ soh
 sAB
 ota
 ooS
-oAe
-nFE
-fOt
+iIl
+iEm
+oGD
 bqj
 hdJ
 qmO
@@ -96292,8 +96481,8 @@ soh
 hOv
 riM
 ooS
-oAe
-nFE
+iIl
+iEm
 sBS
 bqj
 non
@@ -96549,9 +96738,9 @@ soh
 soh
 soh
 rwa
-oAe
-nFE
-fOt
+iIl
+iEm
+iEm
 bqj
 wvm
 hPl
@@ -96806,9 +96995,9 @@ ota
 bZn
 aiZ
 ooS
-oAe
+iIl
 nFE
-oAe
+iEm
 bqj
 wlV
 mFm
@@ -96836,7 +97025,7 @@ ttj
 ttj
 ttj
 oVr
-qnV
+hLe
 xtD
 qnV
 gTu
@@ -97063,9 +97252,9 @@ ota
 lWF
 oEB
 ooS
-oAe
-nFE
-scl
+iIl
+eSD
+iEm
 bqj
 wDe
 iLH
@@ -97076,11 +97265,11 @@ xwI
 dmv
 xbL
 vtC
-oMf
+lZD
 fiN
 fcI
 kGV
-fwm
+peO
 fcI
 ozG
 vda
@@ -97093,7 +97282,7 @@ gws
 vWl
 ttj
 fQu
-uxT
+iRd
 sPy
 eKb
 wpW
@@ -97320,9 +97509,9 @@ qOB
 enj
 qCm
 aOK
-oAe
-nFE
-wzY
+iIl
+nqx
+iEm
 bqj
 tQx
 vGc
@@ -97350,7 +97539,7 @@ qDV
 rAo
 ttj
 jiJ
-uxT
+iRd
 quS
 nfx
 keU
@@ -97577,9 +97766,9 @@ jSx
 nCc
 eeU
 lzS
-oAe
-nFE
-lgL
+iIl
+dAk
+iEm
 bqj
 wLI
 tGr
@@ -97607,9 +97796,9 @@ kHH
 dGK
 ttj
 xSx
+fMf
 uxT
-uxT
-hYS
+wSu
 iOb
 lOH
 tQT
@@ -97834,9 +98023,9 @@ tGI
 tkU
 kle
 oKb
-oAe
-nFE
-ciS
+iIl
+kFA
+iEm
 bqj
 wDx
 fSA
@@ -98090,10 +98279,10 @@ bAL
 svq
 fPs
 pgD
-vEd
-oAe
-fsn
-oAe
+igH
+iIl
+iIl
+vgD
 bqj
 hIM
 cnb
@@ -98347,11 +98536,11 @@ bAL
 bLt
 fPs
 ffO
-pgP
-oAe
+lIV
+cFg
 ihE
-oAe
-gyq
+bmv
+nTx
 gzb
 xTY
 qDk
@@ -98374,7 +98563,7 @@ mgY
 oeZ
 tOE
 eev
-axi
+vzP
 bBn
 ttj
 lOH
@@ -98601,15 +98790,15 @@ roi
 bdX
 xDy
 bAL
-bLt
+wtE
 fPs
 frW
-uQJ
-oAe
+lIV
+aRR
 iYy
-oAe
-vcb
-gzb
+mCv
+sil
+aVF
 qxo
 kOT
 lJl
@@ -98631,7 +98820,7 @@ msD
 xFa
 tOE
 bzJ
-axi
+vzP
 alG
 iSu
 mrK
@@ -98639,7 +98828,7 @@ qCC
 ttj
 mww
 gGu
-avb
+alG
 fSW
 mSg
 lEN
@@ -98862,18 +99051,18 @@ lsY
 cwZ
 nwt
 vqS
-oAe
-mCu
+kMB
+nTx
 dpZ
-sil
-kjb
-lcF
-hgT
+nTx
+gzb
+nTx
+qDk
 eTW
 lxd
 lxd
 lxd
-vOY
+nTx
 xKA
 kcZ
 vWz
@@ -98896,7 +99085,7 @@ alG
 hRb
 rVH
 gGu
-avb
+alG
 xFy
 mSg
 lEN
@@ -99118,11 +99307,11 @@ uti
 bLt
 aUW
 frW
-fyE
-oAe
-iVr
-oAe
-gmi
+xWG
+nIY
+gyq
+flX
+gzb
 gzb
 qDk
 qDk
@@ -99145,15 +99334,15 @@ tAZ
 lYf
 xxC
 rne
-avb
-avb
-axi
+alG
+alG
+vzP
 rEs
 rKd
 ukO
 rKd
 rKd
-avb
+alG
 mzv
 mSg
 iEq
@@ -99376,9 +99565,9 @@ bLt
 aUW
 frW
 jHw
-oAe
-bua
-oAe
+nIY
+vcb
+flX
 pyI
 pyI
 wUs
@@ -99403,14 +99592,14 @@ imC
 tOE
 tUs
 alG
-alG
-vzP
-alG
+mLj
+nbO
+qCw
 rZl
 idm
-avb
+alG
 rKd
-avb
+alG
 lfG
 mSg
 mSg
@@ -99635,7 +99824,7 @@ frW
 fyE
 oAe
 iVr
-oAe
+poC
 oAe
 oAe
 oAe
@@ -99667,7 +99856,7 @@ gMZ
 gMZ
 oPb
 xLu
-avb
+alG
 lfG
 mSg
 lrN
@@ -99889,9 +100078,9 @@ bdX
 lsY
 aUW
 frW
-vqS
+vEd
 oAe
-wkE
+pwY
 gnL
 lJT
 lJT
@@ -99917,8 +100106,8 @@ jeY
 xxq
 gMZ
 roG
-qeg
-uYT
+lIo
+uax
 qeg
 rQl
 gMZ
@@ -100148,7 +100337,7 @@ cXv
 hLZ
 udX
 oAe
-pwY
+fOt
 rxa
 oAe
 uXG
@@ -100175,21 +100364,21 @@ eFE
 gMZ
 nGQ
 rom
-uax
+fYn
 bKT
 asX
 gMZ
-avb
+alG
 rKd
-avb
+alG
 gvg
 wew
 nmk
 wjE
 rjO
 uQZ
-hfR
-hfR
+rjO
+rjO
 uuR
 qtH
 mSg
@@ -100693,7 +100882,7 @@ lvA
 eZx
 fTb
 aQb
-avb
+alG
 rKd
 qHm
 mYz
@@ -100950,10 +101139,10 @@ oBb
 gJD
 fdy
 aQb
-avb
+alG
 rKd
 mjF
-mYz
+pFP
 wew
 jMz
 jMU

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -12607,7 +12607,7 @@
 "eHG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "eHU" = (
 /obj/structure/marker_beacon/burgundy,
@@ -13517,7 +13517,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/flora/bush/snow/style_random,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "eYb" = (
 /obj/structure/disposalpipe/segment{
@@ -20487,7 +20487,7 @@
 /area/station/hallway/primary/aft)
 "hFK" = (
 /obj/structure/flora/rock/icy/style_random,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "hFL" = (
 /obj/structure/table,
@@ -20884,7 +20884,7 @@
 /area/station/engineering/atmos)
 "hNT" = (
 /obj/structure/flora/tree/pine/style_random,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "hOi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25299,7 +25299,7 @@
 /area/station/hallway/primary/central/fore)
 "jzs" = (
 /obj/structure/flora/bush/snow/style_random,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "jzx" = (
 /obj/effect/turf_decal/siding/wood{
@@ -29296,7 +29296,7 @@
 "kTN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/rock/icy/style_random,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "kTT" = (
 /obj/machinery/iv_drip,
@@ -30741,7 +30741,7 @@
 /obj/effect/spawner/random/mod/maint,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "lwo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -61531,7 +61531,7 @@
 /area/station/maintenance/starboard/central)
 "wOy" = (
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/fake_snow,
+/turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
 "wOA" = (
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -8275,11 +8275,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"cXS" = (
-/obj/structure/rack,
-/obj/item/grenade/firecracker,
-/turf/open/floor/stone,
-/area/station/maintenance/starboard/central)
 "cXV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59843,7 +59838,6 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "vSG" = (
-/obj/item/grenade/firecracker,
 /obj/structure/rack,
 /turf/open/floor/stone,
 /area/station/maintenance/starboard/central)
@@ -110576,7 +110570,7 @@ bRU
 bGM
 uZp
 bRU
-cXS
+vSG
 vSG
 aUm
 bRU

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -6667,15 +6667,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
-"cvl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central)
 "cvz" = (
 /obj/item/relic,
 /obj/item/bedsheet/black{
@@ -8956,6 +8947,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/service/hydroponics/garden)
+"djw" = (
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "djE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -9739,6 +9737,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"dzT" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/library/lounge)
 "dAd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -13154,15 +13161,15 @@
 /turf/open/floor/glass,
 /area/station/maintenance/department/science)
 "eOf" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
 "eOj" = (
@@ -14741,8 +14748,7 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "frU" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/bronze,
+/turf/open/floor/wood/stairs/left,
 /area/station/service/library)
 "frW" = (
 /turf/open/floor/iron/terracotta/small,
@@ -20093,6 +20099,9 @@
 "hqK" = (
 /obj/machinery/door/airlock/bronze,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "hqZ" = (
@@ -21723,6 +21732,9 @@
 "hYE" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/railing,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "hYF" = (
@@ -25505,6 +25517,13 @@
 /obj/machinery/plate_press,
 /turf/open/floor/carpet/purple,
 /area/station/security/prison/work)
+"jwk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/station/service/library)
 "jws" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26752,11 +26771,8 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
 "jVe" = (
-/obj/machinery/door/airlock/bronze,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/machinery/door/airlock/bronze,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "jVi" = (
@@ -27766,11 +27782,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
-"kmM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/royalblack,
-/area/station/service/library/lounge)
 "kmS" = (
 /turf/open/misc/asteroid/airless,
 /area/space)
@@ -28601,6 +28612,10 @@
 /area/station/hallway/primary/central/fore)
 "kBa" = (
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "kBd" = (
@@ -28731,9 +28746,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
 	},
 /turf/open/floor/bronze,
 /area/station/service/library)
@@ -31212,9 +31224,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "lwy" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -36666,7 +36675,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "nsd" = (
-/obj/structure/stairs/wood{
+/obj/structure/bookcase/random/fiction,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/bronze,
@@ -37783,9 +37793,10 @@
 /turf/open/floor/stone,
 /area/station/hallway/primary/starboard)
 "nNe" = (
-/obj/structure/girder/bronze,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/bronze,
+/obj/structure/stairs/wood{
+	dir = 8
+	},
+/turf/open/space/basic,
 /area/station/service/library)
 "nNh" = (
 /obj/machinery/door/firedoor/border_only{
@@ -40127,6 +40138,15 @@
 "oDe" = (
 /turf/open/openspace/airless,
 /area/space)
+"oDi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/station/service/library/lounge)
 "oDl" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/jungle/c/style_random,
@@ -43708,6 +43728,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/aft)
+"pTp" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/bronze,
+/area/station/service/library)
 "pTw" = (
 /obj/structure/table/wood,
 /obj/item/razor{
@@ -43870,6 +43894,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"pXb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/library/lounge)
 "pXo" = (
 /obj/machinery/computer/camera_advanced/base_construction/aux{
 	dir = 4
@@ -45180,8 +45213,12 @@
 /area/station/science/research)
 "qvg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "qvq" = (
@@ -47488,9 +47525,6 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
@@ -47533,9 +47567,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rln" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -50239,13 +50270,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "skY" = (
-/obj/structure/railing{
+/obj/structure/railing/corner/end/flip{
 	dir = 4
 	},
-/obj/machinery/holopad,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
 "sle" = (
@@ -50253,6 +50281,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"slo" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central)
 "slq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -54002,13 +54037,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"tEN" = (
-/obj/structure/bookcase/random/fiction,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/bronze,
-/area/station/service/library)
 "tEQ" = (
 /turf/closed/wall,
 /area/station/solars/starboard/fore)
@@ -54722,6 +54750,8 @@
 "tSQ" = (
 /obj/structure/chair/bronze,
 /obj/effect/landmark/start/hangover,
+/obj/effect/landmark/event_spawn,
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "tSR" = (
@@ -57675,13 +57705,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "vdG" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
 "vdL" = (
@@ -59336,6 +59361,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"vIN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/royalblack,
+/area/station/service/library/lounge)
 "vIP" = (
 /obj/item/storage/box/beakers{
 	pixel_x = 3;
@@ -59440,6 +59471,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/construction)
+"vLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/library/lounge)
 "vLz" = (
 /obj/item/wallframe/firealarm,
 /turf/open/floor/plating,
@@ -60569,6 +60607,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
 "wgz" = (
@@ -62262,9 +62301,7 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "wHn" = (
-/obj/structure/chair/bronze,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library/lounge)
 "wHq" = (
@@ -65469,12 +65506,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
-"xQI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/bronze,
-/area/station/service/library/lounge)
 "xQQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/glass/reinforced,
@@ -95641,7 +95672,7 @@ oOy
 fHG
 weR
 cPm
-oYq
+pTp
 nNe
 nsd
 kDp
@@ -95898,9 +95929,9 @@ bIu
 bIu
 eTQ
 bcA
-oYq
+pTp
 frU
-tEN
+nsd
 gFS
 oYq
 igG
@@ -96156,7 +96187,7 @@ qyC
 ilj
 pUk
 mpn
-mpn
+jwk
 mpn
 qgs
 pEC
@@ -160920,8 +160951,8 @@ rAq
 rAq
 pkB
 kKv
-cJg
-wYG
+vLt
+oDi
 skY
 vdG
 cEw
@@ -161178,8 +161209,8 @@ rAq
 tfd
 sJN
 hYE
-kmM
 dba
+dzT
 lwy
 cEw
 wYG
@@ -161434,8 +161465,8 @@ rAq
 rAq
 pkB
 kKv
-cJg
-xQI
+vIN
+dba
 eOf
 rln
 pFm
@@ -161693,7 +161724,7 @@ tfd
 lBf
 kBa
 qvg
-cJg
+pXb
 jSF
 vdL
 wpw
@@ -162207,7 +162238,7 @@ xfC
 pkB
 pkB
 rkx
-ajB
+djw
 pkB
 pkB
 cZN
@@ -162463,8 +162494,8 @@ uyN
 vXZ
 rqE
 kNc
-cvl
-psK
+vop
+slo
 wiP
 nxg
 xly

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -11493,6 +11493,13 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
+"ehW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/station/service/library)
 "ehZ" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
@@ -37791,7 +37798,7 @@
 /obj/structure/stairs/wood{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/bronze,
 /area/station/service/library)
 "nNh" = (
 /obj/machinery/door/firedoor/border_only{
@@ -43725,6 +43732,7 @@
 /area/station/hallway/primary/central/aft)
 "pTp" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing,
 /turf/open/floor/bronze,
 /area/station/service/library)
 "pTw" = (
@@ -59255,6 +59263,13 @@
 	},
 /turf/open/floor/noslip,
 /area/station/biodome/aft)
+"vHi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner,
+/turf/open/floor/bronze,
+/area/station/service/library)
 "vHk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -95409,7 +95424,7 @@ kco
 kco
 wnH
 bjN
-bjN
+vHi
 mpP
 mpP
 dzB
@@ -96180,7 +96195,7 @@ qyC
 qyC
 ilj
 pUk
-mpn
+ehW
 jwk
 mpn
 qgs

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -326,6 +326,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "afP" = (
@@ -729,6 +732,7 @@
 /area/station/security/brig)
 "amq" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "amG" = (
@@ -969,6 +973,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"aqP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "aqX" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -1289,6 +1302,7 @@
 /area/station/cargo/bitrunning/den)
 "awg" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "awl" = (
@@ -1304,6 +1318,7 @@
 /obj/structure/sign/directions/engineering{
 	pixel_y = -21
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "awm" = (
@@ -1649,6 +1664,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aDk" = (
@@ -1696,6 +1712,9 @@
 "aEf" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Zoo Center"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -2335,6 +2354,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"aPL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "aPN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -2703,6 +2730,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aWy" = (
@@ -3058,6 +3086,7 @@
 /area/station/engineering/atmos/pumproom)
 "bdk" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bdu" = (
@@ -3091,6 +3120,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bdR" = (
@@ -3116,6 +3146,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "beC" = (
@@ -3248,6 +3281,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Bridge Lake Overlook"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bix" = (
@@ -3537,6 +3571,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Port Fore Stairs"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bnd" = (
@@ -3719,6 +3756,7 @@
 /obj/structure/sign/flag/pride/trans{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "brE" = (
@@ -3739,6 +3777,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/work)
+"bsb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bsi" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -3780,6 +3826,9 @@
 /area/station/command/heads_quarters/hop)
 "bsP" = (
 /obj/structure/chair/sofa/bamboo,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bsR" = (
@@ -3805,6 +3854,7 @@
 /area/station/maintenance/starboard/central)
 "btl" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "btB" = (
@@ -4395,6 +4445,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bFq" = (
@@ -4440,6 +4491,7 @@
 /area/station/maintenance/department/science)
 "bGv" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bGA" = (
@@ -4565,6 +4617,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bIU" = (
 /obj/structure/sign/warning/secure_area/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bJf" = (
@@ -4881,6 +4939,7 @@
 /obj/machinery/button/door/directional/east{
 	id = "cargowarehouse"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bPx" = (
@@ -4925,6 +4984,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"bQb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bQd" = (
 /obj/structure/sign/warning/radiation/rad_area/directional/north,
 /obj/effect/turf_decal/bot_white,
@@ -5034,6 +5102,9 @@
 /area/station/hallway/primary/aft)
 "bRJ" = (
 /obj/machinery/light/dim/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bRR" = (
@@ -5469,6 +5540,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "caf" = (
@@ -5619,6 +5691,7 @@
 /area/station/commons/fitness)
 "cdt" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cdD" = (
@@ -7126,6 +7199,7 @@
 /area/space)
 "cDa" = (
 /obj/machinery/door/airlock/public/glass,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cDb" = (
@@ -7240,6 +7314,7 @@
 /area/station/biodome/fore)
 "cFc" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cFg" = (
@@ -7310,6 +7385,7 @@
 "cGo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cGz" = (
@@ -7614,6 +7690,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cLz" = (
@@ -7644,6 +7726,9 @@
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway -Bee Roof"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -7706,6 +7791,9 @@
 "cMT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cMV" = (
@@ -8067,6 +8155,12 @@
 /area/station/commons/vacant_room/commissary)
 "cUL" = (
 /obj/machinery/status_display/ai/directional/west,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cUO" = (
@@ -8118,6 +8212,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "cVY" = (
 /obj/structure/sign/departments/maint/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cVZ" = (
@@ -8319,6 +8414,9 @@
 "dar" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Dormitory"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -8568,6 +8666,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dfi" = (
@@ -8698,6 +8797,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dhg" = (
@@ -8705,6 +8807,9 @@
 	icon_state = "L7"
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dhk" = (
@@ -8836,6 +8941,7 @@
 /area/station/maintenance/department/engine)
 "diS" = (
 /obj/machinery/mining_weather_monitor/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "djt" = (
@@ -8924,6 +9030,7 @@
 /obj/structure/sign/directions/supply/directional/east{
 	pixel_y = -11
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dkK" = (
@@ -8961,6 +9068,9 @@
 /area/station/science/robotics/lab)
 "dlY" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dmd" = (
@@ -9217,6 +9327,9 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Hallway - Zoo Port"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "drk" = (
@@ -9338,6 +9451,7 @@
 /area/station/maintenance/aft/upper)
 "dtJ" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dtP" = (
@@ -9661,6 +9775,7 @@
 /area/station/cargo/warehouse)
 "dAG" = (
 /obj/structure/sign/departments/maint/alt/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dAJ" = (
@@ -9715,6 +9830,7 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dBn" = (
 /obj/structure/sign/departments/maint/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dBo" = (
@@ -10380,6 +10496,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "dOp" = (
@@ -10465,6 +10584,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
+"dQG" = (
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dQH" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
@@ -10605,6 +10730,9 @@
 "dSl" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Service Hall Roof"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -10851,6 +10979,9 @@
 /area/station/medical/medbay/central)
 "dVH" = (
 /obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -11467,6 +11598,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"elD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "elG" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -11909,10 +12047,14 @@
 /area/station/service/chapel/office)
 "euf" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "euh" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eui" = (
@@ -11925,6 +12067,9 @@
 "euj" = (
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "euk" = (
@@ -11942,6 +12087,7 @@
 /area/station/maintenance/central/greater)
 "euJ" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "euM" = (
@@ -12031,6 +12177,7 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/yes_smoking/circle/directional/east,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "evL" = (
@@ -12072,6 +12219,9 @@
 /area/station/maintenance/port/central)
 "ewO" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ewP" = (
@@ -12277,6 +12427,7 @@
 /obj/structure/sign/directions/arrival/directional/east{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "eBh" = (
@@ -12413,6 +12564,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Biodome Aft Starboard Stairs"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eEW" = (
@@ -12677,6 +12829,9 @@
 "eIQ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Hallway - Port Aft Stairs"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -14151,6 +14306,9 @@
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "fjt" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fjN" = (
@@ -14733,6 +14891,12 @@
 "fuu" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/radshelter/civil)
+"fuK" = (
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fuM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -15322,6 +15486,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"fGR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fGW" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/openspace,
@@ -15517,6 +15688,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"fLn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fLq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15871,6 +16047,9 @@
 	c_tag = "Hallway - Zoo Starboard"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "fQs" = (
@@ -15898,6 +16077,9 @@
 "fQW" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fQZ" = (
@@ -16263,6 +16445,9 @@
 /area/station/maintenance/port/greater)
 "fWb" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fWc" = (
@@ -16936,6 +17121,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "gjC" = (
@@ -17011,6 +17197,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gls" = (
@@ -17281,6 +17470,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "grV" = (
@@ -17923,6 +18113,7 @@
 /area/station/biodome/aft)
 "gDN" = (
 /obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "gDP" = (
@@ -18069,6 +18260,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"gGI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gGP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18221,6 +18418,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gJk" = (
@@ -18230,6 +18433,7 @@
 /area/station/maintenance/port/lesser)
 "gJo" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gJx" = (
@@ -18262,6 +18466,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"gKl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gKm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18371,6 +18584,9 @@
 "gMu" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
+	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -18544,6 +18760,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gQv" = (
@@ -18650,6 +18867,9 @@
 /area/station/maintenance/central/greater)
 "gRQ" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gRT" = (
@@ -19147,6 +19367,9 @@
 /area/station/security/execution/education)
 "hcy" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hcC" = (
@@ -19225,6 +19448,7 @@
 /area/station/security/processing)
 "hdy" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hdC" = (
@@ -19269,6 +19493,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hec" = (
@@ -19338,6 +19568,9 @@
 /area/station/hallway/primary/central)
 "hgd" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hgi" = (
@@ -19470,6 +19703,16 @@
 	},
 /turf/open/openspace,
 /area/station/biodome/aft)
+"hjj" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hjr" = (
 /turf/open/floor/bamboo/tatami/black{
 	dir = 8
@@ -19961,6 +20204,15 @@
 /obj/structure/musician/piano,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
+"htw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "htx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20567,6 +20819,16 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/cargo/miningdock)
+"hGQ" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hGY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -20685,6 +20947,7 @@
 /area/station/service/chapel/funeral)
 "hJi" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hJk" = (
@@ -21101,6 +21364,12 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hSm" = (
@@ -22045,6 +22314,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iiP" = (
@@ -22160,6 +22430,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ikV" = (
@@ -22308,6 +22579,9 @@
 /area/station/cargo/office)
 "ioI" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ioK" = (
@@ -22333,6 +22607,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ioS" = (
@@ -22443,6 +22721,12 @@
 "irp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -22833,6 +23117,13 @@
 	},
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"izO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "izR" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/supply,
@@ -22894,6 +23185,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iAY" = (
@@ -22926,6 +23220,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iBE" = (
@@ -22998,6 +23293,10 @@
 	color = "#a9734f"
 	},
 /area/station/biodome/aft)
+"iCN" = (
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iCX" = (
 /obj/effect/spawner/random/structure/table,
 /obj/item/paper/pamphlet/radstorm,
@@ -23935,6 +24234,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iYr" = (
@@ -24040,6 +24343,7 @@
 /area/station/biodome/fore)
 "iZY" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "jad" = (
@@ -24096,8 +24400,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"jaU" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jaZ" = (
 /obj/structure/broken_flooring/singular/directional/west,
 /turf/open/floor/plating,
@@ -24186,6 +24498,15 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"jcK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jcM" = (
 /obj/machinery/power/solar{
 	id = "aicore";
@@ -24275,6 +24596,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Command - Hop Line"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "jeh" = (
@@ -24384,6 +24706,9 @@
 /area/station/maintenance/radshelter/civil)
 "jfX" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "jgb" = (
@@ -24627,6 +24952,9 @@
 "jkS" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -25112,6 +25440,7 @@
 /area/station/commons/dorms)
 "jva" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "jvc" = (
@@ -25603,6 +25932,7 @@
 /obj/structure/sign/flag/pride/bi{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "jFc" = (
@@ -25839,6 +26169,13 @@
 /obj/machinery/vending/security,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/lockers)
+"jIP" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jIQ" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood/large,
@@ -26549,12 +26886,27 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"jXD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jXK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "jXN" = (
 /obj/structure/sign/departments/science/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "jXP" = (
@@ -27370,6 +27722,7 @@
 /obj/structure/sign/flag/pride/lesbian{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kme" = (
@@ -27461,6 +27814,10 @@
 /area/station/commons/lounge)
 "knF" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "knH" = (
@@ -28001,6 +28358,7 @@
 "kvT" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/departments/court/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "kwe" = (
@@ -28039,6 +28397,9 @@
 	},
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kxf" = (
@@ -28235,6 +28596,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kBa" = (
@@ -28494,6 +28856,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kFW" = (
@@ -28639,6 +29002,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "kIB" = (
 /obj/structure/sign/directions/vault/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "kIG" = (
@@ -28667,6 +29031,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kIT" = (
@@ -28985,6 +29350,9 @@
 "kNM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kNS" = (
@@ -29671,6 +30039,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "laH" = (
@@ -29692,11 +30061,6 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/station/command/gateway)
-"lbS" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
 "lcn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29714,6 +30078,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lcC" = (
@@ -29761,6 +30126,9 @@
 /area/station/maintenance/department/science)
 "lcY" = (
 /obj/structure/sign/departments/maint/alt/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ldq" = (
@@ -29960,6 +30328,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/janitor)
+"lge" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/station/hallway/primary/starboard)
 "lgl" = (
 /obj/structure/table,
 /turf/open/misc/asteroid,
@@ -30348,6 +30725,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "loN" = (
@@ -30458,6 +30836,9 @@
 	dir = 2;
 	pixel_y = -7
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lqx" = (
@@ -30476,6 +30857,9 @@
 /area/station/command/meeting_room)
 "lqC" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lqF" = (
@@ -30505,6 +30889,7 @@
 /obj/item/hand_labeler,
 /obj/item/toner,
 /obj/effect/spawner/random/bureaucracy/birthday_wrap,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lqI" = (
@@ -30573,6 +30958,9 @@
 "lrg" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "lrN" = (
@@ -31015,6 +31403,9 @@
 /area/station/security/prison/workout)
 "lyT" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lyU" = (
@@ -31050,6 +31441,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/security/brig)
+"lzp" = (
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "lzy" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/two,
@@ -31161,6 +31559,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "lBf" = (
@@ -31177,6 +31578,7 @@
 /area/station/science/cytology)
 "lBt" = (
 /obj/structure/sign/departments/maint/alt/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "lBI" = (
@@ -31368,6 +31770,7 @@
 "lEQ" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "lEX" = (
@@ -32075,6 +32478,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Bridge Lake Fore Overlook"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lRL" = (
@@ -32541,6 +32945,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"lZC" = (
+/obj/structure/chair/sofa/bamboo,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "lZD" = (
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -32684,6 +33098,9 @@
 "mbv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -33440,6 +33857,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/bronze,
 /area/station/service/library)
+"mpq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "mpy" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/transport/linear/public,
@@ -33606,6 +34034,9 @@
 /area/station/service/chapel)
 "mss" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "msz" = (
@@ -33638,6 +34069,9 @@
 "msV" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "msX" = (
@@ -33882,6 +34316,9 @@
 /area/station/engineering/atmos)
 "myS" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "myU" = (
@@ -34751,6 +35188,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"mQg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "mQi" = (
 /turf/open/floor/glass,
 /area/station/hallway/primary/central)
@@ -34924,6 +35370,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mUg" = (
@@ -34938,6 +35385,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"mUk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "mUl" = (
 /obj/structure/table/wood,
 /obj/structure/desk_bell{
@@ -34969,6 +35428,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/openspace,
 /area/station/maintenance/port/greater)
+"mVl" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/closed/wall/mineral/bamboo,
+/area/station/service/lawoffice)
 "mVu" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 1
@@ -34997,6 +35462,9 @@
 "mVY" = (
 /obj/structure/sign/departments/science/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "mWd" = (
@@ -35215,6 +35683,7 @@
 /area/space/nearstation)
 "naK" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "naO" = (
@@ -35393,6 +35862,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nds" = (
@@ -35618,6 +36088,7 @@
 /area/station/service/kitchen)
 "ngn" = (
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ngE" = (
@@ -35700,6 +36171,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nit" = (
@@ -35761,6 +36235,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"njF" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "njP" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
@@ -35896,6 +36374,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nnC" = (
@@ -36029,6 +36510,9 @@
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "npo" = (
@@ -36351,6 +36835,7 @@
 /obj/structure/sign/flag/pride/ace{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nvU" = (
@@ -36401,6 +36886,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"nwv" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nwI" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -36434,6 +36926,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nxu" = (
@@ -36638,6 +37133,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nBc" = (
@@ -36693,6 +37191,9 @@
 /area/station/engineering/atmos)
 "nCa" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nCb" = (
@@ -36872,6 +37373,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nFt" = (
@@ -36977,6 +37481,9 @@
 /area/station/maintenance/aft/upper)
 "nHe" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nHf" = (
@@ -37021,6 +37528,7 @@
 /area/station/medical/chemistry)
 "nIC" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nIY" = (
@@ -37370,6 +37878,9 @@
 /area/station/commons/lounge)
 "nOx" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nOL" = (
@@ -37577,6 +38088,9 @@
 /area/station/maintenance/department/security/brig)
 "nSu" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nSE" = (
@@ -37593,6 +38107,7 @@
 /obj/structure/sign/flag/pride/pan{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nSZ" = (
@@ -37978,6 +38493,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oaw" = (
@@ -38038,6 +38556,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "obq" = (
@@ -38575,6 +39096,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"ojZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "okj" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Civilian - Garden Overlook Stardboard"
@@ -38853,6 +39380,7 @@
 /area/station/service/hydroponics)
 "opC" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "opJ" = (
@@ -38963,6 +39491,9 @@
 "osc" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Fore Biodome Stairs"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -39268,6 +39799,9 @@
 	icon_state = "L11"
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oyC" = (
@@ -39563,6 +40097,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"oCG" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oCK" = (
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/terracotta,
@@ -39781,6 +40324,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oHb" = (
@@ -39893,6 +40437,15 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central)
+"oJc" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oJi" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -39946,6 +40499,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"oJY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oKb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40195,6 +40758,7 @@
 /area/station/asteroid)
 "oOJ" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oOK" = (
@@ -41503,6 +42067,7 @@
 /area/station/security/brig)
 "pmV" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pnf" = (
@@ -41569,6 +42134,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "poe" = (
@@ -41584,6 +42152,9 @@
 /area/station/service/janitor)
 "pol" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pom" = (
@@ -41840,6 +42411,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pup" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pux" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -41879,6 +42460,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"pvt" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pvw" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -42066,6 +42655,13 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"pzn" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pzr" = (
 /obj/structure/railing{
 	dir = 8
@@ -42308,6 +42904,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pEs" = (
@@ -42426,6 +43023,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pGx" = (
@@ -42585,6 +43183,9 @@
 /area/station/security/detectives_office)
 "pJf" = (
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pJg" = (
@@ -42674,6 +43275,9 @@
 "pLp" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - AI Sat and Science Back Entrance"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -42811,6 +43415,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pNM" = (
@@ -42916,6 +43526,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Storage Entrance"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pPN" = (
@@ -42968,6 +43579,9 @@
 "pQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -43277,6 +43891,7 @@
 /area/station/maintenance/port/greater)
 "pXx" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pXI" = (
@@ -43318,6 +43933,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pYG" = (
@@ -43680,6 +44296,9 @@
 /area/station/maintenance/disposal)
 "qfh" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "qfq" = (
@@ -43804,6 +44423,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
+"qik" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qil" = (
 /obj/machinery/modular_computer/preset/cargochat/science{
 	dir = 4
@@ -44366,6 +44989,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qrh" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qrj" = (
 /obj/structure/window/spawner/directional/west,
 /obj/machinery/computer/teleporter{
@@ -44405,6 +45032,9 @@
 /obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -44561,6 +45191,7 @@
 /area/station/maintenance/disposal/incinerator)
 "qvr" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "qvC" = (
@@ -44687,6 +45318,7 @@
 /area/station/biodome/aft)
 "qxL" = (
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qxU" = (
@@ -44771,6 +45403,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qzJ" = (
@@ -44847,6 +45480,10 @@
 	pixel_y = -21;
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qAz" = (
@@ -44859,6 +45496,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/pods/directional/south,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qAP" = (
@@ -45078,6 +45717,7 @@
 "qEh" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qEw" = (
@@ -45431,6 +46071,7 @@
 /area/station/maintenance/aft/upper)
 "qLq" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qLt" = (
@@ -45455,6 +46096,7 @@
 "qLS" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qLW" = (
@@ -45712,10 +46354,12 @@
 /area/station/science/research)
 "qQj" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qQw" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qQA" = (
@@ -46241,6 +46885,7 @@
 "qYG" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "qYK" = (
@@ -46332,6 +46977,17 @@
 	icon_state = "L8"
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"rah" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ran" = (
@@ -47017,6 +47673,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"rnr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rnu" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
@@ -47358,6 +48025,10 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Vault Access"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rtH" = (
@@ -47423,6 +48094,7 @@
 "ruD" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ruE" = (
@@ -47613,6 +48285,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rxV" = (
@@ -48135,6 +48808,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "rIP" = (
@@ -48325,6 +49001,7 @@
 /area/station/commons/fitness)
 "rML" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rMY" = (
@@ -48611,6 +49288,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "rSM" = (
@@ -48706,6 +49386,7 @@
 /obj/structure/sign/directions/engineering/directional/east{
 	dir = 2
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rUb" = (
@@ -48763,6 +49444,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"rUY" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rVi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
@@ -48784,6 +49471,9 @@
 /area/station/maintenance/department/engine)
 "rVy" = (
 /obj/structure/sign/departments/maint/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rVG" = (
@@ -49449,6 +50139,12 @@
 "siV" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"sjh" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sjl" = (
 /obj/structure/railing{
 	dir = 8
@@ -49480,6 +50176,7 @@
 /area/station/maintenance/central/greater)
 "sjU" = (
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "sjW" = (
@@ -49556,6 +50253,11 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"slq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "slB" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -49931,6 +50633,9 @@
 /area/station/cargo/miningdock)
 "stp" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "stx" = (
@@ -50205,6 +50910,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "syw" = (
@@ -50355,6 +51061,9 @@
 /area/station/service/bar)
 "sAN" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sAX" = (
@@ -50386,6 +51095,9 @@
 /turf/open/floor/engine/hull,
 /area/station/asteroid)
 "sBt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sBz" = (
@@ -51177,6 +51889,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "sQY" = (
@@ -51314,6 +52027,18 @@
 /area/station/commons/locker)
 "sTk" = (
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"sTo" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sTy" = (
@@ -52225,6 +52950,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tlr" = (
@@ -52403,6 +53131,15 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"tns" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "tny" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid,
@@ -52577,6 +53314,7 @@
 "trX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "tse" = (
@@ -52852,6 +53590,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
+"txu" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "txv" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -53121,6 +53866,9 @@
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tCx" = (
@@ -54023,6 +54771,7 @@
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tUo" = (
@@ -54062,6 +54811,12 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /obj/structure/disposalpipe/sorting/mail,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tVl" = (
@@ -54227,6 +54982,12 @@
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"tYP" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tYW" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -54337,6 +55098,7 @@
 /obj/structure/sign/flag/pride{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ubG" = (
@@ -54366,6 +55128,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ucm" = (
@@ -54424,6 +55187,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
+"ucR" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "udd" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -54587,6 +55360,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ugH" = (
@@ -54606,6 +55382,14 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"uht" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uhF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54690,6 +55474,14 @@
 /obj/effect/landmark/start/assistant/dept/srv,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"ukL" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ukO" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/structure/cable,
@@ -54706,6 +55498,9 @@
 "ukV" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ulb" = (
@@ -55506,6 +56301,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "uBZ" = (
@@ -55526,6 +56324,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"uCm" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "uCp" = (
 /obj/structure/transit_tube,
 /turf/open/openspace,
@@ -55552,6 +56360,7 @@
 /area/station/maintenance/fore/greater)
 "uCA" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "uCC" = (
@@ -55694,6 +56503,9 @@
 "uFG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -55868,6 +56680,9 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Hallway - Port Fore Stairs"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uJf" = (
@@ -55998,6 +56813,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uMc" = (
@@ -56671,6 +57487,9 @@
 	pixel_y = 28;
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vaP" = (
@@ -57140,6 +57959,10 @@
 /obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"vjI" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vjY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -57329,6 +58152,9 @@
 /area/station/maintenance/aft/upper)
 "vmQ" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "vmU" = (
@@ -57610,6 +58436,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"vsr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vsu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -57640,6 +58472,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"vsL" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vtd" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -58213,6 +59051,7 @@
 "vEr" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vEw" = (
@@ -58322,6 +59161,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "vGr" = (
@@ -58604,6 +59447,9 @@
 "vLA" = (
 /obj/structure/chair/sofa/bamboo,
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vLD" = (
@@ -58631,6 +59477,7 @@
 	pixel_y = -4;
 	dir = 2
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vLR" = (
@@ -58769,6 +59616,10 @@
 	c_tag = "Hallway - Commissary"
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "vOG" = (
@@ -58893,6 +59744,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"vQO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vRd" = (
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -59251,6 +60109,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "vXp" = (
@@ -59559,10 +60420,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"wee" = (
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wek" = (
@@ -59855,6 +60725,12 @@
 /area/station/biodome)
 "wjv" = (
 /obj/structure/sign/departments/science/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wjE" = (
@@ -59867,6 +60743,9 @@
 "wjI" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Fore Biodome Overlook"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -60165,6 +61044,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wnj" = (
@@ -60341,6 +61221,16 @@
 /obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/hallway/primary/starboard)
+"wpD" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wpF" = (
 /obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/plating,
@@ -60657,6 +61547,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
 	},
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "wwF" = (
@@ -60753,6 +61646,9 @@
 /obj/structure/sign/directions/supply/directional/north{
 	pixel_y = 21;
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -61144,6 +62040,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"wDJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wDW" = (
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -61267,6 +62175,9 @@
 "wFv" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wFw" = (
@@ -61363,6 +62274,14 @@
 /obj/item/flashlight/flare/candle,
 /turf/open/floor/wood/large,
 /area/station/biodome)
+"wHt" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wHv" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -62455,6 +63374,7 @@
 	},
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xco" = (
@@ -63274,6 +64194,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "xvd" = (
@@ -63657,6 +64580,13 @@
 /obj/item/radio,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"xCt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xCT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63798,6 +64728,7 @@
 "xEP" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xEV" = (
@@ -63816,6 +64747,9 @@
 /area/station/maintenance/fore/greater)
 "xEZ" = (
 /obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xFa" = (
@@ -64384,6 +65318,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"xNB" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xNE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -64456,6 +65397,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xPy" = (
@@ -64463,6 +65408,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
+"xPz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "xPG" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -64918,6 +65870,18 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"xXq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/station/hallway/primary/starboard)
 "xXs" = (
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
 /obj/effect/landmark/start/hangover/closet,
@@ -65346,6 +66310,9 @@
 /area/station/science/ordnance/bomb)
 "yeS" = (
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "yeX" = (
@@ -65481,6 +66448,10 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "yif" = (
@@ -109065,8 +110036,8 @@ bYp
 iaB
 rsZ
 bRU
-ftr
-dUI
+lge
+xXq
 kPb
 hNy
 hNy
@@ -113192,7 +114163,7 @@ kPb
 kPb
 kPb
 gRY
-kbW
+mVl
 rrr
 tnf
 pRf
@@ -156112,7 +157083,7 @@ tJN
 pSH
 pSH
 ikk
-neH
+iCN
 tIy
 xIR
 ple
@@ -156370,7 +157341,7 @@ sqw
 pSH
 ikk
 ajb
-jhb
+gGI
 jwZ
 dEy
 dEy
@@ -156882,9 +157853,9 @@ gGS
 aVG
 ruD
 neH
-neH
+iCN
 nPd
-jhb
+gGI
 vxC
 vxC
 vxC
@@ -157088,9 +158059,9 @@ xOr
 nCs
 nUi
 phJ
-xLH
+pvt
 bnZ
-xLH
+tYP
 tFt
 hNy
 hNy
@@ -157138,9 +158109,9 @@ wRg
 xEr
 aVG
 pLT
+elD
 gpd
-gpd
-gpd
+elD
 gpd
 beC
 bDR
@@ -157598,60 +158569,60 @@ vHM
 ipc
 phJ
 bmE
-jzd
-jzd
-jzd
+ojZ
+ojZ
+ojZ
 bRJ
-jzd
+ojZ
 aPB
-jzd
+qik
 uIS
 lqw
-jzd
+ojZ
 ioI
 stp
-jzd
-jzd
+ojZ
+ojZ
 hgd
 ioI
 nCa
 hgd
-jzd
-jzd
-jzd
-jzd
+ojZ
+ojZ
+ojZ
+ojZ
 mbv
 tln
 stp
 wei
 hgd
 eIQ
-cqe
+wHt
 neH
 xas
 nPd
 tIy
 neH
-cqe
+wHt
 ewO
-xas
-tIy
+htw
+gKl
 pJf
-neH
-neH
+vsr
+vsr
 oAm
 eeu
 lFm
-neH
-neH
+vsr
+vsr
 pJf
-neH
-gJo
-neH
+vsr
+jIP
+vsr
 drh
 hcy
 nSu
-pLT
+fGR
 dST
 fJC
 fJC
@@ -157908,7 +158879,7 @@ aWD
 aWD
 aWD
 ljH
-pLT
+fGR
 dST
 fJC
 fJC
@@ -158111,24 +159082,24 @@ phJ
 phJ
 phJ
 phJ
-jzd
+ojZ
 imi
 jzd
-jzd
+qik
 rML
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-nCa
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+qik
+slq
 nSU
 ubv
 nvR
@@ -158136,20 +159107,20 @@ jEW
 kmc
 brC
 qYG
-jzd
-jzd
-jzd
-jzd
+qik
+qik
+qik
+qik
 dkA
-neH
+fuK
 nFl
 nFl
-neH
-neH
+fuK
+fuK
 dAJ
 sjU
 awg
-neH
+vjI
 atz
 dhV
 xAC
@@ -158159,13 +159130,13 @@ sxz
 gDG
 rmm
 atz
-neH
-neH
-neH
-neH
+vjI
+vjI
+vjI
+vjI
 neH
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -158368,7 +159339,7 @@ phJ
 fiZ
 weu
 phJ
-xLH
+pvt
 yaN
 xLH
 pGm
@@ -158420,9 +159391,9 @@ cBe
 cBe
 cBe
 jpN
-cqe
+wHt
 sJr
-cqe
+vsL
 dST
 fJC
 fJC
@@ -158934,9 +159905,9 @@ cZN
 fQs
 fQs
 jpN
-oOJ
+xNB
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -159193,7 +160164,7 @@ fQs
 jpN
 euf
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -159448,7 +160419,7 @@ pkB
 fQs
 fQs
 jpN
-neH
+vsr
 swn
 ngn
 dST
@@ -159653,7 +160624,7 @@ wPB
 htY
 dwX
 phJ
-cGo
+bsb
 bma
 cGo
 pGm
@@ -159705,9 +160676,9 @@ pkB
 fQs
 fQs
 jpN
-neH
+vsr
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -159910,9 +160881,9 @@ wPB
 htY
 pYM
 phJ
-mss
+uCm
 imi
-jzd
+qik
 nfE
 ggF
 dIi
@@ -160167,9 +161138,9 @@ ptU
 wPB
 nZB
 kPY
-xRm
+jXD
 ayc
-jzd
+qik
 nfE
 ggF
 dIi
@@ -160219,9 +161190,9 @@ pkB
 fQs
 fQs
 sXp
-neH
+vsr
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -160426,7 +161397,7 @@ dHO
 fMx
 irp
 ayc
-jzd
+qik
 nfE
 ggF
 kFI
@@ -160476,9 +161447,9 @@ pkB
 fQs
 fQs
 sXp
-neH
+vsr
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -160683,7 +161654,7 @@ blP
 phJ
 hSe
 ayc
-jzd
+qik
 nfE
 ggF
 dIi
@@ -160733,9 +161704,9 @@ pkB
 fQs
 fQs
 sXp
-neH
+vsr
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -160990,9 +161961,9 @@ pkB
 fQs
 fQs
 jpN
-neH
+vsr
 swn
-neH
+vjI
 dST
 fJC
 fJC
@@ -161197,7 +162168,7 @@ vOa
 phJ
 qrX
 ayc
-pEk
+rah
 nfE
 ggF
 dIi
@@ -161454,7 +162425,7 @@ phJ
 phJ
 cLh
 ayc
-jzd
+qik
 nfE
 ggF
 dIi
@@ -161504,7 +162475,7 @@ nxg
 nxg
 plp
 jpN
-neH
+wee
 wWM
 oHa
 dST
@@ -161711,7 +162682,7 @@ uBS
 gyL
 tUV
 oMz
-jzd
+qik
 nfE
 ggF
 dIi
@@ -161761,7 +162732,7 @@ sjl
 sjl
 sjl
 wek
-neH
+wee
 wWM
 qzF
 dST
@@ -161966,9 +162937,9 @@ fjt
 fQW
 fjt
 qav
-kLA
+ucR
 kME
-jzd
+qik
 nfE
 ggF
 dIi
@@ -162018,9 +162989,9 @@ kTd
 jnT
 pHy
 wek
-neH
+wee
 tCM
-neH
+vjI
 dST
 fJC
 fJC
@@ -162223,9 +163194,9 @@ phW
 phW
 phW
 phW
-lqC
+wpD
 kME
-jzd
+qik
 nfE
 ggF
 dIi
@@ -162275,9 +163246,9 @@ vop
 ajB
 mHz
 wek
-neH
+wee
 wWM
-neH
+vjI
 dST
 fJC
 fJC
@@ -162482,7 +163453,7 @@ pGx
 phW
 nCa
 qYi
-nCa
+slq
 pGm
 ggF
 dIi
@@ -162994,7 +163965,7 @@ cSp
 cSp
 xpM
 phW
-jzd
+mQg
 kME
 uck
 pGm
@@ -163046,9 +164017,9 @@ fQs
 fQs
 fQs
 jpN
-oOJ
+xNB
 eij
-neH
+vjI
 pNS
 jKM
 wvD
@@ -163251,7 +164222,7 @@ jVw
 cSp
 xIb
 oKS
-jzd
+mQg
 kME
 aWo
 pGm
@@ -163303,9 +164274,9 @@ fQs
 fQs
 fQs
 sXp
-neH
+vsr
 eij
-neH
+vjI
 maE
 jib
 ppS
@@ -163508,9 +164479,9 @@ gfI
 hNO
 qZK
 hlu
-aPB
+wDJ
 kME
-jzd
+qik
 pGm
 ggF
 xGC
@@ -163560,9 +164531,9 @@ fQs
 fQs
 fQs
 sXp
-neH
+vsr
 eij
-neH
+vjI
 maE
 fug
 ppS
@@ -163765,9 +164736,9 @@ jVw
 hNO
 tJA
 oKS
-jzd
+mQg
 kME
-jzd
+qik
 pGm
 ggF
 xGC
@@ -163817,9 +164788,9 @@ fQs
 fQs
 fQs
 sXp
-neH
+vsr
 eij
-neH
+vjI
 wFV
 jKM
 biD
@@ -164022,9 +164993,9 @@ cSp
 hNO
 fWi
 phW
-jzd
+mQg
 kME
-jzd
+qik
 wvB
 ggF
 xGC
@@ -164074,7 +165045,7 @@ kCb
 rsE
 koU
 sXp
-neH
+vsr
 eij
 vOA
 jKM
@@ -164281,7 +165252,7 @@ iXV
 phW
 jfX
 kME
-jzd
+qik
 pGm
 lLW
 xGC
@@ -164331,9 +165302,9 @@ fQs
 fQs
 uzh
 sXp
-neH
+vsr
 eij
-neH
+lzp
 dfj
 lqj
 nTy
@@ -164590,7 +165561,7 @@ pEf
 sXp
 jkS
 oVE
-neH
+lzp
 dfj
 lqj
 nTy
@@ -164847,7 +165818,7 @@ sAB
 sXp
 oaf
 qVM
-nIC
+oCG
 jAa
 lqj
 nTy
@@ -165307,7 +166278,7 @@ iMz
 xRc
 bkL
 lSi
-jzd
+ojZ
 bbS
 rac
 pGm
@@ -165361,7 +166332,7 @@ cqU
 jpN
 dhg
 jrQ
-neH
+vjI
 jAa
 jbE
 nTy
@@ -165618,7 +166589,7 @@ xEH
 ief
 wwz
 nOu
-neH
+vjI
 jAa
 wSx
 lqj
@@ -166337,7 +167308,7 @@ eZX
 nSZ
 jzd
 sro
-jzd
+qik
 nfE
 sZD
 bjs
@@ -166387,9 +167358,9 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 wWM
-neH
+lzp
 dfj
 lqj
 gUS
@@ -166594,7 +167565,7 @@ nff
 nSZ
 jzd
 sro
-jzd
+qik
 nfE
 fsz
 kfd
@@ -166644,7 +167615,7 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 plF
 xPs
 jAa
@@ -166851,7 +167822,7 @@ lSi
 nSZ
 jzd
 sro
-jzd
+qik
 nfE
 bLh
 bjs
@@ -166901,7 +167872,7 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 plF
 uCA
 jAa
@@ -167108,7 +168079,7 @@ dYH
 hEt
 jzd
 sro
-pEk
+rah
 pGm
 pGm
 feT
@@ -167158,7 +168129,7 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 plF
 pPI
 jAa
@@ -167415,7 +168386,7 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 plF
 nIC
 jAa
@@ -167622,7 +168593,7 @@ pmH
 pGm
 lHq
 sro
-jzd
+qik
 dtv
 pGm
 dbR
@@ -167672,9 +168643,9 @@ fQs
 fQs
 ctJ
 sXp
-neH
+vsr
 plF
-neH
+vjI
 jAa
 jAa
 jAa
@@ -167929,7 +168900,7 @@ fQs
 fQs
 ctJ
 jpN
-qQw
+xCt
 cNE
 qQw
 jAa
@@ -168136,7 +169107,7 @@ qjE
 qjE
 jzd
 sro
-jzd
+qik
 nfE
 ftO
 wuM
@@ -168186,7 +169157,7 @@ fQs
 fQs
 pEf
 jpN
-neH
+vsr
 plF
 lBt
 jAa
@@ -168393,7 +169364,7 @@ wgo
 wgo
 rVy
 sro
-jzd
+qik
 nfE
 sZD
 sZD
@@ -168445,7 +169416,7 @@ fQs
 jpN
 xEZ
 wEM
-pQc
+aPL
 rVR
 igQ
 aon
@@ -168650,7 +169621,7 @@ sLK
 fbn
 kNM
 gub
-jzd
+qik
 nfE
 sZD
 sZD
@@ -168700,7 +169671,7 @@ apy
 apy
 apy
 jpN
-neH
+vsr
 wWM
 dBn
 jAa
@@ -168907,7 +169878,7 @@ cHp
 wgo
 lcY
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -168957,7 +169928,7 @@ sAB
 ycX
 sAB
 uqA
-neH
+vsr
 wWM
 naK
 jAa
@@ -169164,7 +170135,7 @@ aIe
 wgo
 nCa
 rpy
-nCa
+slq
 pGm
 sZD
 sZD
@@ -169214,7 +170185,7 @@ vaX
 vaX
 vaX
 vaX
-neH
+vsr
 wWM
 qLS
 jAa
@@ -169419,9 +170390,9 @@ jWh
 czJ
 czJ
 czJ
-jfX
+hGQ
 pqA
-jzd
+qik
 pGm
 sZD
 sZD
@@ -169471,7 +170442,7 @@ dUG
 oht
 xpN
 hMD
-neH
+aqP
 wWM
 nIC
 jAa
@@ -169678,7 +170649,7 @@ oqJ
 czJ
 wjv
 pqA
-jzd
+qik
 pGm
 faO
 faO
@@ -169728,7 +170699,7 @@ qLH
 jXK
 pNi
 mYe
-eij
+mUk
 wWM
 knF
 jAa
@@ -169985,9 +170956,9 @@ qLH
 lQM
 fKP
 hMD
-neH
+aqP
 kTB
-ikM
+rnr
 lvB
 wRo
 wRo
@@ -170192,7 +171163,7 @@ rRi
 czJ
 wjv
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -170242,9 +171213,9 @@ tub
 klX
 wkI
 vaX
-neH
+aqP
 rBT
-pAd
+ukL
 hWt
 gbr
 gbr
@@ -170447,9 +171418,9 @@ lHe
 lHe
 lHe
 lHe
-mss
+hjj
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -170499,7 +171470,7 @@ qLH
 nZD
 fKP
 nuT
-neH
+aqP
 uVy
 qAx
 jAa
@@ -170704,9 +171675,9 @@ rxA
 aew
 nwa
 sYC
-jzd
+ojZ
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -170756,7 +171727,7 @@ qLH
 ttS
 cAF
 nuT
-neH
+aqP
 uVy
 sQN
 jAa
@@ -170961,7 +171932,7 @@ xoI
 kRf
 jFc
 sYC
-jzd
+ojZ
 pqA
 uck
 nfE
@@ -171015,7 +171986,7 @@ iDh
 vaX
 bIU
 cxe
-neH
+vjI
 jAa
 nTy
 uIR
@@ -171220,7 +172191,7 @@ eZk
 lHe
 wjI
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -171270,9 +172241,9 @@ vaX
 vaX
 vaX
 vaX
-neH
+vsr
 cxe
-neH
+vjI
 jAa
 dQF
 uIR
@@ -171475,9 +172446,9 @@ edN
 rar
 lpq
 sYC
-jzd
+ojZ
 pqA
-pEk
+rah
 nfE
 sZD
 sZD
@@ -171527,7 +172498,7 @@ iKq
 vXL
 skV
 fAY
-neH
+aqP
 cxe
 dtJ
 jAa
@@ -171732,9 +172703,9 @@ kRf
 kRf
 xys
 rWo
-jzd
+ojZ
 pqA
-kLA
+jaU
 nfE
 sZD
 sZD
@@ -171989,9 +172960,9 @@ xWY
 mFo
 fvR
 sYC
-jzd
+ojZ
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -172041,9 +173012,9 @@ bTg
 gaX
 sLX
 fAY
-neH
+aqP
 gUD
-nIC
+uht
 jAa
 nTy
 nTy
@@ -172248,7 +173219,7 @@ eeJ
 eeJ
 euj
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -172298,9 +173269,9 @@ aqX
 alI
 fAY
 fAY
-neH
+vsr
 gUD
-pLT
+oJY
 vGr
 frm
 frm
@@ -172505,7 +173476,7 @@ sHp
 tAw
 vaL
 pqA
-jzd
+qik
 nfE
 sZD
 sZD
@@ -172555,9 +173526,9 @@ uXk
 jjE
 pbo
 fAY
-neH
+vsr
 uVy
-neH
+pzn
 vpc
 nTy
 nTy
@@ -172760,9 +173731,9 @@ wms
 uvm
 etu
 tAw
-xLH
+pvt
 wmE
-xLH
+tYP
 pGm
 sZD
 sZD
@@ -172812,7 +173783,7 @@ jav
 jav
 rjJ
 fAY
-cDa
+nwv
 mIH
 cDa
 cEV
@@ -173020,55 +173991,55 @@ tAw
 osc
 pqA
 jzd
-jzd
+dQG
 dhf
 dhf
 yeS
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
-jzd
+ojZ
+ojZ
+ojZ
+ojZ
+ojZ
+ojZ
+ojZ
+ojZ
 stp
-jzd
-jzd
-jzd
+ojZ
+ojZ
+ojZ
 nCa
-jzd
-kLA
-jzd
-jzd
+ojZ
+pup
+bQb
+bQb
 sTk
-jzd
-jzd
-jzd
-jzd
-xLH
-neH
-neH
-neH
-neH
+ojZ
+ojZ
+ojZ
+ojZ
+pvt
+vsr
+vsr
+vsr
+vsr
 cUL
-neH
+oJc
 heb
-neH
-neH
-cqe
+oJc
+vsr
+wHt
 dVH
 dVH
 cqe
 rSI
 pAd
 pQD
+vsr
+vsr
+vsr
+vsr
 neH
-neH
-neH
-neH
-neH
-neH
+vsr
 neH
 uVy
 nIC
@@ -173274,7 +174245,7 @@ cQA
 hZd
 djt
 jws
-aPB
+jcK
 hgN
 iIX
 iIX
@@ -173328,7 +174299,7 @@ pQc
 pQc
 pQc
 mjE
-eeu
+fLn
 uIs
 rUx
 rUx
@@ -173533,24 +174504,24 @@ xdO
 pGm
 mss
 wAl
-jzd
-jzd
+qik
+qik
 vLL
 bdQ
 iZY
 opC
 loH
 bPw
-jzd
-jzd
-jzd
+qik
+qik
+qik
 iZY
 lRK
 jzd
 dBT
 idP
-jzd
-nCa
+qik
+slq
 deV
 cVY
 gjA
@@ -173559,32 +174530,32 @@ btl
 eBf
 jzd
 tiN
-jzd
+qik
 rTY
 biu
 bdk
-neH
-neH
+vjI
+vjI
 bFh
 trX
 grI
 bdk
 awg
-cqe
+vsL
 eET
 bdk
-cqe
-oAm
+vsL
+vQO
 pGw
 kIB
 kvT
 ndr
-neH
+vjI
 bFh
-neH
+vjI
 jdW
 gJo
-oAm
+vQO
 qEh
 cEV
 cEV
@@ -173814,9 +174785,9 @@ cpx
 pGm
 pGm
 pGm
-jzd
+rUY
 tiN
-jzd
+qrh
 pGm
 eZB
 eZB
@@ -174071,7 +175042,7 @@ dfI
 aha
 cjF
 pGm
-bGv
+txu
 iAV
 bGv
 eZB
@@ -174090,7 +175061,7 @@ bsP
 ukj
 svB
 cab
-lbS
+jsf
 hHc
 hHc
 hHc
@@ -174317,9 +175288,9 @@ iyx
 iyx
 pGm
 myS
-jzd
-dBT
-idP
+sTo
+mpq
+xPz
 euJ
 pGm
 lrZ
@@ -175114,7 +176085,7 @@ eZB
 eZB
 alo
 jsf
-bsP
+lZC
 nGD
 svB
 tjp
@@ -175372,7 +176343,7 @@ eZB
 eZB
 kPb
 rtD
-nGD
+njF
 pUp
 gnw
 hoD
@@ -175887,9 +176858,9 @@ tAd
 kPb
 wFA
 qyU
-nGD
-oXK
-nGD
+sjh
+tns
+sjh
 vZz
 wFA
 nUl
@@ -176659,7 +177630,7 @@ hHc
 dUQ
 hHc
 iBf
-oXK
+izO
 hlN
 hHc
 dUQ

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -167,6 +167,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"adq" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "adC" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -181,12 +187,6 @@
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"adI" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "adK" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -541,10 +541,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
-"ajO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "ajU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -878,6 +874,9 @@
 /area/station/maintenance/port/central)
 "api" = (
 /obj/machinery/requests_console/auto_name/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "apj" = (
@@ -894,11 +893,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/office)
-"apt" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "apu" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy"
@@ -1165,6 +1159,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
+"aum" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "aut" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 1
@@ -2279,6 +2280,9 @@
 "aOF" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aOK" = (
@@ -3289,6 +3293,12 @@
 /obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"biX" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "bjh" = (
 /turf/open/misc/dirt/jungle/dark/biodome,
 /area/station/maintenance/central/greater)
@@ -3455,6 +3465,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "blQ" = (
@@ -3706,6 +3717,9 @@
 /area/station/hallway/primary/central/fore)
 "brE" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "brP" = (
@@ -3721,6 +3735,9 @@
 /area/station/security/prison/work)
 "bsi" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsm" = (
@@ -4120,6 +4137,7 @@
 /area/station/security/checkpoint/customs)
 "bzt" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bzx" = (
@@ -4266,6 +4284,12 @@
 	},
 /turf/open/floor/bamboo,
 /area/station/command/heads_quarters/qm)
+"bCM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "bCN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5039,6 +5063,10 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"bRY" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bSh" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/station/maintenance/central/greater)
@@ -5670,6 +5698,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals - Fore Dock"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ceH" = (
@@ -5800,6 +5831,9 @@
 "cgK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/arrow_cw{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cgO" = (
@@ -6100,6 +6134,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"cnf" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "cnq" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
@@ -6718,6 +6756,9 @@
 "cxg" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cxn" = (
@@ -6864,8 +6905,9 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/prison)
 "czz" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "czI" = (
@@ -7066,6 +7108,7 @@
 /area/station/maintenance/fore/greater)
 "cCv" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cCx" = (
@@ -7396,6 +7439,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"cIn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/digital_clock/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "cIv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7680,12 +7730,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
-"cNt" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "cNE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7933,6 +7977,14 @@
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"cTe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "cTv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/north,
@@ -8128,7 +8180,7 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "cXv" = (
 /obj/machinery/door/airlock/public/glass,
@@ -8348,6 +8400,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Locker and Dorms Junction"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "dbD" = (
@@ -8424,6 +8479,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ddq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "ddA" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -8786,10 +8848,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "dju" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/full,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
 /area/station/service/hydroponics/garden)
 "djE" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -8816,6 +8877,9 @@
 /area/station/commons/storage/primary)
 "djP" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "djQ" = (
@@ -8828,13 +8892,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/hallway/secondary/service)
-"dka" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "dke" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 10
@@ -9083,6 +9140,12 @@
 	},
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/service/chapel/office)
+"doY" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "dpm" = (
 /turf/closed/wall,
 /area/station/service/lawoffice)
@@ -9440,6 +9503,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/curtain/cloth/fancy,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dwV" = (
@@ -9447,6 +9513,7 @@
 /area/station/maintenance/fore/greater)
 "dwX" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dxp" = (
@@ -9573,10 +9640,6 @@
 /obj/structure/girder,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
-"dAf" = (
-/obj/machinery/light/warm/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "dAg" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -9631,6 +9694,7 @@
 "dAR" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/light/warm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dAV" = (
@@ -10027,6 +10091,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dIh" = (
@@ -10242,6 +10307,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"dMN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "dMW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
@@ -10339,12 +10411,16 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "dPg" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dPj" = (
@@ -10644,6 +10720,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dUf" = (
@@ -10978,11 +11055,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"eaA" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "eaI" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/eighties,
@@ -11448,6 +11520,14 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/donk,
 /area/station/security/prison/mess)
+"emO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "emU" = (
 /obj/effect/spawner/random/engineering/vending_restock,
 /turf/open/floor/plating,
@@ -11927,7 +12007,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "evB" = (
-/obj/machinery/light/small/directional/north,
+/obj/structure/urinal/directional/north,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "evH" = (
@@ -11955,6 +12036,9 @@
 /area/station/engineering/atmos/mix)
 "evY" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ewv" = (
@@ -12261,6 +12345,9 @@
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Holodeck Controls"
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
@@ -13302,6 +13389,13 @@
 	},
 /turf/open/floor/grass,
 /area/station/science/breakroom)
+"eVe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eVp" = (
 /obj/item/stack/ore/iron,
 /turf/open/misc/asteroid/airless,
@@ -13379,6 +13473,9 @@
 "eXg" = (
 /obj/structure/table/wood,
 /obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "eXy" = (
@@ -13688,6 +13785,9 @@
 "fcr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/curtain/cloth/fancy,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fct" = (
@@ -13754,6 +13854,9 @@
 /area/station/engineering/atmos)
 "fdp" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fdy" = (
@@ -13816,6 +13919,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/security/processing)
+"feZ" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Civilian - Mining Aux Base and Garden Junction"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ffl" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -13960,6 +14072,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fiz" = (
@@ -14335,7 +14448,7 @@
 /obj/machinery/plumbing/synthesizer{
 	reagent_id = /datum/reagent/water
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "fqk" = (
 /obj/structure/chair/office/light,
@@ -14646,6 +14759,16 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
+"fvv" = (
+/obj/machinery/camera{
+	c_tag = "Civilian - aux_base Construction";
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "fvR" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/dark/small,
@@ -14736,6 +14859,7 @@
 /area/station/service/janitor)
 "fxB" = (
 /obj/structure/chair/comfy/beige,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fxQ" = (
@@ -14748,6 +14872,12 @@
 	dir = 4
 	},
 /area/station/engineering/transit_tube)
+"fyl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "fyu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -14996,6 +15126,7 @@
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fCL" = (
@@ -17045,6 +17176,10 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"gqi" = (
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "gqA" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17477,10 +17612,13 @@
 /obj/vehicle/sealed/mecha/ripley/cargo,
 /turf/open/floor/iron/recharge_floor,
 /area/station/cargo/warehouse)
-"gyb" = (
-/obj/structure/cable,
+"gxX" = (
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/port)
 "gyj" = (
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -18208,6 +18346,9 @@
 /area/station/medical/treatment_center)
 "gMO" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "gMZ" = (
@@ -18350,10 +18491,7 @@
 /area/station/engineering/atmos/pumproom)
 "gQd" = (
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/green{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/stairs,
 /area/station/service/hydroponics/garden)
 "gQh" = (
 /obj/structure/cable/multilayer/multiz,
@@ -18434,6 +18572,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrivals - Central Hall"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -18688,6 +18829,12 @@
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"gXv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gXA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18970,6 +19117,18 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"hcC" = (
+/obj/structure/railing/corner/end{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "hcH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
@@ -19156,7 +19315,7 @@
 "hgi" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/siding/green{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -19435,6 +19594,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"hlx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "hlC" = (
 /obj/structure/railing{
 	dir = 6
@@ -19786,6 +19951,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
+"htM" = (
+/obj/structure/plaque/static_plaque/golden/commission/biodome,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "htY" = (
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -19974,7 +20144,7 @@
 "hxH" = (
 /obj/effect/spawner/random/trash/mopbucket,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "hxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20395,6 +20565,9 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Arrivals - Aft Hall"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "hHj" = (
@@ -20576,6 +20749,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"hKV" = (
+/obj/item/pickaxe/rusted,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "hKX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray/cafeteria,
@@ -20783,6 +20960,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals - Ferry"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "hPX" = (
@@ -20838,6 +21018,11 @@
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"hQH" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/station/construction/mining/aux_base)
 "hQL" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -21840,10 +22025,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
-"iiR" = (
-/obj/structure/plaque/static_plaque/golden/commission/biodome,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "iji" = (
 /obj/structure/ladder,
 /turf/open/floor/iron/dark/telecomms,
@@ -22426,14 +22607,14 @@
 /area/station/service/chapel/office)
 "ivo" = (
 /obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/storage/box/lights/mixed,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/construction/mining/aux_base)
 "ivx" = (
 /obj/machinery/duct,
@@ -23437,6 +23618,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/bar)
+"iRG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "iRL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -23464,6 +23650,9 @@
 /area/station/security/brig/entrance)
 "iTp" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iTy" = (
@@ -24080,6 +24269,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jeJ" = (
@@ -24316,6 +24506,7 @@
 /area/station/asteroid)
 "jjr" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jjA" = (
@@ -24497,8 +24688,20 @@
 /obj/effect/spawner/random/entertainment/cigarette,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"jnG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "jnI" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jnJ" = (
@@ -24584,6 +24787,7 @@
 /area/station/hallway/primary/central/aft)
 "jpO" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jqn" = (
@@ -24776,6 +24980,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"jtz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "jtE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle,
@@ -25010,7 +25222,10 @@
 /turf/open/floor/carpet/executive,
 /area/station/security/prison)
 "jys" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "jyv" = (
@@ -25484,6 +25699,9 @@
 	dir = 4
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "jHc" = (
@@ -25533,6 +25751,28 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"jIn" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/south{
+	id = "aux_base_shutters";
+	name = "Public Shutters Control";
+	req_access = list("aux_base")
+	},
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/assault_pod/mining,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
+/area/station/construction/mining/aux_base)
 "jIp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Permabrig Visitation"
@@ -25866,10 +26106,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/misc/asteroid,
 /area/station/cargo/miningdock)
-"jPp" = (
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
 "jPA" = (
 /turf/open/misc/asteroid,
 /area/station/maintenance/fore/greater)
@@ -26111,6 +26347,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Checkpoint"
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -26431,6 +26670,9 @@
 /area/station/service/hydroponics)
 "kaJ" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kaK" = (
@@ -26459,7 +26701,7 @@
 /area/station/service/hydroponics/garden)
 "kaV" = (
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "kbd" = (
 /obj/structure/cable,
@@ -26859,6 +27101,15 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"kjq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kju" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/checker,
@@ -27217,6 +27468,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "koo" = (
@@ -27816,6 +28068,9 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kyo" = (
@@ -28202,6 +28457,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/meeting_room)
+"kGH" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "kGO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -29103,6 +29368,10 @@
 "kVg" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/shower)
+"kVm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "kVn" = (
 /turf/closed/wall,
 /area/station/medical/surgery/aft)
@@ -29321,6 +29590,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"lav" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lax" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/door/window/right/directional/north{
@@ -29724,6 +30000,9 @@
 "liq" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "liD" = (
@@ -30411,6 +30690,10 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"lvw" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "lvA" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -30468,6 +30751,14 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"lwu" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "lwv" = (
 /obj/structure/table/wood,
 /obj/item/book/granter/magazine/biodome{
@@ -30658,6 +30949,9 @@
 /area/station/security/detectives_office)
 "lyL" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "lyO" = (
@@ -31296,6 +31590,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
+"lIQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/corner,
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "lJa" = (
 /obj/item/picket_sign,
 /turf/open/misc/asteroid,
@@ -31901,8 +32201,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "lVd" = (
-/obj/effect/turf_decal/siding/green/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/bottle/nutrient/rh{
+	pixel_y = 8;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -31924,6 +32237,14 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
+"lVF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "lWa" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -32249,22 +32570,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mbi" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/pestspray{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/item/reagent_containers/cup/bottle/nutrient/rh,
-/obj/item/reagent_containers/cup/watering_can,
 /obj/effect/turf_decal/siding/green{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "mbl" = (
@@ -32645,6 +32957,11 @@
 	},
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"mhA" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "mhJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube{
@@ -33342,6 +33659,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"mvp" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "mvr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -33510,6 +33836,9 @@
 "mzm" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Arrivals - Aft Dock"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -33819,15 +34148,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"mGu" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "mGA" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/stripes/line{
@@ -33965,8 +34285,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mJi" = (
-/obj/structure/stairs/wood,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/siding/green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "mJo" = (
 /obj/item/fishing_rod,
@@ -35019,6 +35343,15 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"ndY" = (
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "nec" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -35169,6 +35502,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/landmark/start/assistant,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "nfL" = (
@@ -35696,11 +36030,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"nqU" = (
-/obj/effect/turf_decal/siding/green,
-/obj/structure/railing/corner/end/flip,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "nrd" = (
 /obj/structure/railing{
 	dir = 1
@@ -35744,6 +36073,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "nrz" = (
@@ -36033,6 +36363,9 @@
 /area/station/security/prison)
 "nxM" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "nxR" = (
@@ -36874,6 +37207,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"nND" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "nNM" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -37173,16 +37515,6 @@
 /obj/machinery/component_printer,
 /turf/open/floor/iron,
 /area/station/science/circuits)
-"nTo" = (
-/obj/structure/table,
-/obj/effect/spawner/random/trash/janitor_supplies,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "nTs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -37405,6 +37737,13 @@
 /obj/effect/landmark/start/clown,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
+"nXD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nXI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -37494,6 +37833,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/break_room)
+"nZB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "nZD" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -37853,6 +38199,12 @@
 /obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ofj" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "ofl" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -38074,6 +38426,11 @@
 /obj/machinery/modular_computer/preset/id,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"oji" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "ojn" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -38197,12 +38554,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"olz" = (
-/obj/effect/turf_decal/siding/green/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "olA" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/command,
@@ -38210,6 +38561,9 @@
 /area/station/command/meeting_room)
 "olJ" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "olM" = (
@@ -38412,6 +38766,9 @@
 /area/station/security/office)
 "opV" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "opX" = (
@@ -39021,6 +39378,9 @@
 "oBd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "oBg" = (
@@ -39051,6 +39411,12 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"oBs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "oBt" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39293,6 +39659,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Civilian - Dormitories Gathering Area"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oGJ" = (
@@ -39423,6 +39790,9 @@
 /area/station/hallway/primary/central)
 "oJi" = (
 /obj/structure/table,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "oJl" = (
@@ -39745,6 +40115,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/warm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oOW" = (
@@ -40096,6 +40467,12 @@
 "oWW" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/workout)
+"oWX" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "oXd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40173,7 +40550,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "oYE" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "oYV" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -40186,6 +40563,9 @@
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/siding/green{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -40680,6 +41060,7 @@
 /area/station/maintenance/department/science)
 "pht" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "phJ" = (
@@ -40803,6 +41184,9 @@
 "pjN" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pka" = (
@@ -41032,6 +41416,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"pnl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "pnu" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/chair_maintenance{
@@ -41673,6 +42064,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/security/courtroom)
+"pBC" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "pBE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/central)
@@ -41953,6 +42348,9 @@
 /area/station/maintenance/solars/port/aft)
 "pHk" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pHn" = (
@@ -42140,6 +42538,12 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"pLy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "pLz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
 	dir = 4
@@ -42245,6 +42649,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"pNw" = (
+/obj/machinery/duct,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/commons/toilet)
 "pND" = (
 /obj/effect/landmark/start/lawyer,
 /obj/structure/chair/office{
@@ -42296,6 +42704,9 @@
 "pOB" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42350,6 +42761,12 @@
 /obj/item/gun/syringe,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"pPD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pPI" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Storage Entrance"
@@ -42511,6 +42928,9 @@
 "pSZ" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Dormitories"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -42692,8 +43112,13 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "pXo" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/iron,
+/obj/machinery/computer/camera_advanced/base_construction/aux{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/mining_weather_monitor/directional/west,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/construction/mining/aux_base)
 "pXv" = (
 /obj/machinery/duct,
@@ -42764,6 +43189,7 @@
 /obj/machinery/holopad,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pYQ" = (
@@ -43180,6 +43606,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals - Fore Hall"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qgI" = (
@@ -43427,6 +43856,10 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/item/reagent_containers/spray/pestspray{
+	pixel_x = -11;
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "qlC" = (
@@ -43596,6 +44029,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"qnz" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qnB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -43672,12 +44112,13 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "qoG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qoW" = (
@@ -43915,6 +44356,11 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"qup" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "quv" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/chair/stool/directional/south{
@@ -44193,6 +44639,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qzY" = (
@@ -44588,6 +45037,13 @@
 	},
 /turf/open/water/jungle/biodome,
 /area/station/biodome)
+"qGN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "qGY" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -44697,6 +45153,9 @@
 /area/station/science/robotics/lab)
 "qJa" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qJl" = (
@@ -45719,6 +46178,14 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"ran" = (
+/obj/machinery/light/warm/directional/west,
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rar" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45744,10 +46211,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"raJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "rba" = (
 /obj/structure/reagent_dispensers/watertank{
 	pixel_x = -1
@@ -46394,6 +46857,9 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rnu" = (
@@ -46488,6 +46954,9 @@
 "roK" = (
 /obj/structure/table/wood,
 /obj/item/pai_card,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "roR" = (
@@ -46700,6 +47169,9 @@
 "rtf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rtt" = (
@@ -46771,26 +47243,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ruq" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/south{
-	id = "aux_base_shutters";
-	name = "Public Shutters Control";
-	req_access = list("aux_base")
-	},
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/assault_pod/mining,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/construction/mining/aux_base)
 "rut" = (
 /obj/effect/spawner/random/maintenance,
@@ -47081,6 +47543,7 @@
 /obj/machinery/bluespace_vendor/directional/east,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/air,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rzh" = (
@@ -47193,6 +47656,14 @@
 /obj/item/stamp/head/qm,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
+"rBu" = (
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rBD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47295,9 +47766,6 @@
 "rDI" = (
 /turf/open/misc/asteroid,
 /area/station/asteroid)
-"rDV" = (
-/turf/closed/wall,
-/area/space)
 "rEj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow,
@@ -47590,6 +48058,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"rKg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "rKm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/dark_green{
@@ -48327,6 +48801,9 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Civilian - Dormitories Minor Gathering Area"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rYo" = (
@@ -48346,10 +48823,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome)
-"rYH" = (
-/obj/machinery/light/directional/west,
-/turf/open/openspace,
-/area/station/service/hydroponics/garden)
 "rYO" = (
 /obj/structure/holosign/barrier/atmos/leaf,
 /turf/open/openspace,
@@ -48505,6 +48978,9 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "sch" = (
@@ -48995,10 +49471,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "smP" = (
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/siding/green{
-	dir = 10
+	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "snd" = (
@@ -49685,6 +50162,10 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/item/reagent_containers/cup/watering_can,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "sAh" = (
@@ -49887,8 +50368,17 @@
 /area/station/science/cytology)
 "sFk" = (
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"sFo" = (
+/obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "sFu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -50146,6 +50636,9 @@
 "sJF" = (
 /obj/structure/chair/comfy/lime{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -51419,6 +51912,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tjd" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "tje" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -51857,6 +52356,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"trp" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "trC" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -52333,11 +52838,6 @@
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"tAj" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "tAn" = (
 /obj/structure/falsewall,
 /obj/structure/disposalpipe/segment,
@@ -52795,19 +53295,6 @@
 	},
 /turf/open/floor/iron/terracotta,
 /area/station/service/chapel)
-"tIH" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for the Auxiliary Mining Base.";
-	dir = 4;
-	name = "Auxiliary Base Monitor";
-	network = list("auxbase");
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "tIJ" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -53031,6 +53518,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"tME" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "tMG" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -53456,6 +53950,12 @@
 /area/station/hallway/primary/starboard)
 "tWl" = (
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tWv" = (
@@ -53668,6 +54168,12 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"ubV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "ucg" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Satellite Access"
@@ -53942,12 +54448,6 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
-"uhS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
 "uhU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/stripes{
@@ -54002,10 +54502,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/bar)
-"ujW" = (
-/obj/structure/railing/corner/end,
-/turf/open/openspace,
-/area/station/service/hydroponics/garden)
 "ukj" = (
 /turf/open/floor/glass,
 /area/station/hallway/primary/starboard)
@@ -54224,6 +54720,7 @@
 /area/station/maintenance/aft/upper)
 "uoM" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uoU" = (
@@ -54289,6 +54786,14 @@
 /obj/structure/marker_beacon/olive,
 /turf/open/space/basic,
 /area/space/nearstation)
+"upC" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "upK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
@@ -54590,6 +55095,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uvm" = (
@@ -54605,6 +55113,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uwk" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "uwm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
@@ -54619,6 +55131,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/brig)
+"uwU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "uwY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -54641,6 +55158,9 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/green{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -55068,6 +55588,9 @@
 "uHc" = (
 /obj/machinery/light/warm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "uHr" = (
@@ -55187,6 +55710,13 @@
 	},
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
+"uJn" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uJp" = (
 /turf/closed/wall/mineral/wood,
 /area/station/maintenance/radshelter/civil)
@@ -55303,6 +55833,9 @@
 "uMt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -56079,6 +56612,14 @@
 "vco" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
+"vcr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "vcv" = (
 /obj/structure/chair/pew,
 /turf/open/floor/iron/chapel{
@@ -56564,6 +57105,13 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"vmt" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Civilian - Garden Overlook Port"
+	},
+/obj/structure/railing,
+/turf/open/openspace,
+/area/station/service/hydroponics/garden)
 "vmv" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/tile/neutral/half,
@@ -57074,6 +57622,9 @@
 /area/station/hallway/primary/aft)
 "vwy" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vwD" = (
@@ -57476,6 +58027,7 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "vEm" = (
@@ -57910,6 +58462,7 @@
 /obj/structure/holosign/barrier/atmos/leaf{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "vLU" = (
@@ -57968,8 +58521,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/lesser)
 "vMH" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "vMK" = (
@@ -58025,6 +58576,7 @@
 "vOa" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vOf" = (
@@ -58053,7 +58605,6 @@
 /area/station/maintenance/port/greater)
 "vOM" = (
 /obj/effect/turf_decal/siding/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -58068,6 +58619,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/corner,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vOY" = (
@@ -58248,6 +58800,9 @@
 /obj/machinery/computer/holodeck{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vSV" = (
@@ -58327,12 +58882,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "vUl" = (
-/obj/machinery/computer/camera_advanced/base_construction/aux{
+/obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/obj/machinery/mining_weather_monitor/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for the Auxiliary Mining Base.";
+	dir = 4;
+	name = "Auxiliary Base Monitor";
+	network = list("auxbase");
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/yellow/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/construction/mining/aux_base)
 "vUn" = (
 /obj/structure/disposalpipe/segment{
@@ -58449,7 +59010,7 @@
 /area/station/medical/medbay/lobby)
 "vVr" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
 "vVu" = (
 /obj/structure/table,
@@ -58666,6 +59227,7 @@
 /area/station/security/prison)
 "wbk" = (
 /obj/machinery/light/warm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "wbl" = (
@@ -58896,14 +59458,6 @@
 /obj/structure/ladder,
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
-"wfF" = (
-/obj/effect/turf_decal/tile/yellow/diagonal_edge,
-/obj/machinery/camera{
-	c_tag = "Civilian - aux_base Construction";
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "wfG" = (
 /obj/structure/railing,
 /obj/machinery/door/firedoor,
@@ -59544,6 +60098,11 @@
 /obj/effect/spawner/random/armory/rubbershot,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
+"woj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "wom" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
@@ -59703,6 +60262,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wrL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "wrT" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
@@ -60244,6 +60809,12 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"wAS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/station/hallway/secondary/entry)
 "wAW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -60683,6 +61254,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "wIo" = (
@@ -61197,6 +61771,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wSZ" = (
+/obj/effect/spawner/random/structure/table_fancy,
+/obj/item/flashlight/lamp{
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/obj/item/newspaper,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "wTa" = (
 /obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
 	dir = 4
@@ -61468,6 +62051,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wYy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "wYz" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -61739,13 +62329,6 @@
 "xdO" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xdR" = (
-/obj/structure/stairs/wood,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
 "xdT" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
@@ -61870,11 +62453,6 @@
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
-"xgk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "xgT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -62101,13 +62679,10 @@
 /turf/open/floor/stone,
 /area/station/commons/lounge)
 "xlg" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 1
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/stairs,
 /area/station/service/hydroponics/garden)
 "xls" = (
 /obj/structure/cable,
@@ -62488,6 +63063,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome/aft)
+"xuf" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "xuo" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai)
@@ -63019,6 +63598,15 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/cmo)
+"xEx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "xEA" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -63173,6 +63761,13 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xGG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "xGK" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
@@ -63260,6 +63855,7 @@
 /area/station/maintenance/fore/greater)
 "xIB" = (
 /obj/machinery/light/warm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xII" = (
@@ -63320,12 +63916,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/biodome/fore)
-"xJr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/warm/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xJw" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/blue{
@@ -63472,6 +64062,9 @@
 "xLB" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xLE" = (
@@ -63755,6 +64348,10 @@
 /obj/structure/cable,
 /turf/open/floor/bronze,
 /area/station/service/library/lounge)
+"xQQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/glass/reinforced,
+/area/station/maintenance/department/crew_quarters/dorms)
 "xRa" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -63825,7 +64422,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/plating,
 /area/station/commons/toilet)
 "xRM" = (
 /obj/effect/spawner/structure/window,
@@ -63878,6 +64475,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"xTs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "xTy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64025,13 +64630,6 @@
 /obj/structure/cable,
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
-"xVo" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
 "xVv" = (
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
@@ -64151,6 +64749,9 @@
 "xXA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xXK" = (
@@ -64519,12 +65120,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"yeu" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Civilian - Mining Base and Garden Junction"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "yex" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -64580,6 +65175,9 @@
 /area/station/command/teleporter)
 "yfa" = (
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "yfd" = (
@@ -82807,7 +83405,7 @@ gQd
 hgi
 smP
 mJi
-pSz
+upC
 aMB
 vhE
 aMB
@@ -83061,10 +83659,10 @@ uNS
 pSz
 nxV
 xlg
+hcC
 dey
-nqU
-xdR
-pSz
+qQd
+tME
 aMB
 vhE
 aMB
@@ -83318,10 +83916,10 @@ ugH
 pSz
 uxR
 lVd
+ndY
 pKg
-olz
-adI
-xVo
+qQd
+tME
 vhE
 xEk
 mCk
@@ -83575,10 +84173,10 @@ ugH
 pSz
 qlz
 dey
-raJ
-ajO
+dey
+dey
 qQd
-uhS
+tME
 aMB
 vhE
 aMB
@@ -83832,8 +84430,8 @@ ugH
 pSz
 mbi
 dey
+dey
 olt
-xgk
 vOM
 fBS
 aMB
@@ -84088,7 +84686,7 @@ smL
 ugH
 pSz
 jGV
-sAe
+kGH
 sAe
 pOB
 oZa
@@ -85375,7 +85973,7 @@ pSz
 pzL
 bjW
 wCP
-vhE
+lvw
 mHU
 mwz
 aMB
@@ -139339,7 +139937,7 @@ vtU
 vtU
 vtU
 qlI
-fDn
+oBs
 xpD
 gUy
 nlB
@@ -139355,7 +139953,7 @@ gUy
 gUy
 gUy
 sSb
-fDn
+pLy
 qlI
 hHc
 hHc
@@ -140110,7 +140708,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 wDC
 sCo
 kYp
@@ -140126,7 +140724,7 @@ gUy
 dml
 sCo
 uEb
-fDn
+pLy
 gUy
 gUy
 gUy
@@ -140367,7 +140965,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 hoj
 hoj
 sle
@@ -140383,7 +140981,7 @@ gUy
 vQd
 hoj
 hoj
-fDn
+pLy
 trC
 ipY
 trC
@@ -140624,7 +141222,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 pNg
 hgs
 sle
@@ -140640,7 +141238,7 @@ gUy
 nNp
 hgs
 pNg
-fDn
+pLy
 trC
 xQr
 trC
@@ -141137,7 +141735,7 @@ hHc
 hHc
 hHc
 hHc
-qlI
+wAS
 vwy
 fpU
 gUy
@@ -141652,7 +142250,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 fpU
 gUy
 nlB
@@ -141668,7 +142266,7 @@ gUy
 gUy
 gUy
 cIv
-fDn
+pLy
 qlI
 cCZ
 vtU
@@ -141909,7 +142507,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 cte
 ieV
 gUy
@@ -141925,7 +142523,7 @@ hHc
 gUy
 rlO
 ceA
-fDn
+pLy
 qlI
 cCZ
 vtU
@@ -142166,7 +142764,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 hUO
 xpD
 gUy
@@ -142182,7 +142780,7 @@ hHc
 gUy
 sSb
 hUO
-fDn
+pLy
 qlI
 cCZ
 vtU
@@ -142423,7 +143021,7 @@ hHc
 hHc
 hHc
 qlI
-fDn
+oBs
 pNg
 xpD
 gUy
@@ -142439,7 +143037,7 @@ hHc
 gUy
 sSb
 pNg
-fDn
+pLy
 qlI
 cCZ
 vtU
@@ -142937,7 +143535,7 @@ ybk
 gUy
 dUQ
 qlI
-fDn
+oBs
 pNg
 wDC
 qmX
@@ -142953,7 +143551,7 @@ hwI
 qmX
 uEb
 pNg
-fDn
+pLy
 qlI
 cCZ
 vtU
@@ -143194,23 +143792,23 @@ jWq
 gUy
 gUy
 qlI
-fDn
-pNg
-pNg
-pNg
-fDn
-fDn
-fDn
-fDn
-fDn
-fDn
-fDn
-fDn
-fDn
-fDn
-pNg
+pBC
+ubV
+ubV
 pNg
 fDn
+fDn
+fDn
+fDn
+fDn
+fDn
+fDn
+fDn
+fDn
+fDn
+pNg
+xTs
+trp
 qlI
 cCZ
 vtU
@@ -143454,7 +144052,7 @@ qlI
 qlI
 qlI
 qlI
-pNg
+vcr
 fDn
 qlI
 vYh
@@ -143465,7 +144063,7 @@ cPQ
 qlI
 qlI
 dsE
-pNg
+jtz
 ikk
 ikk
 ikk
@@ -143711,7 +144309,7 @@ hgs
 qNE
 hUO
 dwP
-pNg
+vcr
 fDn
 gUy
 nsy
@@ -143722,7 +144320,7 @@ dzy
 gUy
 jjr
 fDn
-pNg
+jtz
 tXs
 bnJ
 rki
@@ -144225,7 +144823,7 @@ wyM
 wyM
 iuz
 fcr
-pNg
+vcr
 fDn
 gUy
 ebh
@@ -144473,7 +145071,7 @@ cCZ
 qlI
 jyh
 qlI
-fDn
+hlx
 wyM
 wyM
 wyM
@@ -144493,7 +145091,7 @@ aAD
 qlI
 qlI
 yhx
-pNg
+jtz
 ikk
 dqI
 bnJ
@@ -144730,16 +145328,16 @@ qlI
 qlI
 qlI
 qlI
-fdp
+aum
 sJF
 sJF
 kaJ
 sJF
 sJF
 iTp
-fDn
+hlx
 fcr
-pNg
+vcr
 fDn
 ycq
 hgs
@@ -144750,7 +145348,7 @@ fDn
 fDn
 hoj
 cYQ
-pNg
+jtz
 ikk
 dBp
 bnJ
@@ -144996,18 +145594,18 @@ qlI
 qlI
 qlI
 qlI
-pNg
-pNg
-pNg
-pNg
-pNg
+gXv
+xTs
+xTs
+xTs
+xTs
 gRj
 pNg
 cFR
 cFR
 cFR
 cFR
-cFR
+jnG
 ikk
 gnX
 bnJ
@@ -145516,8 +146114,8 @@ dDW
 dDW
 tzH
 lpZ
-gyb
-pNg
+rBO
+nXD
 ibF
 rgJ
 wvK
@@ -147050,8 +147648,8 @@ cCZ
 cCZ
 ngE
 mWR
-nRT
-dDW
+uwU
+xuf
 uNX
 fXt
 kRv
@@ -147306,9 +147904,9 @@ kAI
 hHc
 hHc
 ngE
-mGu
 ngE
 ngE
+mvp
 ngE
 fXt
 fXt
@@ -147563,13 +148161,13 @@ dUQ
 hHc
 hHc
 mLm
-evY
-txv
-txv
-txv
-txv
-txv
-vwk
+lav
+wrL
+wYy
+wrL
+wrL
+wrL
+nND
 bsi
 tWl
 evY
@@ -147805,6 +148403,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 lmJ
 lmJ
@@ -147820,8 +148419,7 @@ lmJ
 lmJ
 lmJ
 lmJ
-eaA
-wBS
+uJn
 wBS
 wBS
 wBS
@@ -148062,6 +148660,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -148073,14 +148672,13 @@ tJQ
 tJQ
 tJQ
 rrD
-tIH
 vUl
 pXo
+hQH
 lmJ
-xJr
-fmZ
+rBu
 qoG
-txv
+bRY
 pSz
 esU
 esU
@@ -148319,6 +148917,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -148330,19 +148929,18 @@ tJQ
 tJQ
 tJQ
 rrD
-apt
 jys
-jys
+adq
+adq
 sCM
-evY
-fmZ
-txv
+wrL
+qoG
 jpO
-rYH
 nDd
 nDd
 nDd
-xmp
+nDd
+vmt
 riL
 riL
 xMk
@@ -148576,6 +149174,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -148587,19 +149186,18 @@ tJQ
 tJQ
 tJQ
 rrD
-jys
+oWX
 lqI
-vMH
+kVm
 sCM
-evY
-fmZ
-txv
+wrL
+qoG
 jpO
 nDd
 nDd
 nDd
 nDd
-nDd
+dwf
 riL
 riL
 iXd
@@ -148833,6 +149431,7 @@ hHc
 kAI
 dUQ
 dUQ
+vtU
 lmJ
 tJQ
 tJQ
@@ -148844,19 +149443,18 @@ tJQ
 tJQ
 tJQ
 rrD
-wfF
-jys
+fvv
 vMH
+woj
 rHl
-evY
-fmZ
-txv
+dMN
+qoG
 vLR
 gxn
 krT
 nDd
-ujW
-isx
+nDd
+dwf
 riL
 riL
 iXd
@@ -149090,6 +149688,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -149101,12 +149700,11 @@ tJQ
 tJQ
 oBo
 kLT
-jys
+oWX
 kLg
-dka
+fyl
 wZS
-wBS
-fmZ
+kjq
 qJa
 vLR
 qgp
@@ -149347,6 +149945,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -149358,13 +149957,12 @@ tJQ
 tJQ
 tJQ
 rrD
-jys
-jys
-cNt
+oWX
+vMH
+oji
 rHl
-txv
+wrL
 fmZ
-txv
 jpO
 riL
 riL
@@ -149604,6 +150202,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -149615,20 +150214,19 @@ tJQ
 tJQ
 tJQ
 rrD
-jys
+oWX
 uvT
-cNt
+oji
 sCM
-txv
+wrL
 fmZ
-iiR
 jpO
 riL
 nMm
 riL
-riL
+mhA
 dju
-riL
+htM
 riL
 nMm
 riL
@@ -149861,6 +150459,7 @@ hHc
 kAI
 hHc
 hHc
+cCZ
 lmJ
 tJQ
 tJQ
@@ -149872,13 +150471,12 @@ tJQ
 tJQ
 tJQ
 rrD
-tAj
-jys
 czz
+czz
+qGN
 sCM
-txv
+wrL
 fmZ
-txv
 jpO
 riL
 riL
@@ -150118,6 +150716,7 @@ hHc
 kAI
 dUQ
 dUQ
+vtU
 lmJ
 tJQ
 tJQ
@@ -150129,13 +150728,12 @@ tJQ
 tJQ
 tJQ
 rrD
-nTo
 ivo
 ruq
+jIn
 lmJ
-dAf
+gxX
 fmZ
-txv
 vLR
 gxn
 isx
@@ -150375,6 +150973,7 @@ hHc
 kAI
 hHc
 hHc
+vtU
 lmJ
 lmJ
 lmJ
@@ -150390,9 +150989,8 @@ lmJ
 lmJ
 lmJ
 lmJ
-yeu
+feZ
 fmZ
-txv
 vLR
 iXd
 dwf
@@ -150639,17 +151237,17 @@ qbT
 vOO
 jJi
 shZ
-cdP
-aOX
+hKV
+iRG
 kQd
 rJu
 jJi
 cqS
 cCo
 jJi
-txv
+ran
+wrL
 fmZ
-txv
 vLR
 iXd
 dwf
@@ -150890,7 +151488,7 @@ kAI
 hHc
 hHc
 jJi
-cdP
+wSZ
 aOX
 cdP
 cdP
@@ -150904,8 +151502,8 @@ ebn
 cdP
 cdP
 jJi
+qnz
 txv
-fmZ
 sFk
 vLR
 qgp
@@ -151147,7 +151745,7 @@ kAI
 hHc
 hHc
 jJi
-cdP
+cnf
 evn
 rps
 rps
@@ -151161,8 +151759,8 @@ rps
 rps
 rps
 sfX
+wrL
 txv
-fmZ
 fmZ
 jeH
 bDH
@@ -151404,7 +152002,7 @@ kAI
 dUQ
 dUQ
 jJi
-cdP
+kQd
 rps
 jJi
 uYb
@@ -151419,8 +152017,8 @@ oQA
 wuF
 wuF
 nxM
-fmZ
 txv
+fmZ
 jpO
 vgz
 bwl
@@ -151661,13 +152259,13 @@ kAI
 hHc
 hHc
 jJi
-cdP
+gqi
 rps
-jJi
+uYb
 tmw
-nvU
+xQQ
 cxJ
-jJi
+uYb
 rps
 wuF
 eou
@@ -151675,9 +152273,9 @@ hUM
 jFt
 jHg
 wuF
+wrL
 txv
 fmZ
-txv
 xLB
 lRJ
 lRJ
@@ -151920,11 +152518,11 @@ hHc
 jJi
 pFK
 rps
-jJi
+uYb
 cxJ
 nvU
 opt
-jJi
+uYb
 rps
 wuF
 dYX
@@ -151932,9 +152530,9 @@ rtN
 gex
 rBi
 wuF
+wrL
 txv
 fmZ
-txv
 xLB
 lRJ
 dPe
@@ -152189,9 +152787,9 @@ wBc
 cFs
 bLX
 wuF
+wrL
 txv
-fmZ
-txv
+fmR
 aOF
 lRJ
 bFu
@@ -152446,9 +153044,9 @@ lQH
 hbH
 jOp
 wuF
+wrL
 txv
-fmZ
-txv
+fmR
 aOF
 lRJ
 pgg
@@ -152703,10 +153301,10 @@ dxY
 aHz
 wuF
 jvz
-txv
+wrL
+fmR
 fmZ
-fmZ
-fmZ
+pPD
 tTk
 dWa
 oup
@@ -152960,7 +153558,7 @@ lGt
 aKp
 txY
 jvz
-dAf
+gxX
 fmZ
 xIB
 lRJ
@@ -153227,7 +153825,7 @@ vHE
 sUd
 lRJ
 loX
-jPp
+mBc
 lRJ
 lRJ
 bqd
@@ -153474,9 +154072,9 @@ ocT
 hUr
 rdE
 jvz
-txv
+wrL
 fmZ
-txv
+bRY
 lRJ
 akG
 kWe
@@ -153733,7 +154331,7 @@ wDZ
 rsd
 rtf
 rQq
-qoG
+eVe
 lRJ
 akG
 bLL
@@ -153988,9 +154586,9 @@ pbc
 ocT
 ckA
 fan
-fmR
+emO
 rQq
-txv
+bRY
 lRJ
 lRJ
 nNU
@@ -154005,11 +154603,11 @@ hNy
 hNy
 bqd
 gMO
-hDO
+doY
 vSU
 oJi
-hDO
-hDO
+doY
+biX
 ikk
 sej
 nQr
@@ -154247,10 +154845,10 @@ vmL
 jvz
 jnI
 rQq
-txv
+bRY
 lRJ
 fqi
-kzF
+pNw
 lRJ
 hNy
 hNy
@@ -154261,11 +154859,11 @@ dIN
 hNy
 hNy
 bqd
-hDO
-smo
+ofj
+xGG
 ncS
 smo
-oBd
+lIQ
 oBd
 oAZ
 hfI
@@ -154504,7 +155102,7 @@ vmv
 jvz
 cxg
 vwk
-evY
+qup
 xRJ
 kaV
 vVr
@@ -154522,7 +155120,7 @@ bqd
 eCW
 lyL
 opV
-xLq
+xEx
 bqd
 ikk
 ikk
@@ -154761,7 +155359,7 @@ xcb
 jvz
 dbz
 vwk
-txv
+bRY
 lRJ
 cXm
 oYE
@@ -155016,7 +155614,7 @@ phJ
 phJ
 phJ
 phJ
-txv
+wrL
 vwk
 cCv
 lRJ
@@ -155262,18 +155860,18 @@ jJi
 eUt
 fiZ
 phJ
-htY
-yfa
-htY
-htY
-htY
+bCM
+sFo
+bCM
+bCM
+bCM
 rYa
 uHc
-htY
-htY
+bCM
+bCM
 olJ
-okw
-txv
+lwu
+wrL
 vwk
 xIB
 pKF
@@ -155519,20 +156117,20 @@ jJi
 ipc
 wia
 phJ
-htY
+bCM
 sWq
 sWq
 sWq
-sWq
-sWq
-sWq
-sWq
-sWq
-htY
-okw
-txv
+rKg
+rKg
+rKg
+rKg
+rKg
+uwk
+tjd
+wrL
 vwk
-txv
+bRY
 pKF
 qrV
 qrV
@@ -155776,7 +156374,7 @@ jJi
 vqW
 vHM
 jFu
-sWq
+lVF
 sWq
 rya
 bec
@@ -155787,9 +156385,9 @@ phJ
 juY
 phJ
 phJ
-txv
+wrL
 vwk
-txv
+bRY
 pKF
 uYy
 oWc
@@ -156033,8 +156631,8 @@ jJi
 rBX
 ldC
 phJ
-htY
-sWq
+bCM
+rKg
 fxB
 rzf
 dUb
@@ -156044,9 +156642,9 @@ qCI
 vHM
 eUt
 phJ
-txv
+wrL
 vwk
-txv
+bRY
 tFt
 hNy
 hNy
@@ -156290,8 +156888,8 @@ jJi
 phJ
 phJ
 phJ
-htY
-sWq
+ddq
+rKg
 phJ
 phJ
 phJ
@@ -156547,8 +157145,8 @@ jJi
 eUt
 uGK
 phJ
-htY
-sWq
+cIn
+rKg
 phJ
 ugc
 vqW
@@ -156804,8 +157402,8 @@ jJi
 ipc
 vHM
 aKL
-sWq
-sWq
+lVF
+rKg
 vfV
 vHM
 ipc
@@ -157054,7 +157652,7 @@ hHc
 hHc
 kAI
 hHc
-rDV
+jJi
 jJi
 qma
 jJi
@@ -157062,7 +157660,7 @@ mNy
 mcK
 phJ
 pSZ
-sWq
+rKg
 phJ
 qjD
 mYc
@@ -157318,7 +157916,7 @@ jJi
 phJ
 phJ
 phJ
-htY
+pnl
 oOU
 phJ
 phJ
@@ -157575,8 +158173,8 @@ jJi
 vqW
 fiZ
 phJ
-htY
-sWq
+cIn
+rKg
 phJ
 fiZ
 weu
@@ -157832,8 +158430,8 @@ jJi
 rGH
 vHM
 dJJ
-sWq
-sWq
+lVF
+rKg
 nih
 vHM
 ipc
@@ -158089,8 +158687,8 @@ jJi
 mNy
 vld
 phJ
-htY
-sWq
+bCM
+rKg
 phJ
 cdF
 bys
@@ -158346,8 +158944,8 @@ jJi
 phJ
 phJ
 phJ
-htY
-sWq
+bCM
+rKg
 phJ
 phJ
 phJ
@@ -159114,7 +159712,7 @@ jJi
 ipc
 tWe
 kXB
-mBP
+cTe
 mBP
 htY
 lQt
@@ -159371,14 +159969,14 @@ jJi
 mNy
 pjw
 phJ
-htY
+bCM
 mBP
 jYK
 fOx
 lUk
 ptU
 wPB
-wPB
+nZB
 kPY
 xRm
 ayc
@@ -159628,7 +160226,7 @@ jJi
 phJ
 phJ
 phJ
-htY
+bCM
 mBP
 jYK
 bqh
@@ -159885,7 +160483,7 @@ jJi
 vqW
 dIh
 hMR
-mBP
+cTe
 mBP
 pco
 mSN
@@ -160402,8 +161000,8 @@ phJ
 pjN
 dAR
 pht
-htY
-htY
+uwk
+uwk
 oGo
 wbk
 vOa


### PR DESCRIPTION
 In this PR:

- Rearranges the garden a bit
- Makes the cryo wonderland's fake snow tiles non extremely cold and low pressure.
- The library's stair is no longer extremely steep (though might be rather awkward)
- Adds and updates a large amount of decals! Wow!
- Removes free fireworks from maintenance