### PR TITLE
If a job is not found, the job heatmap will not die

### DIFF
--- a/orbstation/code/modules/job_heatmap.dm
+++ b/orbstation/code/modules/job_heatmap.dm
@@ -29,6 +29,8 @@
 			if (priority == 0)
 				continue
 			var/datum/job/job_details = get_job(job)
+			if(!job)
+				continue
 			if (!job_details.departments_list)
 				continue
 			var/department_type = job_details.departments_list[1]


### PR DESCRIPTION


## About The Pull Request

If a player has selected a character that had Virologist turned on, we got a null exception while trying to assemble the heatmap. This PR fixes that, ensuring should a job be deleted or its name changed, this does not happen.

## Why It's Good For The Game

I want to see heatmaps work...


