### PR TITLE
Fixes Orb magazines being unreadable

### DIFF
--- a/orbstation/code/objects/items/magazines.dm
+++ b/orbstation/code/objects/items/magazines.dm
@@ -31,6 +31,7 @@
 /// Called when the user starts to read the magazine.
 /obj/item/book/granter/magazine/on_reading_start(mob/living/user)
 	user.visible_message(span_notice("[user] starts flipping through \the [name]."), span_notice("You start flipping through \the [name]."))
+	return TRUE
 
 /// Called when the user completes the magazine.
 /obj/item/book/granter/magazine/on_reading_finished(mob/living/user)


### PR DESCRIPTION
Start reading did not return true to denote success. Seem to have been broken for a year now.