### PR TITLE
Biodome meteor safety, Maintainance Expansion

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -817,7 +817,6 @@
 /area/station/science/research)
 "anr" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/easel,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
@@ -894,6 +893,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/disposal/incinerator)
+"aoy" = (
+/obj/structure/table/wood,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "aoD" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -2766,6 +2770,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/stone,
 /area/station/maintenance/starboard/central)
+"aUn" = (
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "aUr" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -2997,6 +3005,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"aXL" = (
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "aYd" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -7451,12 +7463,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"cBY" = (
-/obj/effect/spawner/structure/window,
-/obj/effect/spawner/structure/window,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
 "cCc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7987,6 +7993,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"cJP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "cJR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
@@ -8420,6 +8432,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "cRP" = (
@@ -11043,6 +11056,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"dOr" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "dOs" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Captain's Desk";
@@ -12259,6 +12277,10 @@
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"elE" = (
+/obj/item/toy/crayon/black,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "elG" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -16243,6 +16265,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"fEk" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/broken_flooring/singular/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "fEl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -20336,6 +20363,15 @@
 	},
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
+"haq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/hallway/primary/starboard)
 "haP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
@@ -20600,6 +20636,7 @@
 /area/station/hallway/primary/central/aft)
 "hec" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "heh" = (
@@ -22382,10 +22419,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
-"hOj" = (
-/obj/structure/ladder,
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/station/asteroid)
 "hOo" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Hut"
@@ -22442,6 +22475,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"hPz" = (
+/turf/open/space/basic,
+/area/station/asteroid)
 "hPB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
@@ -25482,6 +25518,11 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/station/command/bridge)
+"iTL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "iTN" = (
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -25819,6 +25860,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"jaa" = (
+/obj/item/wallframe/airalarm,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "jad" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
@@ -29228,6 +29273,11 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
+"kjz" = (
+/obj/structure/broken_flooring/singular/directional/west,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kjC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -29956,6 +30006,13 @@
 "ktR" = (
 /turf/closed/wall,
 /area/station/biodome/aft)
+"kuk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kup" = (
 /obj/structure/transit_tube{
 	dir = 4
@@ -30517,6 +30574,10 @@
 "kDX" = (
 /turf/open/floor/carpet,
 /area/station/cargo/office)
+"kEb" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kEf" = (
 /obj/structure/railing{
 	dir = 10
@@ -31843,6 +31904,12 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/station/command/gateway)
+"lbN" = (
+/obj/structure/mineral_door/wood{
+	name = "Maintenance Bar"
+	},
+/turf/open/misc/asteroid,
+/area/station/maintenance/fore/greater)
 "lci" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/railing{
@@ -34127,6 +34194,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"lNj" = (
+/obj/structure/broken_flooring/side/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "lNk" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -35919,6 +35990,14 @@
 /obj/effect/turf_decal/siding/dark_green,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"mqz" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "mqA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera/directional/west{
@@ -36249,6 +36328,10 @@
 	},
 /turf/open/floor/stone,
 /area/station/hallway/primary/starboard)
+"mwt" = (
+/obj/item/screwdriver,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "mww" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -38298,6 +38381,11 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/donk,
 /area/station/hallway/secondary/service)
+"niE" = (
+/obj/structure/cable,
+/obj/machinery/power/floodlight,
+/turf/open/misc/asteroid/airless,
+/area/station/asteroid)
 "niI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40928,7 +41016,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/stone,
+/turf/closed/wall,
 /area/station/security/courtroom)
 "oep" = (
 /obj/effect/turf_decal/siding/wood,
@@ -41102,6 +41190,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
 /area/station/commons/storage/primary)
+"ofK" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/lighter,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "ofM" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -41888,7 +41981,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ouU" = (
-/obj/effect/spawner/structure/window,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
@@ -43865,6 +43957,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/service/kitchen/diner)
+"pdg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "pdj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -46475,10 +46571,11 @@
 /area/station/commons/dorms)
 "pYQ" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "pZg" = (
@@ -49797,11 +49894,6 @@
 /obj/effect/landmark/navigate_destination/dockesc,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
-"rdj" = (
-/obj/effect/spawner/random/exotic/technology,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rdm" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -50581,6 +50673,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"rqS" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "rqX" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/medical_all,
@@ -50980,6 +51076,12 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/biodome)
+"rwV" = (
+/obj/structure/broken_flooring/singular/directional/west,
+/obj/item/wrench,
+/obj/structure/broken_flooring/singular/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "rxa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -52128,6 +52230,10 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"rSR" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "rTb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -52451,6 +52557,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"rXI" = (
+/obj/item/rack_parts,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "rXL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52655,8 +52765,10 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
 "sbs" = (
-/obj/effect/decal/cleanable/ash,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "sbA" = (
@@ -53206,6 +53318,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"smS" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/security/courtroom)
 "snd" = (
 /turf/closed/wall/mineral/wood,
 /area/station/service/kitchen/coldroom)
@@ -54332,6 +54450,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sIi" = (
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "sIn" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/misc/asteroid/airless,
@@ -54722,7 +54844,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "sOR" = (
-/obj/item/wallframe/painting/large,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/iron,
+/obj/effect/spawner/random/exotic/technology,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "sOZ" = (
@@ -56087,14 +56211,6 @@
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"tmX" = (
-/obj/item/lighter,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "tna" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
@@ -58503,6 +58619,13 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms)
+"ugh" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "ugn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -59519,6 +59642,11 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/command/gateway)
+"uBk" = (
+/obj/item/wallframe/telescreen/entertainment,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "uBq" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/eighties,
@@ -60236,6 +60364,9 @@
 	dir = 4
 	},
 /area/station/command/heads_quarters/cmo)
+"uOo" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/central/greater)
 "uOp" = (
 /obj/structure/table,
 /obj/item/storage/medkit/brute,
@@ -61683,6 +61814,10 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"voV" = (
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "voY" = (
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/glass/reinforced,
@@ -62253,7 +62388,8 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "vAj" = (
-/obj/effect/decal/cleanable/ash/large,
+/obj/item/stack/sheet/glass,
+/obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "vAA" = (
@@ -63531,11 +63667,6 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
-"vWx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wallframe/airalarm,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "vWz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67862,11 +67993,6 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"xvA" = (
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "xvD" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -68763,6 +68889,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"xKZ" = (
+/obj/item/weldingtool/mini,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "xLe" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/water/jungle/biodome,
@@ -69148,7 +69278,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xRs" = (
-/obj/item/wallframe/painting/large,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
@@ -69407,6 +69536,10 @@
 /obj/structure/cable,
 /turf/open/floor/fake_snow/safe,
 /area/station/medical/break_room)
+"xVu" = (
+/obj/item/wallframe/painting/large,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "xVv" = (
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
@@ -69974,6 +70107,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
+"yeH" = (
+/obj/item/crowbar,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "yeN" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/light/floor,
@@ -86199,11 +86336,11 @@ rRv
 rRv
 rRv
 hNy
-hNy
-hNy
-hNy
-rRv
-rRv
+pKF
+pKF
+pKF
+pKF
+pKF
 rRv
 rRv
 rRv
@@ -86456,11 +86593,11 @@ rRv
 rRv
 hNy
 hNy
-hNy
-hNy
-hNy
-hNy
-hNy
+pKF
+xVu
+ofK
+xVu
+pKF
 rRv
 rRv
 rRv
@@ -86708,15 +86845,15 @@ rRv
 rRv
 rRv
 rRv
-rRv
-rRv
-rRv
+pKF
+jmc
+pKF
 hNy
 hNy
-hNy
-hNy
-hNy
-hNy
+pKF
+aUn
+kuk
+rqS
 pKF
 pKF
 pKF
@@ -86966,14 +87103,14 @@ hNy
 hNy
 hNy
 pKF
-jmc
+cJU
 pKF
 hNy
 hNy
-hNy
-hNy
-hNy
-hNy
+pKF
+xVu
+ugH
+xVu
 pKF
 wLL
 qjl
@@ -87221,15 +87358,15 @@ rRv
 hNy
 hNy
 hNy
-hNy
-pKF
-cJU
 pKF
 pKF
+cUf
 pKF
 pKF
 pKF
 pKF
+pKF
+ugh
 pKF
 pKF
 aoY
@@ -87479,14 +87616,14 @@ hNy
 pKF
 pKF
 pKF
-pKF
-cUf
-pKF
-cJU
-cJU
+mqz
+cJP
+dBC
+dBC
+ugH
 hec
-cJU
-xAX
+ugH
+ugH
 cRz
 pKF
 dBC
@@ -87738,9 +87875,9 @@ ugH
 mGs
 ugH
 iEU
-gVx
-cJU
-rre
+ugH
+ugH
+ugH
 pKF
 qaC
 cJU
@@ -87753,7 +87890,7 @@ pKF
 pKF
 pKF
 pKF
-rRv
+pKF
 cCZ
 cCZ
 cCZ
@@ -88006,11 +88143,11 @@ pSz
 drZ
 ffW
 pKF
-iro
-jaZ
+rre
+rwV
 cJU
+fEk
 pKF
-rRv
 cCZ
 cCZ
 cCZ
@@ -88264,10 +88401,10 @@ cJU
 cJU
 dBC
 cJU
+rre
 cJU
 cJU
 pKF
-rRv
 cCZ
 cCZ
 cCZ
@@ -88523,8 +88660,8 @@ dBC
 cJU
 cJU
 iGJ
+cJU
 pKF
-rRv
 cCZ
 cCZ
 cCZ
@@ -88777,11 +88914,11 @@ pSz
 cJU
 cJU
 pKF
-jaZ
+kjz
 iro
-cJU
+rre
+mwt
 pKF
-hNy
 hNy
 hNy
 hNy
@@ -90611,7 +90748,7 @@ gfv
 gfv
 hNy
 hNy
-cCZ
+hNy
 hNy
 hNy
 cCZ
@@ -94407,11 +94544,11 @@ cCZ
 cCZ
 cCZ
 cCZ
-rRv
-rRv
-hNy
-hNy
-hNy
+pKF
+pKF
+pKF
+pKF
+pKF
 hNy
 pKF
 cJU
@@ -94664,11 +94801,11 @@ cCZ
 cCZ
 cCZ
 cCZ
-rRv
-rRv
-hNy
-hNy
-hNy
+pKF
+yeH
+cJU
+xKZ
+pKF
 pKF
 pKF
 qeX
@@ -94921,11 +95058,11 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-rRv
-hNy
-hNy
-hNy
+pKF
+avJ
+lNj
+ase
+cgO
 pKF
 ehZ
 cJU
@@ -95178,12 +95315,12 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-rRv
-hNy
-hNy
-hNy
 pKF
+cJU
+cJU
+iGJ
+cJU
+tai
 wpF
 aqO
 gxB
@@ -95435,11 +95572,11 @@ vtU
 vtU
 vtU
 vtU
-hNy
-rRv
-hNy
-hNy
-hNy
+pKF
+aqO
+cJU
+avJ
+cgO
 pKF
 rqH
 cJU
@@ -95692,11 +95829,11 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
-rRv
-rRv
-hNy
-hNy
+pKF
+elE
+cJU
+kEb
+pKF
 pKF
 pKF
 tai
@@ -95949,14 +96086,14 @@ cCZ
 cCZ
 cCZ
 cCZ
-rRv
-rRv
-hNy
-hNy
-hNy
+pKF
+pKF
+pKF
+pKF
+pKF
 hNy
 pKF
-cJU
+tai
 bXd
 pKF
 dBC
@@ -105004,11 +105141,11 @@ oAe
 uXG
 oAe
 oAe
-jZC
-jZC
-jZC
-jZC
-jZC
+uOo
+uOo
+uOo
+uOo
+uOo
 jZC
 jZC
 phM
@@ -105261,7 +105398,7 @@ oAe
 cOq
 eLF
 nWL
-jZC
+uOo
 lPc
 szK
 lPc
@@ -105515,10 +105652,10 @@ oAe
 tKF
 hFZ
 oAe
-vWx
-rdj
+wJI
+cOq
 xAu
-jZC
+uOo
 vUj
 osi
 huh
@@ -105772,10 +105909,10 @@ oAe
 aez
 oAe
 oAe
-oAe
-oAe
-oAe
-jZC
+xRs
+vfM
+gRN
+uOo
 bQd
 lPc
 qmt
@@ -106029,10 +106166,10 @@ oAe
 wkE
 wKl
 oAe
-sOR
+jaa
 sbs
 xRs
-jZC
+uOo
 huh
 osi
 vUj
@@ -106287,9 +106424,9 @@ nBL
 ukN
 pYQ
 anr
-tmX
-xvA
-jZC
+cAe
+gRN
+uOo
 lPc
 qkk
 dvi
@@ -106479,7 +106616,7 @@ cHt
 jlt
 hUS
 jlt
-hNy
+hPz
 hNy
 hNy
 sBz
@@ -106543,19 +106680,19 @@ oAe
 tKF
 gPu
 oAe
-sOR
+aoy
 vAj
 sOR
-jZC
-jZC
-jZC
-jZC
-jZC
-jZC
-jZC
-jZC
-jZC
-jZC
+uOo
+uOo
+uOo
+uOo
+uOo
+uOo
+uOo
+uOo
+uOo
+uOo
 hxO
 dxK
 dTP
@@ -106812,7 +106949,7 @@ tLq
 xGz
 gBy
 xQn
-bdN
+uOo
 fTw
 aYY
 mde
@@ -106999,7 +107136,7 @@ hNy
 sBz
 tlU
 mlR
-mlR
+cHk
 rRt
 sBz
 bXR
@@ -107069,7 +107206,7 @@ oAe
 oAe
 oAe
 gRN
-bdN
+uOo
 jGg
 qZF
 qZF
@@ -107254,8 +107391,8 @@ hNy
 hNy
 hNy
 sBz
-hNy
-cHk
+sBz
+sBz
 sBz
 sBz
 sBz
@@ -107326,7 +107463,7 @@ gkC
 eoL
 oAe
 gRN
-bdN
+uOo
 kWu
 lsg
 ckd
@@ -107507,11 +107644,11 @@ hNy
 hNy
 uCx
 hNy
-hNy
-hNy
-hNy
-hNy
-hNy
+sIi
+sXv
+dYQ
+dYQ
+dYQ
 hNy
 sBz
 cwX
@@ -107583,7 +107720,7 @@ nYQ
 wyt
 jUS
 cAe
-bdN
+uOo
 sgC
 uOi
 cgJ
@@ -107764,11 +107901,11 @@ hNy
 uXJ
 jPA
 hNy
-hNy
-hNy
-hNy
-hNy
-hNy
+uBk
+dYQ
+dYQ
+dYQ
+iTL
 hNy
 sBz
 gre
@@ -107840,7 +107977,7 @@ mJV
 jKA
 oAe
 eMn
-bdN
+uOo
 jpp
 jpp
 jpp
@@ -108021,11 +108158,11 @@ hNy
 hNy
 uXJ
 hNy
-hNy
-hNy
-hNy
-hNy
-hNy
+dYQ
+pdg
+dYQ
+dYQ
+dYQ
 hNy
 sBz
 jpC
@@ -108097,7 +108234,7 @@ pgX
 pgX
 pgX
 pJB
-bdN
+uOo
 bdN
 bdN
 bdN
@@ -108278,11 +108415,11 @@ hNy
 uAc
 jPA
 hNy
-hNy
-hNy
-hNy
-hNy
-hNy
+dYQ
+aXL
+dYQ
+dYQ
+sXv
 hNy
 sBz
 xFj
@@ -108534,9 +108671,9 @@ hNy
 hNy
 hNy
 uXJ
-jPA
-jPA
-uCx
+lbN
+dYQ
+pdg
 hNy
 hNy
 hNy
@@ -108790,10 +108927,10 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hNy
 jPA
+hNy
+hNy
+lbN
 hNy
 jPA
 xWW
@@ -109047,7 +109184,7 @@ hNy
 hNy
 hNy
 hNy
-hNy
+jPA
 hNy
 hNy
 jPA
@@ -109304,9 +109441,9 @@ hNy
 hNy
 hNy
 hNy
-hNy
-hNy
-hNy
+jPA
+jPA
+jPA
 jPA
 jPA
 jPA
@@ -113218,7 +113355,7 @@ kPb
 cCZ
 cCZ
 hNy
-hOj
+hNy
 hNy
 hNy
 hNy
@@ -114507,7 +114644,7 @@ kND
 kND
 kND
 dLh
-jdJ
+haq
 enZ
 mnI
 fTn
@@ -115022,7 +115159,7 @@ abK
 abK
 kdK
 dQX
-enZ
+smS
 oqE
 snK
 sbp
@@ -179806,7 +179943,7 @@ ulg
 voY
 ksQ
 eZB
-rRv
+niE
 oOB
 rRv
 hNy
@@ -180063,7 +180200,7 @@ eZB
 eZB
 eZB
 eZB
-hNy
+eZB
 oOB
 oOB
 oOB
@@ -180316,11 +180453,11 @@ rRv
 eZB
 osg
 eZB
-rRv
-rRv
-rRv
-rRv
-hNy
+rSR
+rXI
+rXI
+rSR
+eZB
 hNy
 hNy
 oOB
@@ -180573,11 +180710,11 @@ rRv
 eZB
 rnO
 eZB
-rRv
-rRv
-hNy
-rRv
-hNy
+avN
+avN
+avN
+avN
+eZB
 hNy
 hNy
 oOB
@@ -180829,12 +180966,12 @@ kPb
 rRv
 eZB
 rnO
+isa
+avN
+avN
+avN
+avN
 eZB
-vij
-rRv
-rRv
-rRv
-rRv
 hNy
 rRv
 oOB
@@ -181086,12 +181223,12 @@ kPb
 rRv
 eZB
 rnO
-ouU
-hNy
-hNy
-hNy
-rRv
-rRv
+eZB
+dOr
+voV
+voV
+voV
+eZB
 hNy
 hNy
 oOB
@@ -181343,12 +181480,12 @@ kPb
 rRv
 eZB
 rnO
-ouU
-cBY
-ouU
-ouU
-rRv
-hNy
+eZB
+eZB
+eZB
+eZB
+eZB
+eZB
 hNy
 hNy
 oOB
@@ -181861,7 +181998,7 @@ lGr
 xfs
 avN
 ouU
-rRv
+vij
 rRv
 hNy
 hNy

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -18441,6 +18441,11 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
+"grb" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "gre" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -22776,6 +22781,11 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/storage)
+"hVJ" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/mapping_helpers/damaged_window,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "hVP" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -25250,6 +25260,22 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"iOS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "iOT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/barricade/wooden,
@@ -33952,6 +33978,10 @@
 "lIV" = (
 /turf/open/floor/iron/terracotta,
 /area/station/biodome/aft)
+"lIY" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/misc/asteroid/airless,
+/area/station/asteroid)
 "lJa" = (
 /obj/item/picket_sign,
 /turf/open/misc/asteroid,
@@ -44641,6 +44671,20 @@
 	},
 /turf/open/floor/stone,
 /area/station/maintenance/starboard/central)
+"prs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "prx" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office"
@@ -50311,6 +50355,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/grass,
 /area/station/biodome)
+"rnx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "rnB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -54165,6 +54221,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"sGt" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/lattice,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "sGO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -59688,6 +59749,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
+"uEV" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "uFb" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid,
@@ -60085,6 +60155,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"uMS" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "uNa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -60195,6 +60271,16 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/carpet/executive,
 /area/station/security/prison)
+"uOR" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "uPi" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
@@ -61139,6 +61225,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"vgP" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "vhi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87398,7 +87494,7 @@ cJU
 qaC
 pKF
 rRv
-tFt
+rRv
 rRv
 dMJ
 vtU
@@ -87654,9 +87750,9 @@ cJU
 cJU
 pKF
 pKF
-rRv
-rRv
-rRv
+pKF
+pKF
+pKF
 rRv
 cCZ
 cCZ
@@ -87910,10 +88006,10 @@ pSz
 drZ
 ffW
 pKF
-hNy
-rRv
-rRv
-rRv
+iro
+jaZ
+cJU
+pKF
 rRv
 cCZ
 cCZ
@@ -88166,11 +88262,11 @@ aMB
 pSz
 cJU
 cJU
+dBC
+cJU
+cJU
+cJU
 pKF
-hNy
-rRv
-rRv
-rRv
 rRv
 cCZ
 cCZ
@@ -88422,12 +88518,12 @@ vhE
 aMB
 pSz
 cJU
+cJU
 dBC
+cJU
+cJU
+iGJ
 pKF
-hNy
-rRv
-rRv
-rRv
 rRv
 cCZ
 cCZ
@@ -88681,10 +88777,10 @@ pSz
 cJU
 cJU
 pKF
-rRv
-rRv
-rRv
-hNy
+jaZ
+iro
+cJU
+pKF
 hNy
 hNy
 hNy
@@ -89706,7 +89802,7 @@ aMB
 vhE
 aMB
 pSz
-iro
+cJU
 qdW
 pKF
 ase
@@ -90978,8 +91074,8 @@ hNy
 hNy
 hNy
 pKF
-uNS
-dBC
+rnx
+pKF
 pSz
 vUI
 pSz
@@ -90991,8 +91087,8 @@ pSz
 pSz
 pSz
 pSz
-dBC
-cJU
+uOR
+uOR
 pKF
 pKF
 pKF
@@ -92523,8 +92619,8 @@ hNy
 hNy
 hNy
 pKF
-sUT
-cJU
+iOS
+vgP
 pKF
 pKF
 pKF
@@ -93035,7 +93131,7 @@ hNy
 hNy
 hNy
 pKF
-dBC
+hVJ
 wzE
 sUT
 lth
@@ -94411,7 +94507,7 @@ bqj
 elq
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -94633,7 +94729,7 @@ coj
 coj
 coj
 jKm
-coj
+prs
 coj
 coj
 bwN
@@ -94668,7 +94764,7 @@ iIl
 iIl
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -94925,7 +95021,7 @@ iIl
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -95182,7 +95278,7 @@ iIl
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -95439,7 +95535,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -95696,7 +95792,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -95953,7 +96049,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -96210,7 +96306,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -96467,7 +96563,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -96724,7 +96820,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -96981,7 +97077,7 @@ cCZ
 nLN
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -97238,7 +97334,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -97495,7 +97591,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -97752,7 +97848,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -98009,7 +98105,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -98266,7 +98362,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+vtU
 cCZ
 cCZ
 cCZ
@@ -98523,7 +98619,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -98780,7 +98876,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -99037,7 +99133,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -99294,7 +99390,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-cCZ
+aWF
 cCZ
 cCZ
 cCZ
@@ -99547,11 +99643,11 @@ hNy
 hNy
 hNy
 hNy
-cCZ
-cCZ
-cCZ
-cCZ
-cCZ
+aWF
+vtU
+aWF
+aWF
+aWF
 cCZ
 cCZ
 cCZ
@@ -148823,11 +148919,11 @@ ikk
 ikk
 ikk
 ikk
-hHc
-hHc
-hHc
-hHc
-hHc
+grb
+grb
+grb
+grb
+grb
 hHc
 hHc
 hHc
@@ -149084,7 +149180,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -149341,7 +149437,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -149598,7 +149694,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -149855,7 +149951,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -150112,7 +150208,7 @@ ikk
 ikk
 ikk
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -150369,7 +150465,7 @@ vHx
 bnJ
 ikk
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -150626,7 +150722,7 @@ dBp
 bnJ
 tiU
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -150883,7 +150979,7 @@ pSH
 bnJ
 ikk
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -151139,25 +151235,25 @@ ibF
 pSH
 vHx
 ikk
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
+grb
+uMS
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
+grb
 hNy
 doJ
 doJ
@@ -151397,7 +151493,7 @@ pSH
 tNz
 tiU
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -151654,7 +151750,7 @@ pSH
 bnJ
 ikk
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -153974,7 +154070,7 @@ smF
 ikk
 ikk
 ikk
-vkh
+uEV
 ikk
 ikk
 tms
@@ -154255,9 +154351,9 @@ dce
 ikk
 hNy
 hNy
-hHc
-hHc
-hHc
+grb
+grb
+grb
 hHc
 hHc
 hHc
@@ -154514,7 +154610,7 @@ hNy
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -154771,7 +154867,7 @@ ikk
 ikk
 ikk
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -155028,7 +155124,7 @@ dce
 pSH
 pSH
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -155285,7 +155381,7 @@ pSH
 pSH
 qAf
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -155542,7 +155638,7 @@ dor
 dor
 pSH
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -155799,7 +155895,7 @@ fUx
 dor
 pSH
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -156056,7 +156152,7 @@ uYf
 dor
 pSH
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -156313,7 +156409,7 @@ eyA
 dor
 khI
 ikk
-hHc
+grb
 hHc
 hHc
 hHc
@@ -172156,7 +172252,7 @@ rRv
 rRv
 rRv
 rRv
-rRv
+lIY
 rRv
 jpl
 jpl
@@ -172413,7 +172509,7 @@ rRv
 rRv
 rRv
 rRv
-rRv
+lIY
 rRv
 rRv
 vEn
@@ -172670,7 +172766,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 rRv
 vEn
@@ -172927,7 +173023,7 @@ byv
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 vEn
@@ -173184,7 +173280,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -173441,7 +173537,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -173698,7 +173794,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 uzJ
 dCB
@@ -173955,7 +174051,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 dUQ
 dCB
@@ -174212,7 +174308,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 dUQ
 dCB
@@ -174469,7 +174565,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -174726,7 +174822,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -174983,7 +175079,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 hHc
@@ -175240,13 +175336,13 @@ hHc
 hHc
 hHc
 hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
-hHc
+sGt
+sGt
+sGt
+sGt
+sGt
+sGt
+sGt
 hHc
 jpl
 aXw
@@ -175503,7 +175599,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 jpl
 jpl
@@ -175760,7 +175856,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -176017,7 +176113,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -176274,10 +176370,10 @@ hHc
 hHc
 hHc
 hHc
+sGt
 hHc
 hHc
-hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -176531,12 +176627,12 @@ hHc
 hHc
 hHc
 hHc
+sGt
+sGt
+sGt
+sGt
 hHc
-hHc
-hHc
-hHc
-hHc
-hHc
+cCZ
 hHc
 jpl
 mjm
@@ -176791,7 +176887,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 aCq
 dUQ
@@ -177048,7 +177144,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -177305,7 +177401,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 xpW
 dUQ
@@ -177562,7 +177658,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+grb
 hHc
 hHc
 hHc
@@ -177819,10 +177915,10 @@ hHc
 hHc
 hHc
 hHc
-hHc
-hHc
-hHc
-hHc
+grb
+grb
+grb
+grb
 jpl
 pae
 jpl
@@ -178080,7 +178176,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl
@@ -178337,7 +178433,7 @@ hHc
 hHc
 hHc
 hHc
-hHc
+sGt
 hHc
 hHc
 jpl

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -22475,9 +22475,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"hPz" = (
-/turf/open/space/basic,
-/area/station/asteroid)
 "hPB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
@@ -106616,7 +106613,7 @@ cHt
 jlt
 hUS
 jlt
-hPz
+hNy
 hNy
 hNy
 sBz


### PR DESCRIPTION
-  Adds more grilles and airlocks to port maintenance, to help with the area losing air way too fast
- Moved some maintenance rooms about, and added some emptier, larger rooms
- Fixed a row of doubled up windows