### PR TITLE
Biodome fixes

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -6527,6 +6527,8 @@
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/biodome/fore)
 "cpx" = (
@@ -7596,6 +7598,13 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"cFu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/fore)
 "cFv" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -9198,12 +9207,12 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 5
 	},
 /obj/structure/railing,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/biodome/fore)
 "diJ" = (
@@ -35641,7 +35650,6 @@
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "mvN" = (
-/obj/structure/cable,
 /obj/structure/railing/corner/end/flip{
 	dir = 1
 	},
@@ -40240,10 +40248,6 @@
 	},
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"odW" = (
-/obj/structure/cable,
-/turf/open/floor/iron/terracotta/small,
-/area/station/biodome/fore)
 "odZ" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -96868,9 +96872,9 @@ sBz
 bkp
 boi
 mvN
-odW
+aLk
 fSf
-uPu
+cFu
 uPu
 uPu
 fEU

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -60236,6 +60236,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"veQ" = (
+/obj/effect/baseturf_helper/space,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "veU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -105926,7 +105930,7 @@ oLx
 fjh
 lBW
 lBW
-uXD
+veQ
 uve
 tkq
 wAi

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -16377,6 +16377,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fLl" = (
@@ -19377,6 +19380,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -45445,11 +45451,11 @@
 /area/station/hallway/primary/central/aft)
 "pQE" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/left/directional/east{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "Engineering Delivery";
 	req_access = list("engineering")
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pQJ" = (
@@ -110486,8 +110492,8 @@ hDB
 fOu
 qKr
 tUR
-qKr
-qKr
+hDB
+hDB
 vHY
 vZE
 svn
@@ -110743,8 +110749,8 @@ qsh
 hDB
 hDB
 ukK
-qKr
-qKr
+hDB
+hDB
 tKi
 vZE
 fyH

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1335,6 +1335,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "avJ" = (
@@ -1708,6 +1709,10 @@
 /obj/item/toy/plush/carpplushie,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"aCs" = (
+/obj/structure/flora/rock/pile/jungle/style_3,
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "aCy" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -3597,6 +3602,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
+"blr" = (
+/obj/structure/transport/linear/public,
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "biodome_lake_lift"
+	},
+/obj/structure/railing,
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "blt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -3965,10 +3978,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"bsz" = (
-/obj/structure/lattice,
-/turf/open/openspace,
-/area/station/biodome)
 "bsD" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/structure/sign/poster/official/love_ian/directional/east,
@@ -9074,6 +9083,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"dgH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/machinery/light/floor,
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "dhb" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -9313,6 +9328,16 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"dku" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/bronze,
+/turf/open/floor/grass,
+/area/station/biodome)
 "dky" = (
 /obj/machinery/camera/autoname/directional/west{
 	c_tag = "Storage - Tech"
@@ -9576,6 +9601,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/mix)
+"dpw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/station/biodome)
 "dpE" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -9962,8 +9993,8 @@
 /turf/open/water/jungle/biodome,
 /area/station/maintenance/fore/greater)
 "dwX" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dxp" = (
@@ -11489,6 +11520,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"dYn" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/firecloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "dYG" = (
 /obj/effect/spawner/random/contraband/cannabis,
 /turf/open/misc/asteroid/airless,
@@ -14490,6 +14527,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"fbS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/station/biodome)
 "fbX" = (
 /obj/structure/dresser,
 /obj/item/pinpointer/nuke,
@@ -16097,6 +16140,16 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"fFS" = (
+/obj/machinery/door/window/elevator/right/directional/west{
+	transport_linked_id = "biodome_lake_lift"
+	},
+/obj/machinery/button/elevator/directional/north{
+	id = "biodome_lake_lift"
+	},
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fFW" = (
 /obj/structure/table,
 /obj/item/paper_bin/carbon{
@@ -16159,6 +16212,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"fHe" = (
+/obj/machinery/door/window/elevator/left/directional/west{
+	transport_linked_id = "biodome_lake_lift"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fHG" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -16166,7 +16225,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/turf/open/floor/grass,
+/turf/open/floor/bronze,
 /area/station/biodome)
 "fHJ" = (
 /obj/structure/cable/multilayer/multiz,
@@ -20164,7 +20223,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/turf/open/floor/grass,
+/turf/closed/wall/mineral/wood,
 /area/station/biodome)
 "hcN" = (
 /obj/machinery/camera/motion/directional/south{
@@ -20201,6 +20260,18 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
+"hdm" = (
+/obj/structure/transport/linear/public,
+/obj/machinery/elevator_control_panel/directional/north{
+	name = "Lake Lift Control Panel";
+	preset_destination_names = list("2"="Lake","3"="Lake Overlook");
+	linked_elevator_id = "biodome_lake_lift"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "hdp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external{
@@ -21650,6 +21721,14 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
+"hGG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome)
 "hGH" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26390,6 +26469,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
+"jrp" = (
+/obj/structure/railing,
+/turf/open/openspace,
+/area/station/biodome)
 "jrs" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/smooth_half,
@@ -28102,6 +28185,13 @@
 "jWZ" = (
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
+/area/station/biodome)
+"jXa" = (
+/obj/structure/transport/linear/public,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/water/jungle/biodome,
 /area/station/biodome)
 "jXb" = (
 /obj/structure/chair/office/light{
@@ -30156,6 +30246,13 @@
 /obj/structure/sign/warning/gas_mask,
 /turf/closed/wall,
 /area/station/cargo/storage)
+"kFu" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/diagonal,
+/area/station/biodome/aft)
 "kFA" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/turf_decal/weather/dirt{
@@ -30563,9 +30660,9 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "kMk" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kMo" = (
@@ -31487,6 +31584,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms)
+"ldF" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "ldI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fitness Maintenance"
@@ -31743,6 +31844,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"lho" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/service/hydroponics/garden)
 "lhq" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/structure/cable,
@@ -34373,13 +34481,13 @@
 	network = list("ss13","engine")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable/layer3,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/structure/cable/layer3,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /obj/effect/mapping_helpers/airalarm/link{
 	chamber_id = "engine"
 	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lZC" = (
@@ -34839,6 +34947,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"mgH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/button/elevator/directional/south{
+	id = "biodome_library_lift"
+	},
+/turf/open/floor/grass,
+/area/station/biodome)
 "mgI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
@@ -39032,6 +39149,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"nHd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/transport/linear/public,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/station/biodome)
 "nHe" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -39543,6 +39668,10 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/station/security/prison)
+"nQv" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/fakebasalt,
+/area/station/hallway/primary/aft)
 "nQw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -42412,7 +42541,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/turf/open/floor/grass,
+/turf/open/floor/bronze,
 /area/station/biodome)
 "oOB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46123,6 +46252,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"qfS" = (
+/obj/structure/transport/linear/public,
+/obj/machinery/elevator_control_panel/directional/south{
+	linked_elevator_id = "biodome_library_lift";
+	preset_destination_names = list("2"="Library Entrance","3"="Library Balcony")
+	},
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "biodome_library_lift"
+	},
+/turf/open/floor/plating,
+/area/station/biodome)
 "qgh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -46265,6 +46405,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"qjt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/holosign/barrier,
+/obj/machinery/button/elevator/directional/north{
+	id = "biodome_library_lift"
+	},
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "qjv" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/misc/asteroid,
@@ -46590,10 +46741,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qnz" = (
-/obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qnB" = (
@@ -47547,12 +47698,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
-"qEh" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qEw" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/fakebasalt,
@@ -48828,10 +48973,10 @@
 /area/station/hallway/primary/central/fore)
 "ran" = (
 /obj/machinery/light/warm/directional/west,
-/obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rar" = (
@@ -49847,8 +49992,9 @@
 /obj/structure/railing{
 	dir = 10
 	},
+/obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/iron/diagonal,
-/area/station/biodome)
+/area/station/hallway/primary/central)
 "rsZ" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -49920,6 +50066,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rtH" = (
@@ -50230,6 +50377,13 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
+/area/station/biodome)
+"ryA" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/bronze,
 /area/station/biodome)
 "ryC" = (
 /obj/structure/disposalpipe/segment{
@@ -51723,9 +51877,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "saK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "saU" = (
@@ -51797,6 +51949,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"scd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/structure/holosign/barrier,
+/turf/open/floor/grass,
+/area/station/biodome)
 "sch" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54365,6 +54524,13 @@
 /obj/structure/sign/warning/radiation/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/atmos/hfr_room)
