### PR TITLE
Properly fixes the heatmap looking for nonexistent jobs

### DIFF
--- a/orbstation/code/modules/job_heatmap.dm
+++ b/orbstation/code/modules/job_heatmap.dm
@@ -29,7 +29,7 @@
 			if (priority == 0)
 				continue
 			var/datum/job/job_details = get_job(job)
-			if(!job)
+			if(!job_details)
 				continue
 			if (!job_details.departments_list)
 				continue


### PR DESCRIPTION
I have placed the check on the wrong var. This PR fixed this problem, making departmental heatmap actually functional when someone who has ever had virologist enabled logs on.