### PR TITLE
Fixes biodome ordnance igniter

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -3324,7 +3324,7 @@
 "bip" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "biu" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Hallway - Bridge Lake Overlook"
@@ -3924,7 +3924,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "btO" = (
 /obj/machinery/door/airlock/security{
 	name = "Courtroom Holding Area"
@@ -12040,7 +12040,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "eqU" = (
 /obj/machinery/meter/monitored/distro_loop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -15911,7 +15911,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "fLn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -21859,7 +21859,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "hVQ" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -29048,9 +29048,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/research)
-"kAW" = (
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
 "kAY" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -40730,7 +40727,7 @@
 "oDR" = (
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "oDT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44290,7 +44287,7 @@
 /area/station/maintenance/port/greater)
 "pSI" = (
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "pSM" = (
 /turf/open/floor/carpet/lone/star,
 /area/station/security/brig)
@@ -44618,7 +44615,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "pZn" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/carpet/black,
@@ -47084,7 +47081,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "qRD" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -53544,7 +53541,7 @@
 "tje" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "tjf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61394,7 +61391,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "wfW" = (
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
@@ -62025,7 +62022,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "wov" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
@@ -65266,7 +65263,7 @@
 "xyQ" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "xzb" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -65707,7 +65704,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "xGA" = (
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/service/chapel/office)
@@ -104666,7 +104663,7 @@ cCZ
 aWF
 cCZ
 cCZ
-kAW
+cxr
 fLl
 xGv
 wfT
@@ -104923,7 +104920,7 @@ cCZ
 aWF
 cCZ
 cCZ
-kAW
+cxr
 wot
 oDR
 eqT
@@ -105180,7 +105177,7 @@ cCZ
 aWF
 cCZ
 cCZ
-kAW
+cxr
 pSI
 tje
 pSI
@@ -105437,7 +105434,7 @@ cCZ
 aWF
 cCZ
 cCZ
-kAW
+cxr
 xyQ
 xyQ
 xyQ
@@ -105694,7 +105691,7 @@ cCZ
 aWF
 cCZ
 cCZ
-kAW
+cxr
 cCZ
 cCZ
 cCZ


### PR DESCRIPTION
 
## About The Pull Request
 The biodome ordnance burn chamber has not been updated to use the same area as the lab itself, therefore, it had no power. This Pr fixes that.

## Why It's Good For The Game
This is needed so scientists can make hot mixes.
 
## Changelog
 
:cl:
fix: Biodome ordnance lab igniter works once again.
/:cl:
 