+"sZw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "sZz" = (
 /obj/structure/railing{
 	dir = 1
@@ -55619,12 +55785,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"twp" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central)
 "twq" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56968,6 +57128,12 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"tUx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/closed/wall/mineral/wood,
+/area/station/biodome)
 "tUG" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56981,6 +57147,11 @@
 	},
 /turf/open/floor/fakepit,
 /area/station/hallway/primary/aft)
+"tUR" = (
+/turf/closed/wall/r_wall/fakewood{
+	color = "#a9734f"
+	},
+/area/station/biodome)
 "tUV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57679,6 +57850,15 @@
 /obj/effect/landmark/start/assistant/dept/srv,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/primary/central)
+"ukK" = (
+/obj/machinery/button/elevator/directional/east{
+	id = "biodome_lake_lift"
+	},
+/obj/machinery/door/window/elevator/left/directional/south{
+	transport_linked_id = "biodome_lake_lift"
+	},
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/biodome)
 "ukL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red{
@@ -58199,6 +58379,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/fake_dirt/wasteland,
 /area/station/science/research)
+"uty" = (
+/obj/machinery/status_display/evac/directional/east,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "utC" = (
 /obj/structure/reflector/double/anchored{
 	dir = 5
@@ -60030,6 +60215,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"veJ" = (
+/obj/structure/transport/linear/public,
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "veU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61015,6 +61204,12 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"vyf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/structure/holosign/barrier,
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "vyt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61648,6 +61843,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/fore)
+"vHY" = (
+/obj/structure/flora/rock/pile/jungle/style_5,
+/turf/open/water/jungle/biodome,
+/area/station/biodome)
 "vHZ" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/fakepit,
@@ -61860,12 +62059,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/construction)
-"vMh" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/diagonal,
-/area/station/biodome)
 "vMk" = (
 /mob/living/basic/bat,
 /turf/open/misc/asteroid,
@@ -61955,9 +62148,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vOa" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vOf" = (
@@ -65376,12 +65569,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"wUg" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/iron/diagonal,
-/area/station/biodome)
 "wUs" = (
 /obj/machinery/light/cold/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -65450,6 +65637,13 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/science/genetics)
+"wVJ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/diagonal,
+/area/station/biodome/aft)
 "wVM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65653,6 +65847,11 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/eighties/red,
 /area/station/hallway/secondary/exit/departure_lounge)
+"wZg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "wZh" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -67906,6 +68105,13 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"xPk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/holosign/barrier,
+/turf/open/floor/grass,
+/area/station/biodome)
 "xPs" = (
 /obj/structure/sign/directions/engineering/directional/south{
 	pixel_y = -42
@@ -96900,7 +97106,7 @@ lHT
 iId
 aLa
 tMS
-tMS
+hGG
 tMS
 aWc
 weR
@@ -97156,8 +97362,8 @@ ngd
 ngd
 wju
 ngd
-hcH
-qyC
+scd
+nHd
 bxm
 bxm
 weR
@@ -97413,8 +97619,8 @@ qyC
 rYF
 wju
 ngd
-mAU
-asD
+xPk
+qfS
 bxm
 bxm
 weR
@@ -97670,10 +97876,10 @@ vxL
 szJ
 wju
 ngd
-rmW
-koo
-dGd
-koo
+mgH
+tUx
+ryA
+dpw
 ilj
 oYq
 bjN
@@ -98185,7 +98391,7 @@ qHA
 wju
 ngd
 mHa
-fHG
+dku
 oOy
 fHG
 weR
@@ -98700,8 +98906,8 @@ wju
 hLn
 gbE
 hcH
-qyC
-qyC
+fbS
+fbS
 ilj
 pUk
 ehW
@@ -109999,8 +110205,8 @@ jvP
 baq
 nQz
 qKr
-qKr
-qKr
+aCs
+tKi
 qKr
 vZE
 pnf
@@ -110250,15 +110456,15 @@ qKr
 qKr
 fOu
 qKr
-qKr
-qvR
 tKi
+qvR
+hDB
 fOu
 qKr
-tKi
-qKr
-qKr
-qKr
+tUR
+hdm
+jXa
+vHY
 vZE
 svn
 pnf
@@ -110511,11 +110717,11 @@ bJY
 hDB
 qsh
 hDB
-qKr
-qKr
-qKr
-qKr
-qKr
+hDB
+ukK
+veJ
+blr
+tKi
 vZE
 fyH
 pzk
@@ -155217,7 +155423,7 @@ sFk
 vLR
 qgp
 iqy
-riL
+lho
 kkB
 okj
 xxS
@@ -162694,7 +162900,7 @@ rAq
 rAq
 rAq
 rAq
-vMh
+sjl
 rsY
 pkB
 pkB
@@ -162951,8 +163157,8 @@ rAq
 rAq
 rAq
 rAq
-bsz
-wUg
+pHy
+psK
 pkB
 oJI
 hne
@@ -163207,9 +163413,9 @@ nuN
 rAq
 rAq
 rAq
-rAq
-rAq
-rAq
+bxm
+qjt
+vyf
 tfd
 kKv
 cJg
@@ -163465,8 +163671,8 @@ rAq
 rAq
 rAq
 rAq
-rAq
-rAq
+sZw
+wZg
 pkB
 kKv
 vLt
@@ -163722,8 +163928,8 @@ rAq
 rAq
 rAq
 rAq
-rAq
-rAq
+sZw
+dgH
 tfd
 sJN
 hYE
@@ -163979,8 +164185,8 @@ rAq
 rAq
 rAq
 rAq
-rAq
-rAq
+sZw
+wZg
 pkB
 kKv
 vIN
@@ -164236,8 +164442,8 @@ rAq
 rAq
 rAq
 rAq
-rAq
-rAq
+sZw
+wZg
 tfd
 lBf
 kBa
@@ -164493,8 +164699,8 @@ rAq
 rAq
 rAq
 rAq
-sjl
-twp
+pHy
+psK
 pkB
 pkB
 pkB
@@ -164713,7 +164919,7 @@ bsQ
 bsQ
 oGo
 wbk
-vOa
+dYn
 phJ
 qrX
 ayc
@@ -164764,7 +164970,7 @@ cZN
 pkB
 pkB
 ltx
-fQs
+nxg
 fQs
 jpN
 xEZ
@@ -165020,8 +165226,8 @@ xly
 nxg
 nxg
 vKv
-nxg
-nxg
+kFu
+wVJ
 plp
 jpN
 wee
@@ -165277,8 +165483,8 @@ gux
 sjl
 sjl
 tVl
-sjl
-sjl
+pHy
+pHy
 sjl
 wek
 wee
@@ -169426,9 +169632,9 @@ pOn
 nTy
 nTy
 pGQ
-lqj
-lqj
-lqj
+rSn
+ldF
+nQv
 jAa
 frh
 jAa
@@ -175791,7 +175997,7 @@ lTv
 rbH
 iJK
 lTv
-rAq
+lTv
 rAq
 rAq
 rAq
@@ -176048,7 +176254,7 @@ lTv
 gRD
 gRD
 lTv
-rAq
+jrp
 rAq
 rAq
 rAq
@@ -176306,8 +176512,8 @@ jmI
 fgd
 lTv
 ofe
-cDb
-cDb
+fFS
+fHe
 cDb
 pGm
 ydn
@@ -177105,7 +177311,7 @@ vjI
 jdW
 gJo
 vQO
-qEh
+uCA
 cEV
 lFl
 lFl
@@ -177362,7 +177568,7 @@ jpN
 jpN
 lly
 wiB
-jpN
+uty
 cEV
 qyj
 oDp

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -110492,8 +110492,8 @@ hDB
 fOu
 qKr
 tUR
-hDB
-hDB
+qKr
+qKr
 vHY
 vZE
 svn
@@ -110749,8 +110749,8 @@ qsh
 hDB
 hDB
 ukK
-hDB
-hDB
+qKr
+qKr
 tKi
 vZE
 fyH

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2710,6 +2710,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"aTM" = (
+/turf/open/floor/bronze,
+/area/station/biodome)
 "aUi" = (
 /obj/effect/spawner/random/structure/table,
 /obj/effect/spawner/random/trash/crushed_can,
@@ -3602,14 +3605,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
-"blr" = (
-/obj/structure/transport/linear/public,
-/obj/effect/landmark/transport/transport_id{
-	specific_transport_id = "biodome_lake_lift"
-	},
-/obj/structure/railing,
-/turf/open/water/jungle/biodome,
-/area/station/biodome)
 "blt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -6528,7 +6523,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/cargo/office)
 "cps" = (
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
@@ -8086,7 +8080,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -8612,7 +8605,6 @@
 /area/station/medical/treatment_center)
 "cXZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -9328,16 +9320,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"dku" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/bronze,
-/turf/open/floor/grass,
-/area/station/biodome)
 "dky" = (
 /obj/machinery/camera/autoname/directional/west{
 	c_tag = "Storage - Tech"
@@ -16225,7 +16207,8 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/turf/open/floor/bronze,
+/obj/structure/flora/lunar_plant,
+/turf/open/floor/grass/lavaland,
 /area/station/biodome)
 "fHJ" = (
 /obj/structure/cable/multilayer/multiz,
@@ -19996,6 +19979,11 @@
 /obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"gYq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/warm/directional/east,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome)
 "gYt" = (
 /obj/structure/stairs/south,
 /obj/effect/turf_decal/tile/blue/half{
@@ -20260,18 +20248,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
-"hdm" = (
-/obj/structure/transport/linear/public,
-/obj/machinery/elevator_control_panel/directional/north{
-	name = "Lake Lift Control Panel";
-	preset_destination_names = list("2"="Lake","3"="Lake Overlook");
-	linked_elevator_id = "biodome_lake_lift"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/water/jungle/biodome,
-/area/station/biodome)
 "hdp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external{
@@ -20501,6 +20477,7 @@
 "hhD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "hii" = (
@@ -21721,14 +21698,6 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
-"hGG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/station/biodome)
 "hGH" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22104,6 +22073,12 @@
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/floor/fake_snow/safe,
 /area/station/maintenance/port/greater)
+"hNV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/closed/wall/mineral/wood,
+/area/station/biodome)
 "hOi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24557,6 +24532,13 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
 /area/station/biodome/fore)
+"iGx" = (
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iGJ" = (
 /obj/structure/broken_flooring/singular/directional/north,
 /turf/open/floor/plating,
@@ -26332,6 +26314,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "jpi" = (
@@ -28186,13 +28169,6 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/biodome)
-"jXa" = (
-/obj/structure/transport/linear/public,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/water/jungle/biodome,
-/area/station/biodome)
 "jXb" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -30005,6 +29981,7 @@
 /area/station/security/brig)
 "kBj" = (
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kBo" = (
@@ -30226,7 +30203,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/radshelter/civil)
 "kEZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
@@ -30252,7 +30228,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/diagonal,
-/area/station/biodome/aft)
+/area/station/hallway/primary/central)
 "kFA" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/turf_decal/weather/dirt{
@@ -32641,6 +32617,7 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "lvu" = (
@@ -33447,6 +33424,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"lGC" = (
+/obj/structure/transport/linear/public,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
+/area/station/biodome)
 "lGE" = (
 /obj/machinery/door/morgue{
 	name = "Relic Closet";
@@ -34954,6 +34938,9 @@
 /obj/machinery/button/elevator/directional/south{
 	id = "biodome_library_lift"
 	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "biodome_library_lift"
+	},
 /turf/open/floor/grass,
 /area/station/biodome)
 "mgI" = (
@@ -35656,6 +35643,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mtV" = (
@@ -36280,7 +36268,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/grass/lavaland,
 /area/station/biodome)
 "mHg" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -38717,6 +38705,11 @@
 "nzE" = (
 /turf/closed/wall/mineral/wood,
 /area/station/service/bar/backroom)
+"nzH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "nzK" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/decal/cleanable/dirt,
@@ -39149,14 +39142,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"nHd" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/structure/transport/linear/public,
-/obj/effect/spawner/random/engineering/tool,
-/turf/open/floor/plating,
-/area/station/biodome)
 "nHe" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -42541,7 +42526,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/turf/open/floor/bronze,
+/turf/open/floor/grass/lavaland,
 /area/station/biodome)
 "oOB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42590,6 +42575,7 @@
 	name = "Engineering Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/information,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oPj" = (
@@ -42643,6 +42629,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/security/processing)
+"oPK" = (
+/obj/structure/transport/linear/public,
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "biodome_lake_lift"
+	},
+/obj/structure/railing,
+/turf/open/openspace,
+/area/station/biodome)
 "oPR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/yellow{
@@ -43005,6 +42999,18 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/commons/toilet)
+"oYO" = (
+/obj/machinery/elevator_control_panel/directional/north{
+	name = "Lake Lift Control Panel";
+	preset_destination_names = list("2"="Lake","3"="Lake Overlook");
+	linked_elevator_id = "biodome_lake_lift"
+	},
+/obj/structure/transport/linear/public,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/biodome)
 "oYQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -46254,13 +46260,15 @@
 /area/station/science/explab)
 "qfS" = (
 /obj/structure/transport/linear/public,
-/obj/machinery/elevator_control_panel/directional/south{
-	linked_elevator_id = "biodome_library_lift";
-	preset_destination_names = list("2"="Library Entrance","3"="Library Balcony")
-	},
 /obj/effect/landmark/transport/transport_id{
 	specific_transport_id = "biodome_library_lift"
 	},
+/obj/machinery/elevator_control_panel/directional/west{
+	linked_elevator_id = "biodome_library_lift";
+	preset_destination_names = list("2"="Library Entrance","3"="Library Balcony");
+	name = "Work in Progress Elevator"
+	},
+/obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/biodome)
 "qgh" = (
@@ -46407,12 +46415,12 @@
 /area/station/maintenance/port/central)
 "qjt" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/structure/holosign/barrier,
 /obj/machinery/button/elevator/directional/north{
 	id = "biodome_library_lift"
+	},
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "biodome_library_lift"
 	},
 /turf/open/openspace,
 /area/station/hallway/primary/central)
@@ -47761,6 +47769,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"qFY" = (
+/obj/structure/transport/linear/public,
+/turf/open/openspace,
+/area/station/biodome)
 "qGc" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -50378,18 +50390,12 @@
 	},
 /turf/open/floor/grass,
 /area/station/biodome)
-"ryA" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/bronze,
-/area/station/biodome)
 "ryC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil/streak,
+/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine)
 "ryG" = (
@@ -51953,7 +51959,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/obj/structure/holosign/barrier,
 /turf/open/floor/grass,
 /area/station/biodome)
 "sch" = (
@@ -52208,6 +52213,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Engine Entrance"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "shZ" = (
@@ -55004,6 +55010,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine)
 "tiN" = (
@@ -56574,6 +56584,10 @@
 "tJQ" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"tJT" = (
+/obj/item/trash/energybar,
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/engine)
 "tKd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -58897,6 +58911,7 @@
 /area/station/hallway/primary/central)
 "uEu" = (
 /obj/machinery/light/dim/directional/west,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
 "uEK" = (
@@ -60215,10 +60230,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
-"veJ" = (
-/obj/structure/transport/linear/public,
-/turf/open/water/jungle/biodome,
-/area/station/biodome)
 "veU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60968,6 +60979,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"vsY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome)
 "vtd" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -63030,6 +63048,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/white,
 /area/station/medical/treatment_center)
