### PR TITLE
Flatpacked biodome flatpacker

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -51651,16 +51651,15 @@
 /area/station/tcommsat/server)
 "rUW" = (
 /obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
 	dir = 8
+	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
+/obj/item/multitool{
+	pixel_x = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
@@ -52121,6 +52120,14 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "Engineering Security Door"
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)


### PR DESCRIPTION
Add the flatpacked flatpacker and a multitool to the biodome engineering foyer, bringing the map to parity. With this flatpacked flatpacker they can unpack a flatpacker that can produced flatpacked flatpacks to unpack them. Flatpack.