### PR TITLE
Orbers no longer runtime when you step on a mousetrap with a shoe

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -120,17 +120,18 @@
 			pulse()
 			return FALSE
 		switch(type)
-			if("feet") //ORBSTATION: This whole block had to be changed to give digitigrade legs immunity to mousetraps.
-				if(victim.shoes)
-					to_chat(victim, span_notice("Your [victim.shoes-name] protects you from [src]."))
-				else
+			if("feet")
+				if(!victim.shoes)
 					affecting = victim.get_bodypart(pick(GLOB.leg_zones))
+					//ORBSTATION: Digitigrade legs are immune to mousetraps.
 					if(IS_DIGITIGRADE_LIMB(affecting))
 						affecting = null
 						to_chat(victim, span_notice("Your digitigrade legs protect you from [src]."))
 					else
 						victim.Paralyze(6 SECONDS)
-			//END ORBSTATION
+					//ORBSTATION EDIT END
+				else
+					to_chat(victim, span_notice("Your [victim.shoes.name] protects you from [src]."))
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
 				if(!victim.gloves)
 					affecting = victim.get_bodypart(type)


### PR DESCRIPTION


## About The Pull Request

When stepped on a mousetrap, it looked for `victim.shoe-name` which i assume, tries to return the shoe item of the mob, and tries to remove name from it as if it was a list, which caused a runtime. This is fixed now.

Also, slightly rearranged our digitigrade check edit to the logic, to make it easier to merge changes to it.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

