### PR TITLE
Makes the power system more redundant

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2412,6 +2412,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"aNG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "aNP" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/bot,
@@ -3382,6 +3388,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "bfJ" = (
@@ -3726,6 +3733,7 @@
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bmm" = (
@@ -3926,6 +3934,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"bqH" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "bqQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4779,6 +4791,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bHy" = (
@@ -5102,6 +5115,11 @@
 "bNV" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"bNY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "bOc" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -5515,6 +5533,7 @@
 /area/station/biodome/aft)
 "bVg" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "bVk" = (
@@ -8228,6 +8247,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "cNl" = (
@@ -8477,6 +8497,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cSC" = (
@@ -8912,6 +8933,7 @@
 "dbD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dbR" = (
@@ -11920,6 +11942,7 @@
 "edw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "edA" = (
@@ -12463,6 +12486,7 @@
 /area/station/medical/pharmacy)
 "eoI" = (
 /obj/effect/spawner/random/trash/graffiti,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "eoJ" = (
@@ -12539,10 +12563,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
-"eqm" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/closed/wall,
-/area/station/asteroid)
 "eqB" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
@@ -12641,6 +12661,13 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"esT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "esU" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -13118,6 +13145,11 @@
 /obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/plating/reinforced,
 /area/station/service/janitor)
+"eAv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "eAx" = (
 /turf/closed/wall/r_wall,
 /area/station/security/mechbay)
@@ -14476,6 +14508,7 @@
 "eYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "eYm" = (
@@ -15258,10 +15291,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
-"fmr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
 "fmx" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
@@ -16490,6 +16519,7 @@
 "fJe" = (
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "fJq" = (
@@ -18354,6 +18384,11 @@
 	},
 /turf/open/floor/fakebasalt,
 /area/station/hallway/primary/aft)
+"goJ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "goM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20353,15 +20388,6 @@
 	},
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/central/greater)
-"haq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/starboard)
 "haP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
@@ -20650,6 +20676,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"heD" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "heE" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
@@ -21630,6 +21661,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/fake_dirt/wasteland,
 /area/station/science/research)
+"hyd" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "hyx" = (
 /obj/item/shovel/spade,
 /turf/open/misc/asteroid/dug,
@@ -21825,6 +21861,7 @@
 /area/station/biodome)
 "hDC" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "hDE" = (
@@ -22586,6 +22623,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/red/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "hRr" = (
@@ -23767,11 +23805,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"imi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "imC" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -24009,6 +24042,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iqQ" = (
@@ -24122,6 +24156,7 @@
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "isF" = (
@@ -24543,6 +24578,7 @@
 /area/station/engineering/atmos/pumproom)
 "iAK" = (
 /obj/effect/decal/cleanable/shreds,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "iAO" = (
@@ -24960,6 +24996,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/cargo/miningdock)
+"iIV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "iIW" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 8
@@ -25363,6 +25405,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "iQO" = (
@@ -25552,6 +25595,7 @@
 /area/station/science/cytology)
 "iUN" = (
 /obj/effect/spawner/random/trash/garbage,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "iUP" = (
@@ -25635,6 +25679,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "iWF" = (
@@ -30408,6 +30453,7 @@
 /area/station/service/chapel)
 "kBw" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kBL" = (
@@ -30485,6 +30531,7 @@
 /area/station/security/medical)
 "kCB" = (
 /obj/structure/broken_flooring/singular/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "kCG" = (
@@ -30743,6 +30790,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "kHI" = (
@@ -31173,6 +31221,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kNW" = (
+/obj/structure/cable,
+/turf/open/floor/plating/foam,
+/area/station/maintenance/aft/upper)
 "kOa" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
@@ -32279,6 +32331,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "lhK" = (
@@ -32290,6 +32343,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"lhV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "lig" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -32464,6 +32523,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "lkK" = (
@@ -32998,11 +33058,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"luf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "lul" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -33036,6 +33091,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "luN" = (
@@ -33127,6 +33183,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "lwu" = (
@@ -35762,6 +35819,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/chapel/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mno" = (
@@ -36540,6 +36598,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/moisture,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "mBs" = (
@@ -37668,6 +37727,7 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Research Division"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "mXg" = (
@@ -37692,6 +37752,7 @@
 /area/station/service/chapel)
 "mXt" = (
 /obj/machinery/light/small/red/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "mXu" = (
@@ -38799,6 +38860,11 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"nqO" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "nrd" = (
 /obj/structure/railing{
 	dir = 1
@@ -40897,6 +40963,7 @@
 /area/station/engineering/main)
 "ocv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "ocz" = (
@@ -41004,7 +41071,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/closed/wall,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "oep" = (
 /obj/effect/turf_decal/siding/wood,
@@ -41014,6 +41081,7 @@
 /area/station/commons/lounge)
 "oeq" = (
 /obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "oet" = (
@@ -42614,6 +42682,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
+"oFA" = (
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "oFB" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -43543,6 +43616,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oWu" = (
@@ -45266,6 +45340,7 @@
 /area/station/engineering/atmos)
 "pAP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "pAR" = (
@@ -45310,6 +45385,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "pBY" = (
@@ -45587,6 +45663,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "pGS" = (
@@ -45779,6 +45856,7 @@
 /area/station/maintenance/department/engine)
 "pKd" = (
 /obj/structure/railing/corner,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "pKg" = (
@@ -45869,6 +45947,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grime,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "pMd" = (
@@ -45972,6 +46051,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pNM" = (
@@ -46678,6 +46758,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "qbT" = (
@@ -46709,6 +46790,11 @@
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"qcn" = (
+/obj/effect/landmark/start/assistant/dept/med,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qcE" = (
 /obj/structure/holosign/barrier/atmos/leaf{
 	dir = 1
@@ -46869,6 +46955,11 @@
 /obj/effect/turf_decal/tile/dark/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qev" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "qeL" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/emergency_oxygen/engi{
@@ -47924,6 +48015,7 @@
 /area/space/nearstation)
 "qwG" = (
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "qwL" = (
@@ -47953,6 +48045,10 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/biodome/aft)
+"qxd" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/aft/upper)
 "qxg" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48169,6 +48265,11 @@
 /obj/item/melee/skateboard/improvised,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"qAB" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "qAG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48334,6 +48435,7 @@
 /area/station/commons/dorms)
 "qCM" = (
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qCN" = (
@@ -48385,6 +48487,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qDA" = (
@@ -48417,6 +48520,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "qEw" = (
@@ -48665,6 +48769,7 @@
 	name = "Commissary Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "qJu" = (
@@ -50913,6 +51018,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "rva" = (
@@ -51807,6 +51913,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rKS" = (
@@ -52344,6 +52451,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "rVm" = (
@@ -52716,6 +52824,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "sbf" = (
@@ -52748,6 +52857,10 @@
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"sbD" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sbJ" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/button/elevator/directional/east{
@@ -53327,6 +53440,7 @@
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "snA" = (
@@ -53425,6 +53539,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "soP" = (
@@ -54211,6 +54326,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "sDO" = (
@@ -55379,6 +55495,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/blue/half,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sZk" = (
@@ -55727,6 +55844,7 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "tfc" = (
@@ -56647,6 +56765,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "twr" = (
@@ -57698,6 +57817,7 @@
 /area/station/medical/virology)
 "tOd" = (
 /obj/effect/spawner/random/trash/caution_sign,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "tOe" = (
@@ -58364,6 +58484,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"ubw" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "ubG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -58679,6 +58804,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot_red,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "uhL" = (
@@ -59237,6 +59363,11 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"usm" = (
+/obj/structure/broken_flooring/singular/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "uss" = (
 /obj/structure/flora/bush/stalky/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -62373,6 +62504,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "vAB" = (
@@ -63747,6 +63879,7 @@
 	cycle_id = "viro-passthrough"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "vYg" = (
@@ -63816,6 +63949,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"waR" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port/central)
 "wbc" = (
 /obj/structure/bed,
 /obj/machinery/newscaster/directional/east,
@@ -64006,6 +64143,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/primary/central/aft)
+"wer" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "weu" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/dresser,
@@ -65195,6 +65337,7 @@
 	codes_txt = "patrol;next_patrol=Bar";
 	location = "Hydro"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wxc" = (
@@ -65982,6 +66125,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "wJn" = (
@@ -66363,6 +66507,7 @@
 	name = "Biohazard Containment Door"
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "wQm" = (
@@ -67626,6 +67771,7 @@
 /area/station/service/theater)
 "xoy" = (
 /obj/structure/railing,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "xoz" = (
@@ -67634,6 +67780,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xoI" = (
@@ -67812,11 +67959,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"xsO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "xtg" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68063,6 +68205,7 @@
 "xxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xxM" = (
@@ -69107,6 +69250,11 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
+"xOx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xOJ" = (
 /obj/machinery/camera/directional/south{
 	network = list("ss13","rd","xeno");
@@ -69123,6 +69271,10 @@
 	},
 /turf/open/floor/stone,
 /area/station/commons/lounge)
+"xOU" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "xPc" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/white,
@@ -69803,6 +69955,7 @@
 /area/station/maintenance/port/central)
 "yaA" = (
 /obj/effect/decal/cleanable/molten_object,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "yaB" = (
@@ -69837,6 +69990,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "yaY" = (
@@ -69874,6 +70028,7 @@
 /area/station/maintenance/starboard/lesser)
 "ybr" = (
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "ybs" = (
@@ -91475,19 +91630,19 @@ dIN
 bJf
 vMk
 rDy
-cJU
-cJU
-cJU
-cJU
-cJU
-hgp
-cJU
-cJU
-cJU
-cJU
-cJU
-cJU
-cJU
+bqH
+bqH
+bqH
+bqH
+bqH
+waR
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
 pKF
 pKF
 pKF
@@ -91732,7 +91887,7 @@ hvz
 alY
 dIN
 pKF
-cJU
+bqH
 sQq
 bGW
 bGW
@@ -91744,7 +91899,7 @@ bGW
 bGW
 bGW
 bGW
-cJU
+bqH
 xMO
 otT
 pKF
@@ -92001,7 +92156,7 @@ kxR
 hle
 shx
 bGW
-cJU
+bqH
 dBC
 dBC
 pKF
@@ -92246,7 +92401,7 @@ lRV
 ciy
 cJU
 cvI
-bWG
+oTM
 txW
 bGW
 mkZ
@@ -92258,13 +92413,13 @@ mkZ
 mkZ
 pAe
 bGW
-cJU
-cJU
-cJU
-cJU
-hgp
-cJU
-cJU
+bqH
+bqH
+bqH
+bqH
+waR
+bqH
+bqH
 vYf
 mnk
 qSt
@@ -97099,12 +97254,12 @@ hNy
 hNy
 pKF
 qdW
-cJU
-jaZ
-avJ
-cJU
-cJU
-agH
+bqH
+usm
+hyd
+bqH
+bqH
+esT
 ibz
 kAo
 bQB
@@ -97356,7 +97511,7 @@ hNy
 hNy
 pKF
 wpr
-cJU
+bqH
 dJD
 xMO
 tai
@@ -97870,7 +98025,7 @@ hNy
 hNy
 sBz
 ydf
-dYQ
+xOU
 sBz
 pOj
 lke
@@ -98127,7 +98282,7 @@ sBz
 sBz
 sBz
 uDY
-dYQ
+xOU
 sBz
 bkp
 boi
@@ -98641,7 +98796,7 @@ sBz
 dcf
 krm
 dYQ
-uDY
+nqO
 sBz
 pOj
 oyj
@@ -98898,7 +99053,7 @@ sBz
 sBz
 sBz
 sBz
-dYQ
+xOU
 iJO
 sBz
 afo
@@ -99155,7 +99310,7 @@ gBW
 inF
 vMB
 snV
-dYQ
+xOU
 xPZ
 sBz
 fsz
@@ -99412,7 +99567,7 @@ mDm
 biR
 wZB
 sBz
-dYQ
+xOU
 tkw
 oLs
 fsz
@@ -100183,7 +100338,7 @@ bet
 vsM
 wZB
 sBz
-dYQ
+xOU
 sBz
 xWK
 fsz
@@ -100440,7 +100595,7 @@ gRX
 eLt
 fpj
 sBz
-tkw
+oFA
 sBz
 sBz
 fsz
@@ -100697,7 +100852,7 @@ sBz
 vUY
 sBz
 sBz
-dYQ
+xOU
 dYQ
 sBz
 cTF
@@ -100954,7 +101109,7 @@ gbs
 dYQ
 mDo
 ydf
-dYQ
+xOU
 dYQ
 sBz
 eMi
@@ -107687,7 +107842,7 @@ fPs
 frW
 qPz
 oAe
-jcx
+lJT
 oAe
 jGd
 juL
@@ -108408,7 +108563,7 @@ xFj
 sBz
 sBz
 sBz
-dYQ
+xOU
 sBz
 suE
 ndH
@@ -108458,7 +108613,7 @@ cBF
 cBF
 cBF
 fio
-jcx
+lJT
 jcx
 uOG
 jcx
@@ -108665,7 +108820,7 @@ sBz
 sBz
 hNy
 sBz
-dYQ
+xOU
 sBz
 aLk
 bCN
@@ -108715,7 +108870,7 @@ vxa
 lCa
 axX
 fio
-jcx
+lJT
 gBy
 oAe
 oAe
@@ -108922,7 +109077,7 @@ jPA
 xWW
 jPA
 ksO
-dYQ
+xOU
 sBz
 fbK
 aFY
@@ -108972,7 +109127,7 @@ wzV
 lNs
 axX
 fio
-jcx
+lJT
 lrQ
 oAe
 eVy
@@ -109229,7 +109384,7 @@ fYa
 itH
 qrj
 fio
-jcx
+lJT
 sSH
 oAe
 hko
@@ -109693,7 +109848,7 @@ sBz
 sBz
 sBz
 sBz
-dYQ
+xOU
 sBz
 aLk
 xCT
@@ -109743,7 +109898,7 @@ yeX
 doi
 vAE
 fio
-jcx
+lJT
 rJb
 oAe
 fTB
@@ -109950,7 +110105,7 @@ bVV
 rYp
 lyU
 sBz
-dYQ
+xOU
 sBz
 wzW
 hQu
@@ -110000,7 +110155,7 @@ fYo
 tva
 oMS
 fio
-jcx
+lJT
 ewP
 oAe
 jew
@@ -110257,7 +110412,7 @@ cBF
 cBF
 cBF
 fio
-jcx
+lJT
 gBy
 oAe
 oAe
@@ -110464,7 +110619,7 @@ lPU
 kwM
 qFz
 sBz
-dYQ
+xOU
 sBz
 nwu
 hQu
@@ -110514,7 +110669,7 @@ qeM
 sRL
 sAX
 ktR
-jcx
+lJT
 crO
 cAe
 cAe
@@ -110721,7 +110876,7 @@ qDw
 qTK
 xOm
 sBz
-rcP
+wer
 sBz
 ihl
 oUv
@@ -110978,7 +111133,7 @@ sBz
 sBz
 iKk
 sBz
-sXv
+qev
 sBz
 qpC
 aLk
@@ -111235,7 +111390,7 @@ nSk
 sBz
 sBz
 sBz
-dYQ
+xOU
 sBz
 isF
 aLk
@@ -111542,7 +111697,7 @@ qeM
 mvc
 vca
 ktR
-gRN
+cOq
 oAe
 cbS
 tiC
@@ -111749,7 +111904,7 @@ sBz
 sBz
 sBz
 sBz
-dYQ
+xOU
 sBz
 ucm
 oVW
@@ -112289,9 +112444,9 @@ tne
 pDj
 tne
 sfP
-bGM
-bGM
-bGM
+lhV
+lhV
+lhV
 mBn
 uZp
 rUH
@@ -112310,8 +112465,8 @@ csb
 jVF
 lYC
 roR
-gRN
-gRN
+cOq
+cOq
 tOd
 xoy
 saz
@@ -112520,8 +112675,8 @@ geE
 hNy
 hNy
 bRU
-glu
-uZp
+heD
+tUo
 ykP
 ykP
 ykP
@@ -112545,16 +112700,16 @@ mMx
 mMx
 mMx
 mMx
-bGM
-bGM
+lhV
+lhV
 rUH
 tHs
-bGM
-bGM
-bGM
-bGM
-fmr
-fmr
+lhV
+lhV
+lhV
+lhV
+rwv
+rwv
 rwv
 rwv
 tUo
@@ -112567,7 +112722,7 @@ lYC
 lYC
 jbz
 vAA
-gRN
+cOq
 gRN
 oAe
 ogR
@@ -112820,10 +112975,10 @@ uiG
 dDa
 dUI
 lwo
-rXX
-rXX
-rXX
-rXX
+iIV
+iIV
+iIV
+iIV
 eug
 ftz
 hNy
@@ -114626,7 +114781,7 @@ kND
 kND
 kND
 dLh
-haq
+jdJ
 enZ
 mnI
 fTn
@@ -158774,13 +158929,13 @@ dpR
 rxV
 pkE
 hii
-cfm
-irB
+qAB
+hUr
 bVg
-irB
+hUr
 pAP
 ocv
-ocT
+aNG
 xQz
 uUp
 jvz
@@ -159344,7 +159499,7 @@ dQI
 sZX
 tqQ
 qnE
-woD
+sbD
 vyL
 kJA
 bwV
@@ -159858,7 +160013,7 @@ cqp
 giE
 wAW
 xBr
-dnJ
+qcn
 wEA
 ikk
 ikk
@@ -160115,10 +160270,10 @@ dKV
 dKV
 hbg
 sJE
-woD
+sbD
 sZj
 xoz
-syt
+xOx
 fVb
 fVb
 iuv
@@ -160375,8 +160530,8 @@ vhi
 woD
 nUx
 ikk
-pSH
-hfI
+vkh
+epr
 rmx
 aUV
 wOd
@@ -161661,7 +161816,7 @@ qTC
 gGS
 aVG
 ruD
-luf
+eij
 iCN
 nPd
 gGI
@@ -162437,7 +162592,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 hmI
 hmI
 qcM
@@ -162636,9 +162791,9 @@ mYc
 phJ
 mss
 wxb
-imi
-imi
-imi
+ayc
+ayc
+ayc
 ayc
 ayc
 ayc
@@ -162694,7 +162849,7 @@ fJC
 fJC
 nGY
 wum
-xsO
+bDR
 pAg
 pAg
 jSD
@@ -162892,7 +163047,7 @@ phJ
 phJ
 phJ
 ojZ
-imi
+ayc
 jzd
 qik
 rML
@@ -162951,7 +163106,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 fJC
 okb
 kFl
@@ -163208,7 +163363,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 dtB
 dtB
 vxC
@@ -163406,7 +163561,7 @@ vHM
 ipc
 phJ
 jfX
-imi
+ayc
 pEk
 pGm
 sZD
@@ -163465,7 +163620,7 @@ dST
 dST
 dST
 vxC
-xsO
+bDR
 fJC
 fJC
 dhT
@@ -163663,7 +163818,7 @@ cdF
 bys
 phJ
 nOx
-imi
+ayc
 pXx
 sZD
 sZD
@@ -163722,7 +163877,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 uKI
 qWS
 vXz
@@ -163920,7 +164075,7 @@ phJ
 phJ
 phJ
 mss
-imi
+ayc
 pXx
 sZD
 sZD
@@ -163979,7 +164134,7 @@ fJC
 fJC
 mhT
 mqM
-xsO
+bDR
 vxC
 oCY
 fJC
@@ -164177,7 +164332,7 @@ yfa
 vOa
 phJ
 lqC
-imi
+ayc
 mUb
 pGm
 sZD
@@ -164236,7 +164391,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 vxC
 sFP
 fJC
@@ -164691,7 +164846,7 @@ htY
 pYM
 phJ
 uCm
-imi
+ayc
 qik
 nfE
 ggF
@@ -164750,7 +164905,7 @@ dST
 dST
 dST
 vxC
-xsO
+bDR
 qWS
 wKx
 ePh
@@ -165007,7 +165162,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 fJC
 vxC
 dtB
@@ -165264,7 +165419,7 @@ fJC
 fJC
 oAz
 bJS
-xsO
+bDR
 fJC
 vxC
 gFQ
@@ -165521,7 +165676,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 fJC
 wOr
 fJC
@@ -165778,7 +165933,7 @@ fJC
 fJC
 fJC
 vxC
-xsO
+bDR
 tgg
 cHy
 wdi
@@ -166035,7 +166190,7 @@ dST
 dST
 dST
 vxC
-xsO
+bDR
 lNc
 lAv
 lCz
@@ -166549,10 +166704,10 @@ fJC
 fJC
 wlv
 aUx
-xsO
-fJC
-fJC
-fJC
+bDR
+eKQ
+eKQ
+eKQ
 gRq
 aEU
 gxJ
@@ -167066,7 +167221,7 @@ vxC
 dOp
 fJC
 fJC
-fJC
+eKQ
 gRq
 gRq
 gRq
@@ -167323,7 +167478,7 @@ jKM
 jKM
 jKM
 vxC
-dTr
+goJ
 fJC
 tuU
 qTJ
@@ -167580,16 +167735,16 @@ vDi
 vKp
 lTG
 ajE
-fJC
-fJC
-qTJ
-qTJ
-qTJ
-qTJ
-qTJ
-qTJ
-pxM
-fJC
+eKQ
+eKQ
+qxd
+qxd
+qxd
+qxd
+qxd
+qxd
+kNW
+eKQ
 toX
 rGi
 toX
@@ -168103,10 +168258,10 @@ khx
 khx
 khx
 khx
-pxM
-fJC
+kNW
+eKQ
 iAK
-fJC
+eKQ
 nRz
 hQA
 nec
@@ -168363,7 +168518,7 @@ khx
 xSe
 fJC
 pxM
-fJC
+eKQ
 sMW
 tPY
 pxM
@@ -168620,10 +168775,10 @@ khx
 xSe
 vxC
 fJC
-fJC
-pAg
+eKQ
+bNY
 edw
-hmI
+eAv
 fJC
 pxM
 vxC
@@ -183746,10 +183901,10 @@ eZB
 eZB
 eZB
 qRv
-jgZ
-avN
-avN
-avN
+ubw
+ups
+ups
+ups
 ups
 ups
 rnO
@@ -184531,7 +184686,7 @@ wYZ
 cAQ
 eZB
 tFt
-eqm
+tFt
 tFt
 tFt
 pxk

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -30515,6 +30515,7 @@
 "kCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig)
 "kCx" = (


### PR DESCRIPTION


## About The Pull Request

Adds  loops to the powernet at several points, providing redundancy against mice. Previously the powernet was branching like the air supply pipes, unlike every other map, making it extremely fragile.  This PR makes it much harder to depower the station.

This PR also removes a rogue APC embedded in an asteroid wall, and also two rogue walls, blocking a gate to the courtroom.

## Why It's Good For The Game

What if a single mouse didn't depower the entire station