+"weW" = (
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "weY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -64467,13 +64490,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"wAM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "wAS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -65643,7 +65659,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/diagonal,
-/area/station/biodome/aft)
+/area/station/hallway/primary/central)
 "wVM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66025,6 +66041,11 @@
 /obj/effect/turf_decal/tile/neutral/anticorner,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"xcj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xck" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/siding/purple{
@@ -66349,6 +66370,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"xjb" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xjd" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/misc/asteroid,
@@ -67872,7 +67897,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "xLu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -94845,7 +94869,7 @@ cCZ
 hNy
 hNy
 bqj
-vUn
+cTJ
 iIl
 hNy
 hNy
@@ -95096,13 +95120,13 @@ vtU
 vtU
 vtU
 vtU
-vtU
+iGx
 vtU
 vtU
 hNy
 hNy
 bqj
-vUn
+cTJ
 lkK
 iIl
 hNy
@@ -95359,7 +95383,7 @@ cCZ
 hNy
 hNy
 bqj
-vUn
+cTJ
 iQx
 pAD
 hNy
@@ -95614,9 +95638,9 @@ cCZ
 vtU
 cCZ
 hNy
-hNy
 bqj
-wAM
+bqj
+cTJ
 dSk
 iQx
 hNy
@@ -95871,9 +95895,9 @@ bxM
 hnA
 bxM
 hNy
-hNy
 bqj
-tiH
+tJT
+xwg
 tny
 pdN
 hNy
@@ -96128,8 +96152,8 @@ vtU
 vtU
 vtU
 hNy
-hNy
 bqj
+pZS
 tiH
 iIl
 iIl
@@ -96385,7 +96409,7 @@ bTO
 bTO
 vtU
 rRv
-hNy
+bqj
 bqj
 ryC
 iIl
@@ -97106,7 +97130,7 @@ lHT
 iId
 aLa
 tMS
-hGG
+tMS
 tMS
 aWc
 weR
@@ -97363,9 +97387,9 @@ ngd
 wju
 ngd
 scd
-nHd
 bxm
 bxm
+aTM
 weR
 sIU
 psC
@@ -97622,7 +97646,7 @@ ngd
 xPk
 qfS
 bxm
-bxm
+aTM
 weR
 mDI
 bjN
@@ -97878,7 +97902,7 @@ wju
 ngd
 mgH
 tUx
-ryA
+tUx
 dpw
 ilj
 oYq
@@ -98135,7 +98159,7 @@ wju
 kco
 kco
 kco
-kco
+vsY
 kco
 wnH
 bjN
@@ -98391,7 +98415,7 @@ qHA
 wju
 ngd
 mHa
-dku
+fHG
 oOy
 fHG
 weR
@@ -98649,7 +98673,7 @@ jku
 bIu
 bIu
 bIu
-bIu
+gYq
 bIu
 eTQ
 bcA
@@ -98906,7 +98930,7 @@ wju
 hLn
 gbE
 hcH
-fbS
+hNV
 fbS
 ilj
 pUk
@@ -99164,7 +99188,7 @@ fLd
 vGA
 cKv
 bxm
-bxm
+aTM
 weR
 qJS
 dUC
@@ -99421,7 +99445,7 @@ ltX
 cAW
 bLR
 bxm
-bxm
+aTM
 weR
 weR
 weR
@@ -99677,8 +99701,8 @@ wju
 gwP
 omC
 mAU
-asD
 xti
+asD
 asD
 oAv
 ota
@@ -102554,7 +102578,7 @@ qCC
 ttj
 mww
 gGu
-alG
+xjb
 fSW
 mSg
 lEN
@@ -102810,8 +102834,8 @@ osb
 alG
 hRb
 rVH
-gGu
-alG
+xcj
+xjb
 xFy
 mSg
 lEN
@@ -103067,8 +103091,8 @@ rEs
 rKd
 ukO
 rKd
-rKd
-alG
+nzH
+xjb
 mzv
 mSg
 iEq
@@ -103323,9 +103347,9 @@ nbO
 qCw
 rZl
 idm
-alG
-rKd
-alG
+xjb
+nzH
+xjb
 lfG
 mSg
 mSg
@@ -103582,7 +103606,7 @@ gMZ
 gMZ
 oPb
 xLu
-alG
+xjb
 lfG
 mSg
 lrN
@@ -103837,8 +103861,8 @@ uax
 qeg
 rQl
 gMZ
-mww
-rKd
+weW
+nzH
 kBj
 ttj
 mSg
@@ -104094,9 +104118,9 @@ fYn
 bKT
 asX
 gMZ
-alG
-rKd
-alG
+xjb
+nzH
+xjb
 gvg
 wew
 nmk
@@ -104352,7 +104376,7 @@ mHR
 oeS
 gMZ
 shL
-rKd
+nzH
 rKd
 rKd
 msz
@@ -104608,8 +104632,8 @@ lvA
 eZx
 fTb
 aQb
-alG
-rKd
+xjb
+nzH
 qHm
 mYz
 wew
@@ -104865,8 +104889,8 @@ oBb
 gJD
 fdy
 aQb
-alG
-rKd
+xjb
+nzH
 mjF
 pFP
 wew
@@ -110462,8 +110486,8 @@ hDB
 fOu
 qKr
 tUR
-hdm
-jXa
+qKr
+qKr
 vHY
 vZE
 svn
@@ -110719,8 +110743,8 @@ qsh
 hDB
 hDB
 ukK
-veJ
-blr
+qKr
+qKr
 tKi
 vZE
 fyH
@@ -162899,7 +162923,7 @@ rAq
 rAq
 rAq
 rAq
-rAq
+bxm
 sjl
 rsY
 pkB
@@ -175998,8 +176022,8 @@ rbH
 iJK
 lTv
 lTv
-rAq
-rAq
+oYO
+lGC
 rAq
 uaa
 fQs
@@ -176255,8 +176279,8 @@ gRD
 gRD
 lTv
 jrp
-rAq
-rAq
+qFY
+oPK
 rAq
 uaa
 fQs


### PR DESCRIPTION
## About The Pull Request

- A wire was missing, plunging biodome fore into darkness.
- Another wire was missing, affecting xenobiology
- The engine air alarm will no longer yell about there being too much warm and no oxygen in the engine chamber
- Increased the amount of oxygen and firefighter closets
- Added a horrible work in progress elevator by the library entrance. Stay safe!
- Also added: the lake lift.
![image](https://github.com/lizardqueenlexi/orbstation/assets/2676196/73570e02-71a0-4b2e-b47d-74fc4b7c2dab)
![image](https://github.com/lizardqueenlexi/orbstation/assets/2676196/5748206e-428c-4e7c-baae-a9d3ccc5583c)
- Altered engineering powerlines a bit
- Added one way unrestriced access helpers to the Atmos Space Trench
- Supermatter engine rooms baseturf is now space
- Improved the defense of the delivery windoors