### PR TITLE
Fixes flooring under airlocks and a mis-rotated light on Biodome

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -7211,9 +7211,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "cBF" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/teleporter)
 "cBJ" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -13390,9 +13388,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "eNd" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/tcommsat/server)
 "eNi" = (
 /obj/structure/table/glass,
@@ -15541,9 +15537,7 @@
 /turf/open/openspace,
 /area/station/biodome/aft)
 "fAY" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/heads_quarters/hop)
 "fAZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16208,9 +16202,7 @@
 /turf/open/floor/carpet/donk,
 /area/station/hallway/secondary/service)
 "fNG" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/heads_quarters/captain)
 "fNI" = (
 /obj/machinery/door/airlock/maintenance{
@@ -16314,9 +16306,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "fPj" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/heads_quarters/captain/private)
 "fPm" = (
 /obj/structure/cable,
@@ -18714,9 +18704,7 @@
 /turf/open/floor/wood/large,
 /area/station/biodome/fore)
 "gHP" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/gateway)
 "gHT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -22839,9 +22827,7 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "ijZ" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/hallway/primary/central/aft)
 "ike" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23782,9 +23768,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
 "iCJ" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/biodome/aft)
 "iCN" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
@@ -24379,9 +24363,7 @@
 /turf/open/floor/catwalk_floor/titanium,
 /area/station/ai_monitored/turret_protected/ai)
 "iPI" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/security/holding_cell)
 "iPO" = (
 /obj/structure/table/wood,
@@ -31402,9 +31384,7 @@
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
 "loB" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/security/brig/entrance)
 "loD" = (
 /turf/open/floor/carpet/red,
@@ -32323,7 +32303,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/fakebasalt,
+/turf/open/floor/iron/smooth_half,
 /area/station/security/brig/entrance)
 "lCx" = (
 /obj/machinery/door/airlock/atmos/glass{
@@ -33213,9 +33193,7 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "lTv" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/bridge)
 "lTy" = (
 /obj/machinery/light/small/directional/east,
@@ -33987,9 +33965,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "meU" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "meV" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
@@ -34228,11 +34204,11 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/machinery/light/directional/east,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -38638,9 +38614,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nOL" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/meeting_room)
 "nOR" = (
 /obj/machinery/meter,
@@ -39567,9 +39541,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ofe" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/hallway/primary/central/fore)
 "ofg" = (
 /obj/structure/table,
@@ -40387,9 +40359,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/command/heads_quarters/hop)
 "oup" = (
 /obj/machinery/duct,
@@ -49353,7 +49323,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/fakebasalt,
+/turf/open/floor/iron/smooth_half,
 /area/station/security/brig/entrance)
 "rzW" = (
 /obj/structure/stairs/wood{
@@ -52636,7 +52606,6 @@
 	name = "Queue Shutters Control"
 	},
 /obj/machinery/button/door/directional/south{
-	pixel_y = -24;
 	pixel_x = 8;
 	name = "Privacy Shutters Control";
 	req_access = list("hop");
@@ -58685,9 +58654,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "vaX" = (
-/turf/closed/wall/r_wall/fakewood{
-	color = "#a9734f"
-	},
+/turf/closed/wall/r_wall/fakewood,
 /area/station/ai_monitored/command/storage/eva)
 "vaY" = (
 /obj/machinery/vending/assist,


### PR DESCRIPTION
Gives non-basalt floors under two doors in the Brig entrance, and a mis-rotated light in the Chemistry Lab.
![image](https://github.com/lizardqueenlexi/orbstation/assets/86125936/6fea21ae-82b2-452b-abe9-dc4e6ab33554)
![image](https://github.com/lizardqueenlexi/orbstation/assets/86125936/8606b662-76bc-411b-9952-769086b7ee9d)
