### PR TITLE
Biodome engineering fix

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -17328,6 +17328,7 @@
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "fTb" = (
@@ -61062,7 +61063,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uRz" = (


### PR DESCRIPTION
Fixes duplicate air alarm (should have been a fire alarm), and a missing APC wire in the Biodome engineering department.
 