### PR TITLE
Biodome updates

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -58746,11 +58746,9 @@
 /turf/open/floor/wood,
 /area/station/security/brig)
 "vjl" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/power/smes/full,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "vjn" = (
@@ -64057,9 +64055,7 @@
 /area/station/commons/vacant_room/office)
 "wZi" = (
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "wZn" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -189,12 +189,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
-"adK" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "adL" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
@@ -258,6 +252,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"aeW" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "aeX" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -6136,6 +6134,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
 "cjL" = (
@@ -6245,6 +6244,11 @@
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
+"cmt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "cmX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/decoration/ornament,
@@ -11961,14 +11965,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"eoP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "epe" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -11980,6 +11976,10 @@
 /obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/stone,
 /area/station/maintenance/fore/greater)
+"epn" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "epo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12206,6 +12206,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"eug" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/item/trash/can/food/squid_ink,
+/turf/open/misc/asteroid,
+/area/station/maintenance/central/greater)
 "euh" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -12636,6 +12643,10 @@
 "eBC" = (
 /turf/open/floor/grass,
 /area/station/biodome/fore)
+"eBE" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "eCg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15027,6 +15038,13 @@
 	},
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
+"ftz" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/trash/can/food/envirochow,
+/turf/open/misc/asteroid,
+/area/station/maintenance/central/greater)
 "ftG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -17567,6 +17585,7 @@
 "gnX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gnZ" = (
@@ -17748,6 +17767,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"gsr" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "gsu" = (
 /obj/machinery/computer/exoscanner_control,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -21313,7 +21336,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "hKV" = (
-/obj/item/pickaxe/rusted,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "hKX" = (
@@ -21536,6 +21559,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"hPS" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "hPX" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
@@ -21853,6 +21880,11 @@
 	},
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
+"hVZ" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "hWk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -23605,11 +23637,6 @@
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"iCC" = (
-/obj/effect/spawner/random/bureaucracy,
-/obj/structure/table/glass,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "iCF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -24234,12 +24261,6 @@
 "iQx" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"iQz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "iQB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -24387,6 +24408,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"iUl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "iUm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/table/wood,
@@ -25060,6 +25089,7 @@
 /area/station/maintenance/radshelter/civil)
 "jfA" = (
 /obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "jfX" = (
@@ -27675,6 +27705,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"keY" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "kfd" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/horizontal,
@@ -30250,6 +30284,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/grass,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"kVz" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kVI" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
@@ -32025,6 +32063,10 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/grass,
 /area/station/biodome)
+"lBQ" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "lBW" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -32524,6 +32566,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/station/asteroid)
+"lJR" = (
+/obj/machinery/light/small/red/dim/directional/south,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "lJT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36203,6 +36250,7 @@
 /area/station/hallway/primary/aft)
 "nct" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ncx" = (
@@ -36295,6 +36343,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"ndp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science)
 "ndr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -36931,6 +36984,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"noK" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/central)
 "noO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -37259,6 +37316,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
+"nvm" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "nvv" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/medical/surgery_tool,
@@ -38455,6 +38516,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/structure/railing,
 /turf/open/floor/stone,
 /area/station/hallway/primary/starboard)
 "nQr" = (
@@ -39597,6 +39659,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"okb" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "okj" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Civilian - Garden Overlook Stardboard"
@@ -40916,6 +40982,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"oHU" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "oHW" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron/diagonal,
@@ -42554,6 +42624,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"pmy" = (
+/obj/machinery/space_heater,
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/engine)
 "pmA" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/light/directional/west,
@@ -42756,6 +42830,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"pql" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/target/alien,
+/turf/open/misc/asteroid,
+/area/station/maintenance/central/greater)
 "pqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -43407,6 +43488,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pDj" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "pDq" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -43923,6 +44008,11 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"pMR" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/openspace,
+/area/station/maintenance/port/greater)
 "pNa" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/fakebasalt,
@@ -44712,11 +44802,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome/aft)
-"qdu" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "qdz" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
@@ -45902,6 +45987,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
+"qyj" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "qyo" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -49424,9 +49513,7 @@
 /area/station/science/ordnance)
 "rJu" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/spawner/random/structure/chair_maintenance{
-	dir = 4
-	},
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "rJv" = (
@@ -49932,6 +50019,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "rTu" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "rTx" = (
@@ -50354,6 +50442,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"saz" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "saK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -51102,6 +51194,7 @@
 /area/station/service/kitchen/diner)
 "sqw" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "sqG" = (
@@ -52974,6 +53067,10 @@
 /obj/machinery/smartfridge/petri/preloaded,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"tai" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "tak" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/camera/directional/north{
@@ -53508,6 +53605,10 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"tkg" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/iron/chapel,
+/area/station/service/chapel)
 "tkq" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -54884,6 +54985,11 @@
 "tIY" = (
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"tJc" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/random/bureaucracy,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/crew_quarters/dorms)
 "tJp" = (
 /obj/machinery/button/door/directional/south{
 	id = "Dorm1";
@@ -57258,6 +57364,10 @@
 	},
 /turf/open/floor/iron/vaporwave,
 /area/station/science/lab)
+"uGT" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uGY" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/structure/cable,
@@ -57883,6 +57993,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"uTu" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/station/maintenance/port/central)
 "uTS" = (
 /obj/effect/landmark/start/research_director,
 /obj/structure/chair/office,
@@ -59364,6 +59478,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/mix)
+"vwS" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "vwW" = (
 /obj/structure/table,
 /obj/effect/spawner/round_default_module,
@@ -59552,7 +59670,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "vAB" = (
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "vAC" = (
@@ -60048,6 +60166,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/eighties,
 /area/station/hallway/secondary/exit/departure_lounge)
+"vII" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "vIN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing,
@@ -62903,6 +63025,7 @@
 /area/station/service/chapel/funeral)
 "wFe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "wFr" = (
@@ -63394,10 +63517,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
-"wOY" = (
-/obj/machinery/light/small/directional/north,
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/station/asteroid)
 "wPj" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/misc/dirt/jungle/wasteland/biodome,
@@ -63685,6 +63804,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
+"wUR" = (
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "wUU" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/toilet/auxiliary)
@@ -84020,7 +84145,7 @@ hNy
 pKF
 wLL
 qjl
-kHz
+kVz
 pKF
 rRv
 rRv
@@ -84277,7 +84402,7 @@ pKF
 pKF
 aoY
 cJU
-cJU
+kHz
 pKF
 rRv
 rRv
@@ -87634,7 +87759,7 @@ dcz
 pKF
 xis
 pKF
-ote
+noK
 fKy
 pKF
 pKF
@@ -87891,7 +88016,7 @@ pKF
 pKF
 jly
 pKF
-dIN
+ote
 lcJ
 gmo
 pKF
@@ -88144,7 +88269,7 @@ dIN
 pKF
 sQq
 cJU
-hgp
+uTu
 dBC
 cJU
 cJU
@@ -89455,7 +89580,7 @@ vUn
 iQx
 iQx
 sak
-iQx
+uGT
 gDm
 iQx
 sKC
@@ -91273,7 +91398,7 @@ hNy
 hNy
 hNy
 hNy
-owr
+pmy
 nEB
 xWj
 hNy
@@ -91530,7 +91655,7 @@ iIl
 iIl
 iIl
 iIl
-pZS
+owr
 iGQ
 hNy
 hNy
@@ -92994,7 +93119,7 @@ cCZ
 cCZ
 rRv
 rRv
-rRv
+hNy
 hNy
 hNy
 hNy
@@ -93250,11 +93375,11 @@ cCZ
 cCZ
 rRv
 rRv
-rRv
-rRv
 hNy
 hNy
 hNy
+pKF
+pKF
 pKF
 vkO
 gxB
@@ -93510,9 +93635,9 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
 pKF
+kVz
+tai
 cJU
 gxB
 pKF
@@ -93768,8 +93893,8 @@ pKF
 pKF
 pKF
 pKF
-pKF
-pKF
+lBQ
+cJU
 cJU
 gxB
 pKF
@@ -94282,8 +94407,8 @@ pKF
 wpr
 cJU
 uXI
-cJU
-cJU
+xMO
+tai
 cJU
 uXI
 pUC
@@ -94303,10 +94428,10 @@ cJU
 cJU
 pKF
 oQV
-cJU
-cJU
-cJU
-cJU
+dBC
+uXI
+dBC
+kVz
 rZH
 wpF
 pKF
@@ -96162,7 +96287,7 @@ xsA
 bTO
 vtU
 hNy
-wOY
+hNy
 bqj
 xwg
 pZS
@@ -98648,7 +98773,7 @@ sBz
 tMJ
 rba
 mDo
-dYQ
+xRa
 dYQ
 gbs
 sBz
@@ -101006,7 +101131,7 @@ vaJ
 pli
 gtn
 sZB
-vaJ
+tkg
 uti
 bLt
 aUW
@@ -104559,7 +104684,7 @@ hNy
 sBz
 cwX
 ydf
-rcP
+cmt
 sBz
 kct
 sBz
@@ -105126,7 +105251,7 @@ frW
 uQJ
 oAe
 rVi
-gRN
+fOt
 wLJ
 gRN
 gRN
@@ -108929,8 +109054,8 @@ wOe
 geE
 hNy
 hNy
-sBz
-ybr
+xRa
+qwG
 sBz
 kBo
 lcr
@@ -109209,9 +109334,9 @@ ykP
 ykP
 uZp
 jry
-uZp
-uZp
-uZp
+tne
+pDj
+tne
 sfP
 bGM
 bGM
@@ -109482,7 +109607,7 @@ uZp
 uZp
 uZp
 uZp
-xPW
+lJR
 bRU
 ftr
 dUI
@@ -109491,10 +109616,10 @@ lYC
 lYC
 jbz
 gRN
-fTB
-fTB
+gRN
+gRN
 oAe
-oAe
+saz
 oAe
 hNy
 hNy
@@ -109708,7 +109833,7 @@ uZp
 uZp
 uZp
 uZp
-uZp
+keY
 btj
 ykP
 agK
@@ -109748,8 +109873,8 @@ gRN
 gRN
 gRN
 gRN
-fTB
-fTB
+eug
+ftz
 hNy
 hNy
 hNy
@@ -110004,8 +110129,8 @@ oAe
 jbz
 jbz
 oAe
-fTB
-fTB
+fOt
+pql
 hNy
 hNy
 hNy
@@ -111276,7 +111401,7 @@ oyW
 aCm
 bRU
 bGM
-uZp
+pDj
 bRU
 vSG
 vSG
@@ -149556,7 +149681,7 @@ vJS
 pSH
 pTI
 hdY
-pTI
+tiU
 ikk
 tMa
 cty
@@ -149813,7 +149938,7 @@ ikk
 ikk
 pTI
 pTI
-pTI
+pMR
 ikk
 tMa
 ikk
@@ -153425,7 +153550,7 @@ ikk
 ikk
 pSH
 aJI
-pSH
+eBE
 nKV
 nKV
 nKV
@@ -154666,7 +154791,7 @@ kAI
 hHc
 hHc
 jJi
-kQd
+wUR
 rps
 jJi
 uYb
@@ -156461,7 +156586,7 @@ hHc
 hHc
 kAI
 hHc
-hHc
+jJi
 jJi
 jJi
 jJi
@@ -156532,7 +156657,7 @@ bwV
 bwV
 jHc
 pSH
-ikk
+pSH
 ikk
 ikk
 ikk
@@ -156718,10 +156843,10 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
+hPS
 nct
-rxV
+hVZ
 rxV
 rxV
 jJi
@@ -156789,8 +156914,8 @@ ikk
 ikk
 ikk
 nYB
-eoP
 syt
+iUl
 qBF
 ikk
 duH
@@ -156975,12 +157100,12 @@ hHc
 hHc
 kAI
 hHc
-hHc
+jJi
+jJi
+rxV
+jJi
 jJi
 rps
-qdu
-jJi
-pwa
 jJi
 yhC
 cfm
@@ -157046,7 +157171,7 @@ syt
 fVb
 fVb
 iuv
-ikk
+eBE
 ikk
 ikk
 ikk
@@ -157232,11 +157357,11 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
+uCr
 rxV
-rxV
-rps
+oHU
+pwa
 rps
 jJi
 xXs
@@ -157489,8 +157614,8 @@ hHc
 hHc
 kAI
 dUQ
-dUQ
 jJi
+rps
 rxV
 jJi
 phJ
@@ -157747,7 +157872,7 @@ hHc
 kAI
 hHc
 jJi
-jJi
+rxV
 rxV
 jJi
 eUt
@@ -158005,7 +158130,7 @@ kAI
 hHc
 jJi
 rxV
-rxV
+aJf
 jJi
 ipc
 wia
@@ -158262,7 +158387,7 @@ kAI
 dUQ
 jJi
 rxV
-uCr
+tJc
 jJi
 vqW
 vHM
@@ -158776,7 +158901,7 @@ kAI
 hHc
 jJi
 rxV
-iCC
+sxR
 jJi
 phJ
 phJ
@@ -159033,7 +159158,7 @@ kAI
 dUQ
 jJi
 rxV
-sxR
+rps
 jJi
 eUt
 uGK
@@ -159107,7 +159232,7 @@ vxC
 pwU
 fJC
 eKQ
-fJC
+qWS
 geA
 rzH
 jSy
@@ -159363,7 +159488,7 @@ fJC
 vxC
 xsO
 fJC
-vxC
+dtB
 vxC
 geA
 wse
@@ -159547,7 +159672,7 @@ kAI
 hHc
 jJi
 jJi
-qma
+rxV
 jJi
 mNy
 mcK
@@ -159621,7 +159746,7 @@ wum
 xsO
 fJC
 fJC
-kFl
+okb
 geA
 mvr
 qPj
@@ -159802,8 +159927,8 @@ hHc
 hHc
 kAI
 dUQ
-dUQ
 jJi
+rps
 rxV
 jJi
 phJ
@@ -159878,7 +160003,7 @@ vxC
 xsO
 fJC
 fJC
-qWS
+kFl
 geA
 mvr
 jNi
@@ -160059,8 +160184,8 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
+rxV
 rxV
 jJi
 vqW
@@ -160316,9 +160441,9 @@ hHc
 hHc
 kAI
 hHc
-hHc
 jJi
 rxV
+jJi
 jJi
 rGH
 vHM
@@ -160574,8 +160699,8 @@ rRv
 jJi
 jJi
 jJi
-jJi
 rxV
+qma
 jJi
 mNy
 vld
@@ -165533,7 +165658,7 @@ tfN
 bUe
 vxC
 wFe
-uIF
+okb
 vxC
 xSe
 khx
@@ -166580,7 +166705,7 @@ nJd
 syh
 fRJ
 pOn
-fJC
+vwS
 xKn
 vxC
 hNy
@@ -169041,7 +169166,7 @@ jpl
 jpl
 jpl
 jpl
-btB
+sfJ
 cLA
 aXw
 dJN
@@ -170328,7 +170453,7 @@ hHc
 hHc
 jpl
 jpl
-adK
+fNz
 cLA
 bhY
 dJN
@@ -170584,7 +170709,7 @@ hHc
 hHc
 hHc
 jpl
-cLA
+aeW
 fNz
 cLA
 urw
@@ -170841,7 +170966,7 @@ hHc
 hHc
 uzJ
 dCB
-hUb
+urw
 fNz
 cLA
 dJN
@@ -171355,7 +171480,7 @@ hHc
 hHc
 hHc
 dCB
-cLA
+hUb
 fNz
 cLA
 dJN
@@ -171612,7 +171737,7 @@ hHc
 hHc
 hHc
 jpl
-bhl
+btB
 fNz
 fNz
 fNz
@@ -173423,7 +173548,7 @@ hHc
 jpl
 cLA
 jpl
-cLA
+nvm
 jpl
 jqK
 rFM
@@ -174778,11 +174903,11 @@ uVy
 nIC
 cEV
 fKL
-gww
+qyj
 mXg
-uEl
+gsr
 kSo
-uEl
+gww
 aSS
 aSS
 aSS
@@ -175480,7 +175605,7 @@ hHc
 hHc
 hHc
 jpl
-sfJ
+vII
 cLA
 tIJ
 xdO
@@ -175991,7 +176116,7 @@ hHc
 hHc
 hHc
 jpl
-eRw
+ndp
 oyl
 vNu
 jpl
@@ -178566,7 +178691,7 @@ jpl
 xNN
 oCQ
 cLA
-iQz
+eHu
 jpl
 jpl
 jpl
@@ -178612,7 +178737,7 @@ wtM
 mae
 eSK
 eZB
-avN
+epn
 aFC
 avN
 hKD
@@ -179077,8 +179202,8 @@ hHc
 hHc
 hHc
 hHc
-hHc
 jpl
+brn
 cLA
 eHu
 jpl
@@ -179334,8 +179459,8 @@ hHc
 hHc
 hHc
 hHc
-hHc
 jpl
+bhl
 cLA
 eHu
 jsl
@@ -179591,7 +179716,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+jpl
 jpl
 caf
 caf

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -6200,11 +6200,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "clm" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
+	},
+/obj/machinery/modular_computer/preset/id{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -18057,11 +18057,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gxl" = (
-/obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
 /obj/structure/sign/departments/aiupload/directional/north,
+/obj/machinery/computer/cargo/request,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "gxn" = (
@@ -31575,11 +31575,11 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "luq" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
+	},
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -33206,10 +33206,8 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "lWa" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/full,
 /turf/open/floor/catwalk_floor/titanium,
 /area/station/ai_monitored/turret_protected/ai)
 "lWc" = (
@@ -50256,7 +50254,6 @@
 /turf/open/water/jungle/biodome,
 /area/station/biodome/fore)
 "rXg" = (
-/obj/machinery/computer/cargo/request,
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Bridge Fore"
 	},
@@ -50264,6 +50261,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/machinery/modular_computer/preset/engineering,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "rXr" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -53605,10 +53605,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tkg" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/iron/chapel,
-/area/station/service/chapel)
 "tkq" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -101131,7 +101127,7 @@ vaJ
 pli
 gtn
 sZB
-tkg
+vaJ
 uti
 bLt
 aUW


### PR DESCRIPTION
**Biodome** 

- Increased the number of guaranteed heaters by a couple, but not much.
- Greatly increased the number of atmos device spawners
- Greatly increased the number of crate spawners
- Greatly increased the number of PACMANs
- Rearranged bits of maintenance.
- Added one more maintenance air canister, and moved some of the existing ones near doors.
- AIs start with a full SMES, as they are supposed to be.
- Adds a missing ID console to the bridge, replaces the mining shuttle console with it.