### PR TITLE
Biodome wire update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -566,6 +566,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ajN" = (
@@ -1011,6 +1012,12 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/iron,
 /area/station/science/circuits)
+"aqt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "aqC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/camera/directional/south{
@@ -1076,10 +1083,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
-"arC" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/port/central)
 "arN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -1345,6 +1348,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "avI" = (
@@ -3360,7 +3366,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4413,7 +4418,6 @@
 /obj/item/pipe_dispenser,
 /obj/item/pipe_dispenser,
 /obj/item/pipe_dispenser,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "bzM" = (
@@ -4494,10 +4498,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "bBn" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
 /obj/item/banner/engineering/mundane,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bBr" = (
@@ -5669,6 +5672,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"bYe" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "bYl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -5986,9 +5995,6 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "cdV" = (
 /obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "cdX" = (
@@ -6520,6 +6526,8 @@
 "cnF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "cnW" = (
@@ -8162,6 +8170,10 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Supermatter Engine Room"
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cMO" = (
@@ -8579,8 +8591,7 @@
 /turf/open/floor/plating,
 /area/station/security/prison)
 "cVe" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "cVi" = (
@@ -11946,7 +11957,6 @@
 /area/station/hallway/primary/central/aft)
 "eev" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -12502,6 +12512,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"epv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "epx" = (
 /obj/structure/closet/l3closet/janitor,
 /turf/open/floor/wood/tile,
@@ -16664,6 +16680,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "fMp" = (
@@ -16965,7 +16984,6 @@
 /area/station/biodome/aft)
 "fQu" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "fQL" = (
@@ -17117,9 +17135,6 @@
 	pixel_y = 3
 	},
 /obj/item/book/manual/wiki/engineering_construction,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "fTb" = (
@@ -17769,6 +17784,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Gateway Entrance"
 	},
+/obj/machinery/transport/power_rectifier,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
 "gfn" = (
@@ -18509,6 +18525,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/biodome/aft)
+"gtj" = (
+/obj/machinery/button/transport/tram/boat/middle,
+/turf/closed/wall/r_wall/fakewood{
+	color = "#a9734f"
+	},
+/area/station/biodome)
 "gtn" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
@@ -18663,9 +18685,6 @@
 /area/station/engineering/storage/tech)
 "gvg" = (
 /obj/item/banner/engineering/mundane,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gvj" = (
@@ -19266,6 +19285,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gGw" = (
@@ -19982,6 +20004,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "gTD" = (
@@ -20526,8 +20549,9 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "hdJ" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/north,
+/obj/machinery/computer/atmos_control/nocontrol/master{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "hdK" = (
@@ -20622,6 +20646,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/office)
+"hfk" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "hfm" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22199,6 +22227,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "hLk" = (
@@ -22495,6 +22526,9 @@
 /area/station/hallway/primary/central)
 "hRb" = (
 /obj/structure/sign/warning/no_smoking/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hRc" = (
@@ -23234,6 +23268,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Main Equipment"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "idp" = (
@@ -23838,19 +23875,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"ioK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "ioR" = (
 /obj/structure/sign/directions/science/directional/south{
 	dir = 1;
@@ -23947,9 +23971,11 @@
 "iqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -24066,6 +24092,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"isF" = (
+/obj/machinery/transport/power_rectifier,
+/turf/open/floor/iron/terracotta/small,
+/area/station/biodome/fore)
 "isM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -24704,9 +24734,6 @@
 /area/station/engineering/atmos)
 "iES" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
@@ -25187,6 +25214,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/digital_clock/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "iOc" = (
@@ -25312,6 +25340,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "iRf" = (
@@ -25373,9 +25404,6 @@
 /area/station/science/explab)
 "iSu" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "iSK" = (
@@ -26298,9 +26326,6 @@
 "jiJ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "jiV" = (
@@ -28920,6 +28945,7 @@
 	c_tag = "Engineering - Equipment"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "keY" = (
@@ -30295,7 +30321,7 @@
 /area/station/security/brig)
 "kBj" = (
 /obj/item/radio/intercom/directional/south,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kBo" = (
@@ -30522,6 +30548,7 @@
 "kEZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kFl" = (
@@ -30638,7 +30665,6 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32060,9 +32086,6 @@
 /area/station/science/xenobiology)
 "lfG" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lfX" = (
@@ -32948,7 +32971,9 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "lvu" = (
@@ -33723,6 +33748,9 @@
 /area/station/medical/virology)
 "lGg" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "lGj" = (
@@ -35054,9 +35082,6 @@
 /area/station/commons/dorms)
 "mcL" = (
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "mcO" = (
@@ -35490,6 +35515,9 @@
 /area/station/hallway/primary/central/aft)
 "mjF" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mjR" = (
@@ -35921,9 +35949,6 @@
 /area/station/commons/vacant_room/commissary)
 "mrK" = (
 /obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mrL" = (
@@ -35966,7 +35991,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "msD" = (
 /obj/structure/cable,
@@ -36197,6 +36222,9 @@
 /area/station/hallway/primary/starboard)
 "mww" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mxo" = (
@@ -36285,9 +36313,6 @@
 	pixel_y = -1
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
@@ -36346,9 +36371,6 @@
 /area/station/security/brig/entrance)
 "mzv" = (
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mzS" = (
@@ -36887,7 +36909,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "mLj" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mLm" = (
@@ -37101,7 +37126,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -37613,9 +37638,6 @@
 /area/station/science/cytology)
 "mYz" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mYF" = (
@@ -37777,7 +37799,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -38478,15 +38500,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "non" = (
-/obj/machinery/computer/atmos_control/nocontrol/master,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
 /obj/machinery/button/door/directional/north{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -6;
 	req_access = list("atmospherics")
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
@@ -38699,6 +38720,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"nrn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "nrv" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/clothing/under/rank/prisoner/skirt,
@@ -39153,6 +39180,7 @@
 "nzH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "nzK" = (
@@ -40756,6 +40784,12 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ocu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ocv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -40807,7 +40841,6 @@
 	id = "Biohazard";
 	name = "Biohazard Containment Door"
 	},
-/obj/item/banner/science/mundane,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
@@ -41651,6 +41684,9 @@
 /area/station/maintenance/fore/greater)
 "osb" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "osc" = (
@@ -43055,7 +43091,9 @@
 	name = "Engineering Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/information,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oPj" = (
@@ -43273,6 +43311,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"oUk" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/item/banner/science/mundane,
+/turf/open/floor/iron,
+/area/station/science/research)
 "oUu" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -43308,7 +43353,6 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "oVw" = (
@@ -43377,6 +43421,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/maintenance/port/central)
+"oWq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "oWu" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
@@ -43850,7 +43905,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "pej" = (
@@ -45110,6 +45164,14 @@
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"pBk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "pBy" = (
 /obj/structure/chair{
 	name = "Defense";
@@ -45327,13 +45389,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"pFP" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
 "pFV" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Departures - Fore Starboard"
@@ -45411,7 +45466,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46705,6 +46759,7 @@
 	},
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qeM" = (
@@ -47322,6 +47377,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "qnX" = (
@@ -47720,11 +47778,6 @@
 /obj/machinery/incident_display/tram/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
-"qvR" = (
-/obj/structure/girder,
-/obj/machinery/button/transport/tram/boat/middle,
-/turf/open/water/jungle/biodome,
-/area/station/biodome)
 "qvT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/right/directional/north{
@@ -48127,7 +48180,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qCw" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -48137,9 +48191,6 @@
 /area/station/hallway/primary/aft)
 "qCC" = (
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "qCH" = (
@@ -48211,9 +48262,11 @@
 "qDy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -48243,7 +48296,6 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -48409,6 +48461,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qHA" = (
@@ -48857,7 +48910,6 @@
 	pixel_x = 2;
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -50074,6 +50126,7 @@
 "rkU" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/status_display/evac/directional/south,
+/obj/item/banner/science/mundane,
 /turf/open/floor/iron,
 /area/station/science/research)
 "rld" = (
@@ -50224,7 +50277,6 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "rnj" = (
@@ -51111,6 +51163,12 @@
 "rAq" = (
 /turf/open/openspace,
 /area/station/biodome)
+"rAt" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rAX" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
@@ -51270,9 +51328,9 @@
 "rEs" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rEJ" = (
@@ -51558,7 +51616,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "rKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51612,7 +51670,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/engineering,
@@ -52181,6 +52238,9 @@
 /area/station/engineering/gravity_generator)
 "rVH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rVI" = (
@@ -52430,6 +52490,9 @@
 /area/station/maintenance/port/central)
 "rZl" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rZs" = (
@@ -52835,7 +52898,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Engine Entrance"
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "shZ" = (
@@ -52871,6 +52936,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/terracotta,
 /area/station/hallway/secondary/construction/engineering)
+"siq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "siM" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/large,
@@ -53985,8 +54057,10 @@
 "sDJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "sDO" = (
@@ -54178,6 +54252,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "sIb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "sIf" = (
@@ -56415,7 +56492,6 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/smooth_large,
@@ -57784,7 +57860,6 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "tUx" = (
@@ -58546,9 +58621,9 @@
 /area/station/maintenance/central/greater)
 "ukO" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ukQ" = (
@@ -60633,6 +60708,10 @@
 	},
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"uZB" = (
+/obj/machinery/transport/power_rectifier,
+/turf/open/misc/ashplanet/wateryrock/biodome,
+/area/station/biodome)
 "uZM" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Test Chamber Maintenance"
@@ -60674,7 +60753,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "vaJ" = (
 /turf/open/floor/iron/chapel,
@@ -63165,9 +63244,6 @@
 /obj/item/flashlight{
 	pixel_x = -1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -63755,11 +63831,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/white,
 /area/station/medical/treatment_center)
-"weW" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "weY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -64243,6 +64314,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "wme" = (
@@ -64555,6 +64629,7 @@
 "wpW" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "wqb" = (
@@ -65709,8 +65784,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/storage)
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wJI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -65906,6 +65985,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "wNK" = (
@@ -66744,6 +66826,7 @@
 "xcj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xck" = (
@@ -67077,6 +67160,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xjb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -67538,6 +67625,9 @@
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "xtK" = (
@@ -67907,6 +67997,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "xAb" = (
@@ -68232,9 +68323,6 @@
 /area/station/construction)
 "xFy" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xFA" = (
@@ -68601,6 +68689,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xLy" = (
@@ -68757,7 +68846,6 @@
 	id = "Biohazard";
 	name = "Biohazard Containment Door"
 	},
-/obj/item/banner/science/mundane,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -69031,7 +69119,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin/tagger,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "xSH" = (
 /obj/machinery/door/airlock/engineering{
@@ -69243,6 +69331,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "xVN" = (
@@ -70108,6 +70197,13 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/hydroponics)
+"yjO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "yjR" = (
 /obj/structure/closet{
 	name = "Evidence Closet 5"
@@ -96547,7 +96643,7 @@ rNa
 hgp
 ebT
 pKF
-arC
+pKF
 gJE
 pKF
 pKF
@@ -100723,7 +100819,7 @@ cCZ
 cCZ
 cCZ
 bqj
-ioK
+fyF
 bqj
 hNy
 hNy
@@ -100979,9 +101075,9 @@ lOH
 lOH
 lOH
 lOH
-lOH
+bqj
 wJn
-lOH
+bqj
 hNy
 rRv
 hNy
@@ -102520,8 +102616,8 @@ hxl
 ttj
 vaA
 lGg
-sIb
-wSu
+bYe
+pBk
 xVL
 lOH
 tQT
@@ -103029,7 +103125,7 @@ mgY
 oeZ
 tOE
 eev
-vzP
+oWq
 bBn
 ttj
 lOH
@@ -103286,8 +103382,8 @@ msD
 xFa
 tOE
 bzJ
-vzP
-alG
+oWq
+hfk
 iSu
 mrK
 qCC
@@ -103547,11 +103643,11 @@ qDy
 sDJ
 iqP
 osb
-alG
+rAt
 hRb
 rVH
 xcj
-xjb
+hfk
 xFy
 mSg
 lEN
@@ -103800,15 +103896,15 @@ tAZ
 lYf
 xxC
 rne
-alG
+epv
 alG
 vzP
 rEs
-rKd
-ukO
-rKd
 nzH
-xjb
+ukO
+nzH
+nzH
+hfk
 mzv
 mSg
 iEq
@@ -104057,15 +104153,15 @@ aCy
 imC
 tOE
 tUs
-alG
+ocu
 mLj
 nbO
 qCw
 rZl
 idm
-xjb
+nrn
 nzH
-xjb
+hfk
 lfG
 mSg
 mSg
@@ -104322,7 +104418,7 @@ gMZ
 gMZ
 oPb
 xLu
-xjb
+hfk
 lfG
 mSg
 lrN
@@ -104577,7 +104673,7 @@ uax
 qeg
 rQl
 gMZ
-weW
+mww
 nzH
 kBj
 ttj
@@ -104834,9 +104930,9 @@ fYn
 bKT
 asX
 gMZ
-xjb
+epv
 nzH
-xjb
+hfk
 gvg
 wew
 nmk
@@ -105093,7 +105189,7 @@ oeS
 gMZ
 shL
 nzH
-rKd
+yjO
 rKd
 msz
 mPn
@@ -105348,12 +105444,12 @@ lvA
 eZx
 fTb
 aQb
-xjb
+epv
 nzH
 qHm
 mYz
 wew
-jrK
+aqt
 wyp
 oFG
 dXZ
@@ -105605,10 +105701,10 @@ oBb
 gJD
 fdy
 aQb
-xjb
-nzH
+epv
+siq
 mjF
-pFP
+mYz
 wew
 jMz
 jMU
@@ -110923,7 +111019,7 @@ sBz
 sBz
 dYQ
 sBz
-aLk
+isF
 aLk
 hWZ
 jqr
@@ -111197,9 +111293,9 @@ qKr
 fOu
 qKr
 tKi
-qvR
-hDB
-fOu
+tUR
+uZB
+gtj
 qKr
 tUR
 qKr
@@ -173874,7 +173970,7 @@ bTC
 kAO
 amX
 fUB
-qCr
+oUk
 pUc
 rkU
 jWh
@@ -184709,7 +184805,7 @@ vZs
 lWc
 qYc
 rRv
-rRv
+vij
 eHU
 hNy
 hNy
@@ -185224,7 +185320,7 @@ rRv
 rRv
 rRv
 rRv
-vij
+rRv
 xBL
 rRv
 hNy
@@ -186252,7 +186348,7 @@ rRv
 rRv
 rRv
 rRv
-vij
+rRv
 xBL
 hHc
 hHc
@@ -187022,7 +187118,7 @@ hHc
 hHc
 sBZ
 hHc
-hHc
+byv
 sBZ
 hHc
 hHc

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -17784,7 +17784,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Gateway Entrance"
 	},
-/obj/machinery/transport/power_rectifier,
 /turf/open/water/jungle/biodome,
 /area/station/biodome/aft)
 "gfn" = (
@@ -42173,6 +42172,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"ozY" = (
+/obj/machinery/transport/power_rectifier,
+/turf/open/water/jungle/biodome,
+/area/station/biodome/aft)
 "oAd" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
@@ -111307,8 +111310,8 @@ pnf
 pnf
 pnf
 pnf
-pnf
-sAX
+soh
+ozY
 qzf
 pnf
 hkP


### PR DESCRIPTION
Biodome update:
* Rewires engineering on feedback, makes emitters and the CE office have priority
* Adds some decals to engineering
* Added missing tram power units
* Moved the atmos office holopad to the center of the room
* Removed a power cable under a wall in maint north of chemistry