### PR TITLE
You can only hijack the shuttle if you have the objective for it

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -33,10 +33,13 @@
 	if(hijack_announce)
 		. += span_danger("Security systems present on console. Any unauthorized tampering will result in an emergency announcement.")
 	if(user?.mind?.get_hijack_speed())
-		. += span_danger("Alt click on this to attempt to hijack the shuttle. This will take multiple tries (current: stage [SSshuttle.emergency.hijack_status]/[HIJACKED]).")
-		. += span_notice("It will take you [(hijack_stage_time * user.mind.get_hijack_speed()) / 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown/10] seconds after each stage.")
-		if(hijack_announce)
-			. += span_warning("It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..")
+		if(!user?.mind?.has_objective(/datum/objective/hijack)) // ORBSTATION EDIT
+			. += span_danger("Unfortunately, you don't know the proper protocols to attempt to hijack the shuttle.")
+		else
+			. += span_danger("Alt click on this to attempt to hijack the shuttle. This will take multiple tries (current: stage [SSshuttle.emergency.hijack_status]/[HIJACKED]).")
+			. += span_notice("It will take you [(hijack_stage_time * user.mind.get_hijack_speed()) / 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown/10] seconds after each stage.")
+			if(hijack_announce)
+				. += span_warning("It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..")
 
 /obj/machinery/computer/emergency_shuttle/attackby(obj/item/I, mob/user,params)
 	if(isidcard(I))
@@ -219,6 +222,9 @@
 		return
 	if(!user?.mind?.get_hijack_speed())
 		to_chat(user, span_warning("You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone."))
+		return
+	if(!user?.mind?.has_objective(/datum/objective/hijack)) // ORBSTATION EDIT
+		to_chat(user, span_danger("You open the user-mode shell on [src], but unfortunately do not know the access codes to hijack the shuttle."))
 		return
 	if(!EMERGENCY_AT_LEAST_DOCKED) // prevent advancing hijack stages on BYOS shuttles until the shuttle has "docked"
 		to_chat(user, span_warning("The flight plans for the shuttle haven't been loaded yet, you can't hack this right now."))


### PR DESCRIPTION

## About The Pull Request

If you try to hijack the shuttle, without being assigned a hijack objective, you will get a warning that you sadly do not know the proper protocols.


## Why It's Good For The Game

We do not have the population to support the intended gameplay of  defending the shuttle cockpit while hijacking it. Usually what happens, is someone who killed a head and took their ID starts hijacking, and nobody who could remove or open the door remains. It just feels like styling on the rest of the crew for no reason.


## Changelog

:cl:
balance: You can only hijack the shuttle if you have an objective for it
/:cl:

