### PR TITLE
Biodome lake contents update

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -393,7 +393,7 @@
 /area/station/maintenance/port/central)
 "agF" = (
 /obj/structure/flora/bush/large/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "agH" = (
 /obj/structure/disposalpipe/segment{
@@ -886,7 +886,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/rock/pile/jungle/style_random,
 /obj/structure/closet/firecloset,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "aou" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
@@ -984,7 +984,7 @@
 /area/station/commons/storage/tools)
 "apE" = (
 /obj/structure/grille/broken,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "apJ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -1740,7 +1740,7 @@
 /area/space/nearstation)
 "aCs" = (
 /obj/structure/flora/rock/pile/jungle/style_3,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "aCy" = (
 /obj/structure/table,
@@ -4747,7 +4747,7 @@
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "bHm" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/central/greater)
 "bHr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4899,7 +4899,7 @@
 /area/station/maintenance/aft/upper)
 "bJY" = (
 /obj/machinery/light/warm/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "bKg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6259,7 +6259,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "chE" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "chZ" = (
 /obj/structure/statue/snow/snowman,
@@ -7778,7 +7778,7 @@
 /area/station/service/kitchen)
 "cHk" = (
 /obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/fore/greater)
 "cHp" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
@@ -8431,7 +8431,7 @@
 /area/station/commons/storage/primary)
 "cSc" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/fore/greater)
 "cSg" = (
 /turf/open/misc/beach/coast,
@@ -10098,7 +10098,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dwV" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/fore/greater)
 "dwX" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -10236,7 +10236,7 @@
 	dir = 1
 	},
 /obj/structure/girder,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "dAg" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -10248,7 +10248,7 @@
 "dAk" = (
 /obj/item/storage/fish_case/random/freshwater,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/department/engine)
 "dAm" = (
 /obj/machinery/mass_driver/trash{
@@ -10776,7 +10776,7 @@
 /area/station/biodome/fore)
 "dIH" = (
 /obj/structure/holosign/barrier/atmos/tram,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "dIN" = (
 /turf/open/misc/asteroid,
@@ -11869,7 +11869,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "ecV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
@@ -14241,7 +14241,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/department/engine)
 "eSK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -15481,7 +15481,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "fqA" = (
 /obj/machinery/door/airlock/external{
@@ -15925,7 +15925,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Biodome - Aft Lake"
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "fyZ" = (
 /obj/effect/turf_decal/siding/purple/corner{
@@ -16457,7 +16457,7 @@
 	name = "Yam";
 	desc = "Ooooooooough."
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "fIP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
@@ -16839,7 +16839,7 @@
 /area/station/maintenance/central/greater)
 "fOu" = (
 /obj/structure/girder,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "fOw" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
@@ -17373,7 +17373,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "fWi" = (
 /obj/structure/cable,
@@ -17548,7 +17548,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "fZq" = (
 /turf/open/floor/carpet/green,
@@ -17784,7 +17784,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Gateway Entrance"
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "gfn" = (
 /obj/structure/table,
@@ -18782,7 +18782,7 @@
 /obj/structure/transport/linear/tram,
 /obj/structure/thermoplastic/light,
 /obj/structure/lattice/catwalk,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "gxh" = (
 /obj/structure/disposalpipe/segment{
@@ -18873,7 +18873,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "gyB" = (
 /obj/structure/sink/directional/east,
@@ -20496,7 +20496,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "hda" = (
 /obj/machinery/door/airlock/research/glass{
@@ -20767,7 +20767,7 @@
 /area/station/maintenance/aft/upper)
 "hip" = (
 /obj/machinery/light/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "hiu" = (
 /obj/structure/chair{
@@ -20907,7 +20907,7 @@
 "hkP" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/girder,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "hkQ" = (
 /obj/effect/turf_decal/siding/dark,
@@ -21361,7 +21361,7 @@
 /obj/structure/transport/linear/tram,
 /obj/structure/lattice/catwalk,
 /obj/structure/musician/piano,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "htw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21748,7 +21748,7 @@
 /area/station/science/ordnance/bomb)
 "hCC" = (
 /obj/machinery/light/small/blacklight/directional/south,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/central/greater)
 "hCI" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -22534,7 +22534,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "hRk" = (
 /obj/machinery/door/airlock/public/glass{
@@ -22606,7 +22606,7 @@
 /area/station/maintenance/starboard/central)
 "hSH" = (
 /obj/structure/flora/rock/pile/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "hTl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23278,7 +23278,7 @@
 /area/station/command/heads_quarters/hop)
 "idz" = (
 /obj/structure/flora/rock/pile/jungle/large/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "idC" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -24425,7 +24425,7 @@
 /area/station/maintenance/department/science)
 "izf" = (
 /obj/effect/landmark/transport/nav_beacon/tram/platform/boat/fore,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "izy" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -25173,7 +25173,7 @@
 /area/station/service/bar)
 "iME" = (
 /obj/effect/spawner/structure/window,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "iMS" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -25522,7 +25522,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "iVh" = (
 /obj/effect/turf_decal/sand/plating,
@@ -25645,7 +25645,7 @@
 /area/station/command/heads_quarters/cmo)
 "iXz" = (
 /obj/effect/landmark/transport/nav_beacon/tram/platform/boat/middle,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "iXJ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -25696,7 +25696,7 @@
 "iYr" = (
 /obj/structure/grille/broken,
 /obj/effect/landmark/blobstart,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "iYy" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -25886,7 +25886,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/structure/window,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "jbE" = (
 /obj/machinery/firealarm/directional/north,
@@ -26947,7 +26947,7 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/reed/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "juL" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -29957,7 +29957,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "kuL" = (
 /obj/machinery/light/small/directional/west,
@@ -30377,7 +30377,7 @@
 /area/station/security/office)
 "kCl" = (
 /obj/structure/statue/bone/rib,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "kCr" = (
 /obj/structure/table/wood,
@@ -30577,7 +30577,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/department/engine)
 "kFI" = (
 /turf/closed/wall/mineral/wood,
@@ -31612,7 +31612,7 @@
 "kXq" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/machinery/light/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "kXu" = (
 /obj/structure/railing{
@@ -33898,7 +33898,7 @@
 /area/station/biodome/fore)
 "lHw" = (
 /obj/item/trash/champagne_cork/sabrage,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "lHF" = (
 /obj/structure/stairs/north,
@@ -36643,7 +36643,7 @@
 /area/station/cargo/office)
 "mGa" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "mGf" = (
 /obj/machinery/door/firedoor,
@@ -36713,7 +36713,7 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
 /obj/structure/closet/emcloset,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "mHi" = (
 /obj/structure/noticeboard/directional/north,
@@ -38628,7 +38628,7 @@
 /area/station/security/detectives_office)
 "nqa" = (
 /obj/effect/spawner/random/structure/barricade,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "nqd" = (
 /turf/open/floor/iron/dark/textured,
@@ -39764,7 +39764,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "nKr" = (
 /obj/structure/ladder,
@@ -40151,7 +40151,7 @@
 /area/station/security/brig)
 "nQz" = (
 /obj/item/toy/balloon,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "nQF" = (
 /obj/structure/table/wood,
@@ -40499,7 +40499,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Command - Teleporter Access"
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "nXv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -42035,7 +42035,7 @@
 /area/station/hallway/primary/central/aft)
 "oyC" = (
 /obj/structure/flora/rock/pile,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "oyE" = (
 /obj/structure/holosign/barrier/atmos/leaf{
@@ -42174,7 +42174,7 @@
 /area/station/commons/fitness)
 "ozY" = (
 /obj/machinery/transport/power_rectifier,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "oAd" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -43008,7 +43008,7 @@
 /area/station/maintenance/disposal/incinerator)
 "oNZ" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "oOb" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -43563,7 +43563,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "oZa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -44340,7 +44340,7 @@
 /area/station/medical/medbay/central)
 "plH" = (
 /obj/effect/spawner/random/food_or_drink,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "plL" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
@@ -44410,7 +44410,7 @@
 	dir = 8
 	},
 /obj/structure/statue/bone/rib,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "pmH" = (
 /obj/machinery/light/directional/south,
@@ -44439,7 +44439,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pnf" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "pnh" = (
 /obj/machinery/status_display/ai/directional/south,
@@ -44564,7 +44564,7 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/reed/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "ppF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -45045,7 +45045,7 @@
 /area/station/hallway/primary/starboard)
 "pzk" = (
 /obj/machinery/light/warm/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "pzl" = (
 /obj/effect/spawner/random/trash/box,
@@ -45204,7 +45204,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "pCc" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/department/engine)
 "pCf" = (
 /obj/machinery/airalarm/directional/west,
@@ -46836,7 +46836,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "qfQ" = (
 /obj/structure/cable,
@@ -48424,7 +48424,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Biodome - Center Lake"
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "qGN" = (
 /obj/structure/cable,
@@ -48524,7 +48524,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/structure/window,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "qIV" = (
 /obj/machinery/holopad,
@@ -48620,7 +48620,7 @@
 /turf/open/floor/white,
 /area/station/medical/medbay/lobby)
 "qKr" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "qKs" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -49430,7 +49430,7 @@
 	dir = 8
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "qXn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -51750,7 +51750,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "rMW" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -52349,7 +52349,7 @@
 	dir = 1
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "rXg" = (
 /obj/machinery/camera/directional/north{
@@ -52456,7 +52456,7 @@
 /obj/structure/transport/linear/tram,
 /obj/structure/thermoplastic/light,
 /obj/structure/lattice/catwalk,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "rYR" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -52502,7 +52502,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "rZD" = (
 /obj/structure/table,
@@ -52749,7 +52749,7 @@
 /area/station/commons/storage/tools)
 "ser" = (
 /obj/structure/statue/bone/skull,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/department/engine)
 "seM" = (
 /obj/structure/lattice,
@@ -52979,7 +52979,7 @@
 /area/station/hallway/primary/central)
 "sjt" = (
 /obj/structure/flora/rock/pile/style_2,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "sjD" = (
 /obj/structure/statue/sandstone/venus{
@@ -53199,7 +53199,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "snN" = (
 /obj/item/radio/intercom/directional/south,
@@ -53577,7 +53577,7 @@
 /area/station/security/prison)
 "svn" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "svq" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -53928,7 +53928,7 @@
 /area/station/hallway/primary/fore)
 "sAX" = (
 /obj/structure/girder,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "sAZ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -53942,7 +53942,7 @@
 /obj/structure/tram,
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "sBf" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -54686,7 +54686,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "sPf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56696,7 +56696,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "tzy" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "tzH" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -56738,7 +56738,7 @@
 /area/station/commons/storage/emergency/starboard)
 "tAz" = (
 /obj/effect/spawner/random/structure/grille,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "tAF" = (
 /obj/item/kirbyplants/random,
@@ -57060,7 +57060,7 @@
 	},
 /obj/machinery/light/warm/directional/south,
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "tFG" = (
 /obj/structure/table,
@@ -57317,7 +57317,7 @@
 /area/station/engineering/engine_smes)
 "tKi" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "tKr" = (
 /obj/structure/table/glass,
@@ -61245,7 +61245,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/structure/window,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "vkh" = (
 /obj/structure/cable,
@@ -61413,7 +61413,7 @@
 "vmG" = (
 /obj/machinery/light/warm/directional/east,
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "vmJ" = (
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -62661,7 +62661,7 @@
 /area/station/biodome/fore)
 "vHY" = (
 /obj/structure/flora/rock/pile/jungle/style_5,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "vHZ" = (
 /obj/machinery/firealarm/directional/west,
@@ -63583,7 +63583,7 @@
 /area/station/hallway/primary/starboard)
 "vZE" = (
 /obj/structure/holosign/barrier/atmos/tram,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "vZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -65484,7 +65484,7 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/lattice/catwalk,
 /obj/structure/table/wood,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "wEe" = (
 /obj/structure/cable,
@@ -65610,7 +65610,7 @@
 /area/station/engineering/atmos/project)
 "wFQ" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/fore)
 "wFV" = (
 /obj/machinery/vending/cigarette,
@@ -66895,7 +66895,7 @@
 /area/station/maintenance/port/greater)
 "xec" = (
 /obj/effect/spawner/random/trash/moisture,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/starboard/central)
 "xee" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -67066,7 +67066,7 @@
 "xhF" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/fore/greater)
 "xhT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67191,7 +67191,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome/aft)
 "xjH" = (
 /obj/effect/spawner/random/entertainment/arcade{
@@ -68669,7 +68669,7 @@
 /area/station/service/theater)
 "xLe" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/fore/greater)
 "xLp" = (
 /obj/machinery/door/airlock/security{
@@ -69089,7 +69089,7 @@
 /area/station/commons/toilet)
 "xRM" = (
 /obj/effect/spawner/structure/window,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/biodome)
 "xRU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/_maps/map_files/biodome/modules/cage_1_axolotl.dmm
+++ b/_maps/map_files/biodome/modules/cage_1_axolotl.dmm
@@ -1,12 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /mob/living/basic/axolotl,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/aft/upper)
 "f" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/aft/upper)
 "i" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21,7 +21,7 @@
 /area/station/maintenance/aft/upper)
 "p" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/aft/upper)
 "y" = (
 /mob/living/basic/axolotl,
@@ -29,7 +29,7 @@
 /turf/open/misc/ashplanet/wateryrock/biodome,
 /area/station/maintenance/aft/upper)
 "D" = (
-/turf/open/water/jungle/biodome,
+/turf/open/water/biodome,
 /area/station/maintenance/aft/upper)
 "J" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/orbstation/code/map/biodome/turfs.dm
+++ b/orbstation/code/map/biodome/turfs.dm
@@ -2,10 +2,11 @@
 	desc = "A huge chunk of reinforced metal used to separate rooms. This one has been painted like a log."
 	color = COLOR_ORANGE_BROWN
 
-/turf/open/water/jungle/biodome
+/turf/open/water/biodome
 	name="Biodome Lake"
 	baseturfs = /turf/open/misc/asteroid
-	fishing_datum = /datum/fish_source/ocean/beach
+	fishing_datum = /datum/fish_source/river
+
 /turf/open/misc/ashplanet/wateryrock/biodome
 	name="Biodome Lake Rocks"
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS


### PR DESCRIPTION
- Makes the biodome water turf a direct subtype to the base water turf, instead of pointless being a jungle subtype, as jungle is an empty type.
- Explicitly sets the biodome water to the river fishing datum, this is a freshwater environment! The base type also uses this, but, this will future proof it.