### PR TITLE
Removes false entry in Dynamic panel; fixes traitor limit.

### DIFF
--- a/orbstation/code/antagonists/rulesets_latejoin.dm
+++ b/orbstation/code/antagonists/rulesets_latejoin.dm
@@ -1,7 +1,7 @@
 /// Latejoin Traitor Ruleset
 
 // Don't create more traitors if it exceeds the limit for the current population
-/datum/dynamic_ruleset/latejoin/infiltrator/can_be_selected()
+/datum/dynamic_ruleset/latejoin/traitor/can_be_selected()
 	if(!SSdynamic.traitor_limit_reached())
 		return FALSE
 	return ..()

--- a/orbstation/code/antagonists/rulesets_midround.dm
+++ b/orbstation/code/antagonists/rulesets_midround.dm
@@ -1,7 +1,7 @@
 /// Midround Traitor Ruleset (From Living)
 
 // Don't create more traitors if it exceeds the limit for the current population
-/datum/dynamic_ruleset/midround/from_living/autotraitor/can_be_selected()
+/datum/dynamic_ruleset/midround/from_living/traitor/can_be_selected()
 	if(!SSdynamic.traitor_limit_reached())
 		message_admins("Midround ruleset [name] could not be executed due to the traitor limit.")
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to uncaught repathing, a few bits of code related to the traitor limit broke. This made midround and latejoin traitors ignore the limit, as well as adding an empty entry to the Dynamic panel under Latejoin rulesets. These paths have been corrected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

yeah

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed the traitor limit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
