### PR TITLE
Biodome: A wave of fire extinguishers

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -586,6 +586,13 @@
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"akc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "aki" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/terracotta/small,
@@ -3058,6 +3065,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bcq" = (
@@ -6333,6 +6341,7 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cov" = (
 /obj/structure/sink/directional/east,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/hydroponics)
 "coF" = (
@@ -7471,6 +7480,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"cFX" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "cGd" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -7796,6 +7812,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cLz" = (
@@ -8323,6 +8340,7 @@
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/warm/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "cWe" = (
@@ -12722,6 +12740,7 @@
 	c_tag = "Hallway - Biodome Aft Starboard Stairs"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eEW" = (
@@ -13389,6 +13408,11 @@
 /obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"ePk" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/smooth_half,
+/area/station/security/brig)
 "ePm" = (
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
@@ -14374,6 +14398,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
 "fhG" = (
@@ -15083,6 +15108,10 @@
 "fuT" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/aft)
+"fvc" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/eighties,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fvj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -16222,6 +16251,7 @@
 /area/station/security/prison/workout)
 "fPW" = (
 /obj/structure/closet/firecloset/full,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/stone,
 /area/station/security/execution/education)
 "fQf" = (
@@ -20148,6 +20178,7 @@
 "hmJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hmK" = (
@@ -21302,6 +21333,7 @@
 	pixel_y = 1
 	},
 /obj/effect/spawner/random/entertainment/gambling,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/carpet/donk,
 /area/station/hallway/secondary/service)
 "hLn" = (
@@ -22458,6 +22490,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Pharmacy"
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ihb" = (
@@ -23431,7 +23464,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/practice,
-/obj/machinery/airalarm/directional/south,
 /obj/item/gun/energy/laser/carbine/practice,
 /turf/open/floor/iron,
 /area/station/science/circuits)
@@ -24489,6 +24521,7 @@
 /obj/structure/rack,
 /obj/item/flashlight/flare,
 /obj/item/extinguisher/mini,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iXO" = (
@@ -29585,6 +29618,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"kMk" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "kMo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -31949,6 +31988,7 @@
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "Command - Teleporter"
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "lCf" = (
@@ -33418,6 +33458,7 @@
 /obj/machinery/computer/records/security{
 	dir = 8
 	},
+/obj/machinery/keycard_auth/directional/east,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hos)
 "mbn" = (
@@ -34786,15 +34827,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"mAL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "hosspace";
-	name = "Space Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/hos)
 "mAU" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -36439,9 +36471,13 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome)
 "ngg" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/machinery/oven/range,
+/obj/machinery/button/door/directional/west{
+	id = "kitchencounter";
+	req_access = list("kitchen");
+	name = "Kitchen Lockdown"
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "ngn" = (
@@ -37479,6 +37515,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
 "nAH" = (
@@ -37926,14 +37963,9 @@
 /area/station/science/server)
 "nJj" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
-/obj/machinery/button/door/directional/north{
-	id = "kitchencounter";
-	name = "Kitchen Lockdown";
-	pixel_x = -25;
-	req_access = list("kitchen")
-	},
 /obj/machinery/griddle,
 /obj/machinery/light/warm/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "nJl" = (
@@ -38881,7 +38913,7 @@
 "oae" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/machinery/deepfryer,
-/obj/machinery/airalarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "oaf" = (
@@ -39338,6 +39370,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
 "ogE" = (
@@ -41828,6 +41861,7 @@
 /area/station/maintenance/fore/greater)
 "pbH" = (
 /obj/machinery/light/warm/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "pbI" = (
@@ -43328,6 +43362,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome/fore)
+"pDx" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/fakepit,
+/area/station/hallway/primary/aft)
 "pDY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -44503,16 +44541,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qbc" = (
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
 /obj/item/storage/fancy/candle_box,
 /obj/structure/sign/painting/large/library_private{
 	dir = 1;
 	pixel_x = -15
 	},
+/obj/structure/rack/skeletal,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "qbe" = (
@@ -45489,11 +45523,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"qrF" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/smooth_half,
-/area/station/security/brig)
 "qrH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -45664,11 +45693,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"qvr" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "qvC" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid,
@@ -46251,6 +46275,7 @@
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "qFz" = (
@@ -48511,6 +48536,11 @@
 "rtw" = (
 /turf/open/openspace,
 /area/station/service/kitchen/diner)
+"rtx" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rty" = (
 /obj/structure/sign/picture_frame/showroom/two{
 	pixel_y = 32
@@ -49722,6 +49752,7 @@
 "rRI" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
 "rRN" = (
@@ -49837,6 +49868,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -49970,6 +50002,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rVd" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/stone,
+/area/station/maintenance/department/security/brig)
 "rVi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
@@ -51537,6 +51573,7 @@
 	c_tag = "Medbay - Chemical Factory Central"
 	},
 /obj/machinery/plumbing/sender,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -52756,6 +52793,7 @@
 /area/station/hallway/primary/central/aft)
 "sXs" = (
 /obj/machinery/module_duplicator,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "sXv" = (
@@ -53411,6 +53449,7 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "tkc" = (
@@ -55146,6 +55185,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"tPR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tPT" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
@@ -57609,6 +57655,7 @@
 "uQo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/grown/ash_flora/mushroom_cap,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "uQu" = (
@@ -58953,6 +59000,10 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"vpR" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/fakepit,
+/area/station/hallway/primary/aft)
 "vpT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62848,6 +62899,12 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
+"wFI" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "wFQ" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/water/jungle/biodome,
@@ -64710,9 +64767,9 @@
 "xsl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/keycard_auth/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "xsA" = (
@@ -66073,6 +66130,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/security/brig)
+"xQq" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "xQr" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -110957,7 +111019,7 @@ jCu
 byR
 jCu
 jCu
-jCu
+rVd
 tQV
 jCu
 jCu
@@ -157152,7 +157214,7 @@ wrT
 dig
 bOj
 utd
-wrT
+cFX
 xcb
 jvz
 dbz
@@ -158183,7 +158245,7 @@ phJ
 juY
 phJ
 phJ
-wrL
+akc
 vwk
 bRY
 pKF
@@ -159207,7 +159269,7 @@ vHM
 ipc
 phJ
 bmE
-ojZ
+tPR
 ojZ
 ojZ
 bRJ
@@ -162108,7 +162170,7 @@ jSc
 lqq
 dBH
 xJx
-hjg
+wFI
 nUq
 nUq
 hJB
@@ -162545,7 +162607,7 @@ mMI
 pco
 htY
 htY
-dwX
+kMk
 phJ
 cLQ
 ayc
@@ -164348,7 +164410,7 @@ iXV
 phW
 ukV
 kME
-qvr
+qik
 pGm
 ggF
 dIi
@@ -165376,7 +165438,7 @@ tJA
 oKS
 mQg
 kME
-qik
+xQq
 pGm
 ggF
 xGC
@@ -166459,7 +166521,7 @@ qVM
 oCG
 jAa
 lqj
-nTy
+vpR
 nPx
 cZt
 jVT
@@ -171084,7 +171146,7 @@ aqP
 wWM
 nIC
 jAa
-nTy
+pDx
 nTy
 dzO
 wRo
@@ -171610,7 +171672,7 @@ oPR
 djN
 ufJ
 ufJ
-nTy
+pDx
 psp
 peI
 qVs
@@ -173654,7 +173716,7 @@ aqP
 gUD
 uht
 jAa
-nTy
+pDx
 nTy
 nTy
 frm
@@ -175172,13 +175234,13 @@ qik
 rTY
 biu
 bdk
-vjI
+rtx
 vjI
 bFh
 trX
 grI
 bdk
-awg
+vjI
 vsL
 eET
 bdk
@@ -175188,7 +175250,7 @@ pGw
 kIB
 kvT
 ndr
-vjI
+rtx
 bFh
 vjI
 jdW
@@ -175225,7 +175287,7 @@ iwf
 rWr
 fpE
 ePm
-qrF
+oKs
 egm
 fht
 skK
@@ -175482,7 +175544,7 @@ cEF
 xbr
 gAM
 ePm
-oKs
+ePk
 egm
 hUJ
 vTi
@@ -177029,7 +177091,7 @@ cwu
 cwu
 vTi
 vTi
-mAL
+vTi
 eBh
 eBh
 eBh
@@ -178743,7 +178805,7 @@ cUx
 tYp
 jsg
 bon
-tYp
+fvc
 tYp
 xfB
 xdO


### PR DESCRIPTION
 **Biodome**

- Replaces the librarian skeletal minibar with a subtype
- Edited some wallmounts, mainly the kitchen shutter button to a proper West subtype, instead of a North one, and also altered the HoS office slightly
- Added a huge amount of fire extinguishers to decrease the deficit. Hopefully we have enough now.