### PR TITLE
Bans our banned poster on the Random Any Poster spawner

### DIFF
--- a/orbstation/code/cleanup/items.dm
+++ b/orbstation/code/cleanup/items.dm
@@ -108,6 +108,8 @@
 
 /obj/structure/sign/poster/contraband/random
 	blacklisted_types = list(
+		/obj/structure/sign/poster/traitor,
+		/obj/structure/sign/poster/abductor,
 		/obj/structure/sign/poster/contraband/got_wood,
 		/obj/structure/sign/poster/contraband/free_tonto,
 	)

--- a/orbstation/code/cleanup/items.dm
+++ b/orbstation/code/cleanup/items.dm
@@ -98,6 +98,14 @@
 	return INITIALIZE_HINT_QDEL
 
 //Never spawn these posters randomly either
+/obj/structure/sign/poster/random
+	blacklisted_types = list(
+		/obj/structure/sign/poster/traitor,
+		/obj/structure/sign/poster/abductor,
+		/obj/structure/sign/poster/contraband/got_wood,
+		/obj/structure/sign/poster/contraband/free_tonto,
+	)
+
 /obj/structure/sign/poster/contraband/random
 	blacklisted_types = list(
 		/obj/structure/sign/poster/contraband/got_wood,

--- a/orbstation/code/cleanup/items.dm
+++ b/orbstation/code/cleanup/items.dm
@@ -108,8 +108,6 @@
 
 /obj/structure/sign/poster/contraband/random
 	blacklisted_types = list(
-		/obj/structure/sign/poster/traitor,
-		/obj/structure/sign/poster/abductor,
 		/obj/structure/sign/poster/contraband/got_wood,
 		/obj/structure/sign/poster/contraband/free_tonto,
 	)


### PR DESCRIPTION
These were only banned on the contraband posters. Also fixes the contraband spawner's override not including the original banned posters with special properties.