### PR TITLE
Adds spies to traitor limit

### DIFF
--- a/orbstation/code/antagonists/traitor_limit.dm
+++ b/orbstation/code/antagonists/traitor_limit.dm
@@ -32,8 +32,7 @@ GLOBAL_VAR_INIT(traitor_limit_antag_count, 0)
 	return ..()
 
 /datum/antagonist/traitor/on_removal()
-	if (GLOB.traitor_limit_antag_count > 0)
-		GLOB.traitor_limit_antag_count--
+	GLOB.traitor_limit_antag_count = max(0, GLOB.traitor_limit_antag_count - 1)
 	return ..()
 
 /datum/antagonist/brother/on_gain()
@@ -41,6 +40,14 @@ GLOBAL_VAR_INIT(traitor_limit_antag_count, 0)
 	return ..()
 
 /datum/antagonist/brother/on_removal()
-	if (GLOB.traitor_limit_antag_count > 0)
-		GLOB.traitor_limit_antag_count--
+	GLOB.traitor_limit_antag_count = max(0, GLOB.traitor_limit_antag_count - 1)
 	return ..()
+
+/datum/antagonist/spy/on_gain()
+	GLOB.traitor_limit_antag_count++
+	return ..()
+	
+/datum/antagonist/spy/on_removal()
+	GLOB.traitor_limit_antag_count = max(0, GLOB.traitor_limit_antag_count - 1)
+	return ..()
+	


### PR DESCRIPTION
## About The Pull Request

Adds spies to our traitor limit.

## Why It's Good For The Game

Because we had 9 antagonists for 18 players in the last round, oops!
Basically we just forgot to do this when spies were added. They're basically a traitor variant, so should be limited the same way.

I would _also_ suggest modifying the number spawned per spy roll too to be honest because it is quite high and our codebase might be comfortable with "one", but that is config not code.
Spies are currently roundstart exclusive, so a lot rolling immediately might still cause many antags to be present at once. This system only blocks midround/latejoin rolls.

## Changelog

:cl:
balance: Spies are counted against our "stop spawning more antagonists" limit.
/:cl:
