### PR TITLE
Fixes the behaviours of several orb exclusive items

### DIFF
--- a/orbstation/code/antagonists/spells/eldritch_minion.dm
+++ b/orbstation/code/antagonists/spells/eldritch_minion.dm
@@ -32,18 +32,17 @@
 	else
 		. += span_cult("Spirits following you: <b>[num_orbiters] / [num_ghosts]</b>")
 
-/obj/item/demonology_for_dummies/afterattack(atom/target, mob/user, proximity, params)
-	. = ..()
+/obj/item/demonology_for_dummies/interact_with_atom(atom/target, mob/user, list/modifiers)
 	if (drawing_rune)
 		user.balloon_alert(user, "already busy!")
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return
 
-	if (!proximity || !check_allowed_items(target) || !isliving(user))
+	if (!check_allowed_items(target) || !isliving(user))
 		return
 
 	if (isturf(target))
 		try_draw_rune(user, target)
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/demonology_for_dummies/proc/try_draw_rune(mob/living/user, turf/target_turf)
 	for (var/turf/nearby_turf as anything in RANGE_TURFS(1, target_turf))

--- a/orbstation/code/antagonists/traitor/items/cursed_tome.dm
+++ b/orbstation/code/antagonists/traitor/items/cursed_tome.dm
@@ -63,9 +63,8 @@
 	user.balloon_alert(user, "marked [target_mob]!")
 	current_target = weak_reference
 
-/obj/item/cursed_tome/afterattack(turf/target_turf, mob/user, proximity, params)
-	. = ..()
-	if (!isturf(target_turf) || !proximity)
+/obj/item/cursed_tome/interact_with_atom(turf/target_turf, mob/user, list/modifiers)
+	if (!isturf(target_turf))
 		return
 	var/mob/living/owner = weak_owner?.resolve()
 	if (owner != user)
@@ -73,13 +72,13 @@
 	var/mob/living/target = current_target?.resolve()
 	if (!target)
 		user.balloon_alert(user, "no target!")
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return
 	if (drawing_rune)
 		user.balloon_alert(user, "already busy!")
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return
 
 	draw_rune(user, target_turf)
-	return COMPONENT_CANCEL_ATTACK_CHAIN
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/cursed_tome/proc/draw_rune(mob/user, turf/target_turf)
 	user.visible_message(span_notice("[user] starts mumbling and waving their arms over the ground!"))

--- a/orbstation/code/objects/items/clothing/prescription_lenses.dm
+++ b/orbstation/code/objects/items/clothing/prescription_lenses.dm
@@ -7,21 +7,18 @@
 		The added weight means they might fall off if you get into a scrape."
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/prescription_lenses/afterattack(obj/item/clothing/glasses/target_glasses, mob/user, proximity)
-	. = ..()
-	if (!proximity)
-		return
+/obj/item/prescription_lenses/interact_with_atom(obj/item/clothing/glasses/target_glasses, mob/user, list/modifiers)
 	if (!istype(target_glasses))
 		return
 	if (!isturf(target_glasses.loc))
-		user.balloon_alert(user, "take glasses off") //They need to be outside your inventory or the trait won't apply
+		user.balloon_alert(user, "put glasses down!") //They need to be outside your inventory or the trait won't apply
 		return
 	if ((HAS_TRAIT(target_glasses, TRAIT_NEARSIGHTED_CORRECTED)) || HAS_TRAIT(target_glasses, TRAIT_FARSIGHTED_CORRECTED))
-		user.balloon_alert(user, "already corrective")
+		user.balloon_alert(user, "already corrective!")
 		return
 	user.visible_message(span_notice("[user] starts attaching [src] to [target_glasses]."))
 	if (!do_after(user, 5 SECONDS, target = target_glasses))
-		user.balloon_alert(user, "interrupted")
+		user.balloon_alert(user, "interrupted!")
 		return
 	if (length(target_glasses.clothing_traits))
 		target_glasses.clothing_traits |= TRAIT_NEARSIGHTED_CORRECTED
@@ -29,7 +26,9 @@
 	else
 		target_glasses.clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED, TRAIT_FARSIGHTED_CORRECTED)
 	target_glasses.AddComponent(/datum/component/knockoff, 25, list(BODY_ZONE_PRECISE_EYES), slot_flags)
+	user.balloon_alert(user, "lens added")
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /datum/crafting_recipe/prescription_lenses
 	name = "Prescription Lens Kit"

--- a/orbstation/code/objects/items/clothing/radio_gloves.dm
+++ b/orbstation/code/objects/items/clothing/radio_gloves.dm
@@ -13,24 +13,21 @@
 		/obj/item/clothing/gloves/rapid,
 	))
 
-/obj/item/radio_glove_assembly/afterattack(obj/item/clothing/gloves/target_gloves, mob/user, proximity)
-	. = ..()
-	if (!proximity)
-		return
+/obj/item/radio_glove_assembly/interact_with_atom(obj/item/clothing/gloves/target_gloves, mob/user, list/modifiers)
 	if (!istype(target_gloves))
 		return
 	if (is_type_in_typecache(target_gloves, gloves_blacklist))
-		user.balloon_alert(user, "incompatible")
+		user.balloon_alert(user, "incompatible!")
 		return
 	if (!isturf(target_gloves.loc))
-		user.balloon_alert(user, "put gloves down") //They need to be outside your inventory or the trait won't apply
+		user.balloon_alert(user, "put gloves down!") //They need to be outside your inventory or the trait won't apply
 		return
 	if (target_gloves.clothing_traits && (TRAIT_CAN_SIGN_ON_COMMS in target_gloves.clothing_traits))
 		user.balloon_alert(user, "already upgraded")
 		return
 	user.visible_message(span_notice("[user] starts attaching [src] to [target_gloves]."))
 	if (!do_after(user, 5 SECONDS, target = target_gloves))
-		user.balloon_alert(user, "interrupted")
+		user.balloon_alert(user, "interrupted!")
 		return
 	if (!target_gloves.clothing_traits)
 		target_gloves.clothing_traits = list()
@@ -38,6 +35,7 @@
 	target_gloves.update_appearance()
 	user.balloon_alert(user, "success")
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/clothing/gloves/update_overlays()
 	. = ..()

--- a/orbstation/code/objects/items/clothing/radio_gloves.dm
+++ b/orbstation/code/objects/items/clothing/radio_gloves.dm
@@ -33,7 +33,7 @@
 		target_gloves.clothing_traits = list()
 	target_gloves.clothing_traits += TRAIT_CAN_SIGN_ON_COMMS
 	target_gloves.update_appearance()
-	user.balloon_alert(user, "success")
+	user.balloon_alert(user, "assembly added")
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 

--- a/orbstation/code/objects/items/hearing_aid.dm
+++ b/orbstation/code/objects/items/hearing_aid.dm
@@ -6,26 +6,24 @@
 	desc = "Attach to a headset to provide auditory support for the hard of hearing."
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/hearing_aid/afterattack(obj/item/radio/headset/target_headset, mob/user, proximity)
-	. = ..()
-	if (!proximity)
-		return
+/obj/item/hearing_aid/interact_with_atom(obj/item/radio/headset/target_headset, mob/user, list/modifiers)
 	if (!istype(target_headset))
 		return
 	if (!isturf(target_headset.loc))
-		user.balloon_alert(user, "put headset down") //They need to be outside your inventory or the trait won't apply
+		user.balloon_alert(user, "put headset down!") //They need to be outside your inventory or the trait won't apply
 		return
 	if (target_headset.hearing_aid)
-		user.balloon_alert(user, "already upgraded")
+		user.balloon_alert(user, "already upgraded!")
 		return
 	user.visible_message(span_notice("[user] starts attaching [src] to [target_headset]."))
 	if (!do_after(user, 5 SECONDS, target = target_headset))
-		user.balloon_alert(user, "interrupted")
+		user.balloon_alert(user, "interrupted!")
 		return
 	target_headset.hearing_aid = TRUE
 	target_headset.update_appearance()
 	user.balloon_alert(user, "success")
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 // Start with one if you are deaf
 /datum/quirk/item_quirk/deafness/add_unique()

--- a/orbstation/code/objects/items/hearing_aid.dm
+++ b/orbstation/code/objects/items/hearing_aid.dm
@@ -21,7 +21,7 @@
 		return
 	target_headset.hearing_aid = TRUE
 	target_headset.update_appearance()
-	user.balloon_alert(user, "success")
+	user.balloon_alert(user, "hearing aid added")
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 

--- a/orbstation/code/objects/items/plushes.dm
+++ b/orbstation/code/objects/items/plushes.dm
@@ -139,10 +139,7 @@
 	)
 
 // Absorb DNA Sting
-/obj/item/toy/plush/crew/nancyplushie/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	if (!proximity_flag)
-		return
+/obj/item/toy/plush/crew/nancyplushie/interact_with_atom(atom/target, mob/user, list/modifiers)
 	var/matched_name
 	for (var/blorbo in plushie_dna)
 		if (findtext(target.name, blorbo))
@@ -153,6 +150,7 @@
 	balloon_alert_to_viewers("giggle~")
 	absorbed_dna |= matched_name
 	flick("nancyflash", src)
+	return ITEM_INTERACT_SUCCESS
 
 // Transform
 /obj/item/toy/plush/crew/nancyplushie/attack_self(mob/user)


### PR DESCRIPTION
Several items were using afterattack intead of interact_with_atom. This PR fixes those. Also tweaked the balloon alerts of these items.